### PR TITLE
feat: add CODEOWNERS file for code owner review enforcement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# CODEOWNERS
+# Each line is a pattern followed by one or more owners.
+# Owners are matched in order, last matching pattern wins.
+
+# Default owner for all files
+* @don-petry


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` assigning `@don-petry` as default owner for all files
- Satisfies the `pr-quality` ruleset's "Require code owner review" setting, which has no effect without a CODEOWNERS file
- Resolves the compliance finding from the weekly audit

## Test plan

- [ ] Verify compliance audit no longer flags `missing-codeowners` after merge
- [ ] Verify `@don-petry` is listed as required reviewer on new PRs

Closes #50

Generated with [Claude Code](https://claude.ai/code)