### PR TITLE
feat: reusable Claude Code workflow with workflows write permission

### DIFF
--- a/.github/workflows/claude-code-reusable.yml
+++ b/.github/workflows/claude-code-reusable.yml
@@ -1,0 +1,95 @@
+# Reusable Claude Code workflow — single source of truth for the org.
+# Repo-level claude.yml files call this to avoid duplicating the prompt and config.
+# Standard: https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#4-claude-code-claudeyml
+name: Claude Code (Reusable)
+
+on:
+  workflow_call:
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        description: "Claude Code OAuth token for API access"
+        required: true
+      GH_PAT_WORKFLOWS:
+        description: "PAT with workflows scope — lets Claude push .github/workflows/ changes"
+        required: false
+
+jobs:
+  # Interactive mode: PR reviews and @claude mentions
+  claude:
+    if: >-
+      (github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+      issues: write
+      actions: read
+      checks: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+      - name: Run Claude Code
+        if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'
+        uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+            checks: read
+
+  # Automation mode: issue-triggered work — implement, open PR, review, and notify
+  claude-issue:
+    if: >-
+      github.event_name == 'issues' && github.event.action == 'labeled' &&
+        github.event.label.name == 'claude'
+    concurrency:
+      group: claude-issue-${{ github.event.issue.number || github.run_id }}
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+      issues: write
+      actions: read
+      checks: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GH_PAT_WORKFLOWS }}
+          label_trigger: "claude"
+          track_progress: "true"
+          additional_permissions: |
+            actions: read
+            checks: read
+          claude_args: |
+            --allowedTools "Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh issue comment:*),Bash(gh run view:*),Bash(gh run watch:*),Edit,Write"
+          prompt: |
+            Implement a fix for issue #${{ github.event.issue.number }}.
+
+            After implementing:
+            1. Create a pull request with a clear title and description. Include "Closes #${{ github.event.issue.number }}" in the PR body.
+            2. Self-review your own PR — look for bugs, style issues, missed edge cases, and test gaps. If you find problems, push fixes.
+            3. Review all comments and review threads on the PR. For each one:
+               - If you can address the feedback, make the fix, push, and mark the conversation as resolved.
+               - If the comment requires human judgment, leave a reply explaining what you need.
+            4. Check CI status. If CI fails, read the logs, fix the issues, and push again. Repeat until CI passes.
+            5. When CI is green, all actionable review comments are resolved, and the PR is ready, read the CODEOWNERS file and leave a comment tagging the relevant code owners to review and merge.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,5 +1,5 @@
-# AI-assisted code review via Claude Code Action on PRs.
-# Issue automation: implement, open PR, self-review, check CI, notify maintainer.
+# Claude Code — thin caller that delegates to the org-level reusable workflow.
+# All logic and prompts are maintained centrally in claude-code-reusable.yml.
 # Standard: https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#4-claude-code-claudeyml
 name: Claude Code
 
@@ -17,19 +17,9 @@ on:
 permissions: {}
 
 jobs:
-  # Interactive mode: PR reviews and @claude mentions
-  claude:
-    if: >-
-      (github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
-        contains(github.event.comment.body, '@claude') &&
-        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review_comment' &&
-        contains(github.event.comment.body, '@claude') &&
-        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+  claude-code:
+    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@main
+    secrets: inherit
     permissions:
       contents: write
       id-token: write
@@ -37,61 +27,3 @@ jobs:
       issues: write
       actions: read
       checks: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 1
-      - name: Run Claude Code
-        if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'
-        uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          additional_permissions: |
-            actions: read
-            checks: read
-
-  # Automation mode: issue-triggered work — implement, open PR, review, and notify
-  claude-issue:
-    if: >-
-      github.event_name == 'issues' && github.event.action == 'labeled' &&
-        github.event.label.name == 'claude'
-    concurrency:
-      group: claude-issue-${{ github.event.issue.number }}
-      cancel-in-progress: true
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    permissions:
-      contents: write
-      id-token: write
-      pull-requests: write
-      issues: write
-      actions: read
-      checks: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 1
-      - name: Run Claude Code
-        uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          label_trigger: "claude"
-          track_progress: "true"
-          additional_permissions: |
-            actions: read
-            checks: read
-          claude_args: |
-            --allowedTools "Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh issue comment:*),Bash(gh run view:*),Bash(gh run watch:*),Edit,Write"
-          prompt: |
-            Implement a fix for issue #${{ github.event.issue.number }}.
-
-            After implementing:
-            1. Create a pull request with a clear title and description. Include "Closes #${{ github.event.issue.number }}" in the PR body.
-            2. Self-review your own PR — look for bugs, style issues, missed edge cases, and test gaps. If you find problems, push fixes.
-            3. Review all comments and review threads on the PR. For each one:
-               - If you can address the feedback, make the fix, push, and mark the conversation as resolved.
-               - If the comment requires human judgment, leave a reply explaining what you need.
-            4. Check CI status. If CI fails, read the logs, fix the issues, and push again. Repeat until CI passes.
-            5. When CI is green, all actionable review comments are resolved, and the PR is ready, read the CODEOWNERS file and leave a comment tagging the relevant code owners to review and merge.


### PR DESCRIPTION
## Summary
- Extracts the full Claude Code config (interactive + issue automation) into `claude-code-reusable.yml` — single source of truth for the org
- Slims `claude.yml` to a thin caller that delegates via `uses:` + `secrets: inherit`
- Adds `github_token: ${{ secrets.GH_PAT_WORKFLOWS }}` to the `claude-issue` job, granting Claude the `workflows` scope needed to push `.github/workflows/` file changes

## Why
All 51 open compliance issues labeled `claude` triggered successfully but ~40% involve missing workflow files (agent-shield.yml, codeql.yml, ci.yml). Claude was blocked from creating PRs for these because the Claude GitHub App token intentionally lacks `workflows` write. The PAT bypasses this limitation.

Centralizing the prompt avoids maintaining identical copies of `claude.yml` across 7 repos.

## Test plan
- [ ] Verify `GH_PAT_WORKFLOWS` org secret is set with a PAT that has `workflow` scope
- [ ] Merge this PR, then update all repo-level `claude.yml` files to the slim caller
- [ ] Re-label a workflow-related compliance issue with `claude` and confirm the PR is created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a new reusable GitHub Actions workflow for Claude Code integration
  * Refactored existing Claude Code workflow to utilize the new reusable workflow, improving maintainability and consistency across the organization
  * Maintains existing functionality for both interactive and automated code assistance modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->