### PR TITLE
fix: auto-create missing required labels during compliance audit

### DIFF
--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -35,7 +35,16 @@ ISSUES_FILE="$REPORT_DIR/issues.json"
 
 REQUIRED_WORKFLOWS=(ci.yml codeql.yml sonarcloud.yml claude.yml dependabot-automerge.yml dependency-audit.yml agent-shield.yml)
 
-REQUIRED_LABELS=(security dependencies scorecard bug enhancement documentation in-progress)
+# name:hex-color:description (color without leading #)
+REQUIRED_LABEL_SPECS=(
+  "security:d93f0b:Security-related PRs and issues"
+  "dependencies:0075ca:Dependency update PRs"
+  "scorecard:d93f0b:OpenSSF Scorecard findings (auto-created)"
+  "bug:d73a4a:Bug reports"
+  "enhancement:a2eeef:Feature requests"
+  "documentation:0075ca:Documentation changes"
+  "in-progress:fbca04:An agent is actively working this issue"
+)
 
 REQUIRED_SETTINGS_BOOL=(
   "allow_auto_merge:true:warning:Allow auto-merge must be enabled for Dependabot workflow"
@@ -301,11 +310,28 @@ check_labels() {
   local existing_labels
   existing_labels=$(gh_api "repos/$ORG/$repo/labels" --jq '.[].name' --paginate 2>/dev/null || echo "")
 
-  for label in "${REQUIRED_LABELS[@]}"; do
+  for spec in "${REQUIRED_LABEL_SPECS[@]}"; do
+    IFS=':' read -r label color description <<< "$spec"
     if ! echo "$existing_labels" | grep -qx "$label"; then
-      add_finding "$repo" "labels" "missing-label-$label" "warning" \
-        "Required label \`$label\` is missing" \
-        "standards/github-settings.md#labels--standard-set"
+      if [ "$DRY_RUN" = "true" ]; then
+        add_finding "$repo" "labels" "missing-label-$label" "warning" \
+          "Required label \`$label\` is missing" \
+          "standards/github-settings.md#labels--standard-set"
+      else
+        info "Auto-creating missing label '$label' on $repo"
+        if gh label create "$label" \
+            --repo "$ORG/$repo" \
+            --color "$color" \
+            --description "$description" \
+            --force 2>/dev/null; then
+          info "Label '$label' created successfully on $repo"
+        else
+          warn "Failed to create label '$label' on $repo — filing finding for manual remediation"
+          add_finding "$repo" "labels" "missing-label-$label" "warning" \
+            "Required label \`$label\` is missing and could not be auto-created" \
+            "standards/github-settings.md#labels--standard-set"
+        fi
+      fi
     fi
   done
 }


### PR DESCRIPTION
## Summary

- Replaces the passive `missing-label-*` compliance finding with active label creation
- `check_labels()` now calls `gh label create --force` for any required label absent from a repo
- A finding is only filed if creation fails (e.g. insufficient permissions) or when `DRY_RUN=true`
- Added `REQUIRED_LABEL_SPECS` array with name, hex color, and description per the [standard](https://github.com/petry-projects/.github/blob/main/standards/github-settings.md#labels--standard-set)
- Removed now-unused `REQUIRED_LABELS` array

Closes #47

## Test plan

- [ ] Verify the compliance audit workflow runs without errors
- [ ] Confirm the `scorecard` label (and any other missing labels) are created on repos that lack them
- [ ] Verify `DRY_RUN=true` still files findings without modifying repos

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated label creation: Missing labels are now automatically created during compliance audits with configured metadata.
  * Enhanced label definitions with colors and descriptions for better organization.

* **Improvements**
  * Better error handling and reporting when label auto-creation encounters issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->