### PR TITLE
fix: pass GH_PAT_WORKFLOWS to actions/checkout so git push uses workflow-scoped token

### DIFF
--- a/.github/workflows/claude-code-reusable.yml
+++ b/.github/workflows/claude-code-reusable.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          token: ${{ secrets.GH_PAT_WORKFLOWS || github.token }}
       - name: Run Claude Code
         if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'
         uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89
@@ -70,6 +71,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          token: ${{ secrets.GH_PAT_WORKFLOWS || github.token }}
       - name: Run Claude Code
         uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89
         with:


### PR DESCRIPTION
## Problem

Claude Code action was unable to push commits touching `.github/workflows/*` even after `GH_PAT_WORKFLOWS` was configured as an org-level secret. Every Claude run on a workflow-touching issue ended with:

> refusing to allow a GitHub App to create or update workflow `<path>` without `workflows` permission

This blocked ~20 of 27 open compliance issues across the org (every `Compliance: missing-*.yml` and `unpinned-actions-*.yml` ticket).

## Root cause

`actions/checkout` was running without an explicit `token:` input, so it stored the default `GITHUB_TOKEN` in the local `.git/config` as the credential for subsequent `git push` commands. The PAT was passed to `claude-code-action` as `github_token`, but the action's git push reuses the local git credentials checkout set up — so pushes still went out under the default token, which has the workflow-file write embargo.

Confirmed empirically:
- All "successful" Claude commits (~9 across 5 repos in the last 17h) were authored by `github-actions[bot]`, not the PAT user — proving the PAT was never reaching git push.
- Identical workflow-permission errors persisted after the PAT was rotated to a classic `workflow`-scoped token.

## Fix

Pass `GH_PAT_WORKFLOWS` to `actions/checkout` in both jobs (`claude` and `claude-issue`), with a fallback to `github.token` so the workflow keeps working if the secret is ever unset.

## Test plan

- [ ] After merge, re-toggle the `claude` label on `petry-projects/google-app-scripts#122` (Compliance: missing-agent-shield.yml)
- [ ] Verify Claude run completes with a real branch push and PR creation
- [ ] Verify commit author on the new branch is the PAT user (not `github-actions[bot]`)
- [ ] Once confirmed, re-toggle the remaining ~19 workflow-touching compliance issues across the org

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced workflow reliability with improved token handling fallback configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->