### PR TITLE
docs: add GitHub repository settings standards

### DIFF
--- a/standards/github-settings.md
+++ b/standards/github-settings.md
@@ -152,8 +152,7 @@ all repos automatically — no per-repo setup needed:
 | `CLAUDE_CODE_OAUTH_TOKEN` | Authentication for Claude Code Action |
 | `SONAR_TOKEN` | SonarCloud analysis authentication |
 
-Repos with additional infrastructure (e.g., GCP deployment) may require
-repo-specific secrets beyond this standard set.
+Repos's may require repo-specific secrets beyond this standard set.
 
 ---
 


### PR DESCRIPTION
## Summary
- Documents standard org and repo-level GitHub configurations based on an audit of all petry-projects repositories
- Covers branch protection rules, repository rulesets (`pr-quality`), merge settings, required integrations, standard labels, and a new-repo onboarding checklist
- References existing Dependabot policy and links to CI standards (companion PR)

## What's Documented
- **Organization settings** — default permissions, Dependabot security
- **Repository defaults** — branch naming, visibility, features (issues/wiki/projects), merge strategy
- **Branch protection** — required reviews, status checks by repo, admin enforcement
- **Rulesets** — `pr-quality` (squash-only, thread resolution), `protect-branches` (google-app-scripts)
- **Integrations** — CodeRabbit, Copilot, SonarCloud, CodeQL, Dependabot
- **Labels** — standard label set for all repos
- **New repo checklist** — step-by-step onboarding guide
- **Audit & compliance** — OpenSSF Scorecard weekly scans

## Test plan
- [ ] Review settings against actual repo configurations via `gh api`
- [ ] Verify all referenced files and links resolve correctly
- [ ] Confirm new-repo checklist is complete and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive GitHub standards document defining org and repository defaults (permissions, default branch, visibility, feature toggles), required branch-protection rulesets and mandatory quality checks, required integrations and organization secrets for automation, standardized label set, ecosystem-specific guidance, a checklist for applying standards, a table of compliance deviations, and a weekly automated scorecard audit workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->