### PR TITLE
feat: split Claude workflow into interactive + issue automation jobs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -89,4 +89,4 @@ jobs:
                - If you can address the feedback, make the fix, push, and mark the conversation as resolved.
                - If the comment requires human judgment, leave a reply explaining what you need.
             4. Check CI status. If CI fails, read the logs, fix the issues, and push again. Repeat until CI passes.
-            5. When CI is green, all actionable review comments are resolved, and the PR is ready, leave a comment tagging @don-petry to review and merge.
+            5. When CI is green, all actionable review comments are resolved, and the PR is ready, read the CODEOWNERS file and leave a comment tagging the relevant code owners to review and merge.

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -222,8 +222,8 @@ jobs:
             4. Check CI status. If CI fails, read the logs, fix the issues,
                and push again. Repeat until CI passes.
             5. When CI is green, all actionable review comments are resolved,
-               and the PR is ready, leave a comment tagging @don-petry
-               to review and merge.
+               and the PR is ready, read the CODEOWNERS file and leave a
+               comment tagging the relevant code owners to review and merge.
 ```
 
 **Required secrets:** `CLAUDE_CODE_OAUTH_TOKEN`
@@ -256,8 +256,9 @@ with triage or write access applies a label. The label name check in the `if:`
 condition ensures only the `claude` label triggers the workflow — other labels
 are ignored. Apply the `claude` label manually to any issue to trigger Claude.
 
-**Customizing the maintainer tag:** Replace `@don-petry` in the `claude-issue`
-prompt with the appropriate maintainer or team for each repository.
+**Maintainer notification:** The `claude-issue` prompt reads `CODEOWNERS` at
+runtime to determine who to tag. No per-repo customization is needed as long
+as `CODEOWNERS` is present (checked by the compliance audit).
 
 ### 5. Dependabot Auto-Merge (`dependabot-automerge.yml`)
 


### PR DESCRIPTION
## Summary

- **Split** the single `claude` job into `claude` (interactive) and `claude-issue` (automation)
- **`claude-issue`** runs when an issue is labeled `claude` — uses a `prompt` to implement, create a PR, self-review, resolve review comments (marking them as resolved), check CI, and tag `@don-petry` when ready
- **`claude`** keeps interactive mode for PR reviews and `@claude` mentions
- Added `actions: read` + `checks: read` permissions so Claude can monitor CI via MCP tools
- **Updated `standards/ci-standards.md`** section 4 and the permissions table to match the new two-job standard

### Context

petry-projects/bmad-bgreat-suite#19 showed that the single-job workflow created a branch for issue-labeled triggers but never opened a PR — Claude posted a "Create PR →" link and stopped. The compliance finding stayed open across multiple audit cycles.

### Files changed

| File | What changed |
|------|-------------|
| `.github/workflows/claude.yml` | Added `issues: [labeled]` trigger, split into two jobs, added automation prompt + CI permissions |
| `standards/ci-standards.md` | Updated standard config, description, permissions table, and notes to reflect the two-job pattern |

## Test plan

- [ ] Label an issue with `claude` on this repo and verify a PR is automatically created
- [ ] Verify Claude self-reviews and resolves its own review comments
- [ ] Verify Claude checks CI and tags `@don-petry` when green
- [ ] Verify `@claude` mentions on PRs still work in interactive mode
- [ ] After validation, roll out updated `claude.yml` to other org repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)