### PR TITLE
fix: add checkout step to Claude Code standard configuration

### DIFF
--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -160,6 +160,10 @@ jobs:
       pull-requests: write
       issues: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
       - name: Run Claude Code
         if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'
         uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89


### PR DESCRIPTION
## Summary

- Adds `actions/checkout@v6.0.2` step to the Claude Code standard workflow configuration
- The action requires the repo to be cloned before it can run `git fetch` for issue-triggered branch setup
- Without this step, all issue-triggered runs fail with `fatal: not a git repository`
- All 6 org repos have already been updated with this fix

## Test plan

- [x] Fix verified across all org repos (broodly, google-app-scripts, ContentTwin, TalkTerm, markets, bmad-bgreat-suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)