### PR TITLE
feat: audit .github repo and add CLAUDE.md/AGENTS.md checks

### DIFF
--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -413,7 +413,7 @@ check_claude_md() {
   if [ -z "$content" ]; then
     add_finding "$repo" "standards" "missing-claude-md" "error" \
       "Missing \`CLAUDE.md\` — every repo must have a CLAUDE.md that references AGENTS.md" \
-      "standards/github-settings.md"
+      "AGENTS.md"
     return
   fi
 
@@ -421,9 +421,9 @@ check_claude_md() {
   decoded=$(echo "$content" | base64 -d 2>/dev/null || echo "")
 
   if ! echo "$decoded" | grep -qi 'AGENTS\.md'; then
-    add_finding "$repo" "standards" "claude-md-missing-agents-ref" "warning" \
+    add_finding "$repo" "standards" "claude-md-missing-agents-ref" "error" \
       "\`CLAUDE.md\` does not reference \`AGENTS.md\`" \
-      "standards/github-settings.md"
+      "AGENTS.md"
   fi
 }
 
@@ -439,7 +439,7 @@ check_agents_md() {
   if [ -z "$content" ]; then
     add_finding "$repo" "standards" "missing-agents-md" "error" \
       "Missing \`AGENTS.md\` — every repo must have an AGENTS.md that references the org-level standards" \
-      "standards/github-settings.md"
+      "AGENTS.md"
     return
   fi
 
@@ -448,10 +448,10 @@ check_agents_md() {
     local decoded
     decoded=$(echo "$content" | base64 -d 2>/dev/null || echo "")
 
-    if ! echo "$decoded" | grep -qE '(\.github/AGENTS\.md|petry-projects/\.github)'; then
-      add_finding "$repo" "standards" "agents-md-missing-org-ref" "warning" \
+    if ! echo "$decoded" | grep -qE '\.github/AGENTS\.md'; then
+      add_finding "$repo" "standards" "agents-md-missing-org-ref" "error" \
         "\`AGENTS.md\` does not reference the org-level \`.github/AGENTS.md\` standards" \
-        "standards/github-settings.md"
+        "AGENTS.md"
     fi
   fi
 }


### PR DESCRIPTION
## Summary

- Removes the `.github` repo exclusion — it now gets audited like all other repos
- Adds two new compliance checks enforcing a standard for Claude Code configuration:
  - **`CLAUDE.md`** must exist in every repo and reference `AGENTS.md`
  - **`AGENTS.md`** must exist in every repo and reference the org-level `.github/AGENTS.md`

## Changes

**`scripts/compliance-audit.sh`**
- Removed `.github` skip from both the audit loop and issue creation loop
- Added `check_claude_md()` — verifies `CLAUDE.md` exists and references `AGENTS.md`
- Added `check_agents_md()` — verifies `AGENTS.md` exists and references org `.github/AGENTS.md`
- Added `standards` to the category breakdown in the summary report

## Dry Run Results

| Repo | Before | After | New Findings |
|------|--------|-------|-------------|
| .github | skipped | 20 | All (newly audited) |
| bmad-bgreat-suite | 19 | 21 | missing CLAUDE.md ref, missing AGENTS.md ref |
| ContentTwin | 10 | 12 | missing CLAUDE.md ref, missing AGENTS.md ref |
| markets | 7 | 8 | missing AGENTS.md ref |
| broodly | 6 | 6 | (already compliant) |
| TalkTerm | 8 | 8 | (already compliant) |
| google-app-scripts | 11 | 11 | (already compliant) |
| **Total** | **61** | **86** | **+25** |

## Test plan

- [x] Dry run: `.github` repo now included with 20 findings
- [x] Dry run: CLAUDE.md/AGENTS.md checks fire correctly across all repos
- [x] Existing checks unaffected (broodly, TalkTerm, google-app-scripts unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added repository checks for CLAUDE.md and AGENTS.md to flag missing files or missing references.

* **Chores**
  * Extended compliance auditing and issue management to include the previously-excluded .github repository.
  * Updated reporting to surface a new "standards" category in audit summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->