### PR TITLE
fix: grant claude-issue job tools to create PRs and check CI

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -79,6 +79,8 @@ jobs:
           additional_permissions: |
             actions: read
             checks: read
+          claude_args: |
+            --allowedTools "Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh run view:*),Bash(gh run watch:*),Bash(cat:*),Edit,Write"
           prompt: |
             Implement a fix for issue #${{ github.event.issue.number }}.
 

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -206,6 +206,8 @@ jobs:
           additional_permissions: |
             actions: read
             checks: read
+          claude_args: |
+            --allowedTools "Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh run view:*),Bash(gh run watch:*),Bash(cat:*),Edit,Write"
           prompt: |
             Implement a fix for issue #${{ github.event.issue.number }}.
 


### PR DESCRIPTION
## Summary

- Added `claude_args` with `--allowedTools` to the `claude-issue` job granting access to `gh pr create`, `gh pr view`, `gh run view/watch`, `cat`, `Edit`, and `Write`
- Updated `standards/ci-standards.md` to match

### Root cause

The `claude-issue` automation prompt tells Claude to create a PR, self-review, and check CI. But the action's default tool allowlist only includes file reading and git commit/push — no `gh` CLI access. Claude implemented fixes and pushed branches for all 21 issues but couldn't execute `gh pr create`, so the action fell back to posting "Create PR →" links.

### Evidence

From run logs (`ALLOWED_TOOLS` before this fix):
```
Glob,Grep,LS,Read,mcp__github_comment__update_claude_comment,
Bash(git add:*),Bash(git commit:*),Bash(git-push.sh:*),Bash(git rm:*)
```

No `gh` commands, no `Edit`/`Write` tools — Claude literally couldn't create PRs or edit files during self-review.

## Test plan

- [ ] Merge this PR, then re-trigger one issue (e.g. #42) and verify a PR is actually created
- [ ] Verify Claude can run `gh pr view` and `gh run view` for self-review and CI checking

🤖 Generated with [Claude Code](https://claude.com/claude-code)