### PR TITLE
Add coding standards & principles section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ All repositories MUST follow these software engineering principles. They apply t
 |-----------|------|---------------------------|
 | **Single Responsibility (SRP)** | Every module, class, or function has exactly one reason to change | Split files that mix concerns (e.g., HTTP handling + business logic + persistence). Each layer owns its own responsibility. |
 | **Open/Closed (OCP)** | Extend behavior through new implementations, not by modifying existing code | Use interfaces, strategy patterns, or composition. Avoid editing stable modules to add new variants. |
-| **Liskov Substitution (LSP)** | Subtypes must be substitutable for their base types without breaking callers | Ensure implementations honour the full contract of their interface — preconditions, postconditions, and invariants. |
+| **Liskov Substitution (LSP)** | Subtypes must be substitutable for their base types without breaking callers | Ensure implementations honor the full contract of their interface — preconditions, postconditions, and invariants. |
 | **Interface Segregation (ISP)** | Clients should not depend on methods they don't use | Prefer small, focused interfaces over large ones. Split fat interfaces into cohesive groups. |
 | **Dependency Inversion (DIP)** | Depend on abstractions, not concretions | High-level policy code MUST NOT import low-level infrastructure directly. Inject dependencies via constructors or configuration. |
 
@@ -101,7 +101,7 @@ All repositories MUST follow these software engineering principles. They apply t
 - **Direction of dependencies.** Dependencies always point inward — infrastructure depends on application, application depends on domain. Never the reverse.
 - **No framework bleed.** Framework-specific types and annotations stay at the infrastructure/adapter layer. Domain and application layers must be framework-agnostic.
 
-### Code Organisation
+### Code Organization
 
 - **Co-locate related code.** Tests live next to the code they test. Types live near the code that uses them. Avoid scattering related files across distant directories.
 - **No barrel files** unless the project explicitly requires them. Re-export files (`index.ts`, `__init__.py`) add indirection and circular dependency risk.


### PR DESCRIPTION
## Summary
- Adds a new **Coding Standards & Principles** section to AGENTS.md covering SOLID, CLEAN Code, DRY, DDD, KISS, YAGNI, defensive coding at boundaries, separation of concerns, and code organisation
- Each principle includes actionable rules with practical guidance so agents (and humans) can apply them consistently across all org repos
- Drawn from patterns already proven and enforced in TalkTerm (CLAUDE.md) and Markets (AGENTS.md)

## What's included

| Principle | Key points |
|-----------|------------|
| **SOLID** | Table format with rule + practical meaning for each principle |
| **CLEAN Code** | Meaningful names, small functions, minimal args, no side-effect surprises, error handling |
| **DRY** | Knowledge duplication vs code duplication; rule of three before abstracting |
| **DDD** | Ubiquitous language, bounded contexts, aggregates, value objects, repository pattern |
| **KISS** | Simplest solution first, no clever code |
| **YAGNI** | No speculative features or abstractions |
| **Defensive coding** | Validate at boundaries, trust internal code, fail fast |
| **Separation of concerns** | Layered architecture, inward dependencies, no framework bleed |
| **Code organisation** | Co-location, no barrel files, consistent naming |

## Test plan
- [ ] Review that principles are language/framework-agnostic
- [ ] Verify no conflicts with existing TDD, Pre-Commit, or Code Style sections
- [ ] Confirm repo-level override clause is clear
- [ ] Check markdown renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive "Coding Standards & Principles" section documenting recommended engineering practices: SOLID principles, CLEAN code guidance (naming, function sizing, arguments, formatting, error handling), DRY guidance, DDD concepts, KISS and YAGNI, defensive coding at boundaries, separation of concerns, and code organization conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->