### PR TITLE
fix: add codeql.yml for CodeQL SAST compliance

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+# CodeQL SAST analysis for the .github standards repository.
+# This repo contains GitHub Actions workflows, so 'actions' is the configured language.
+# Standard: https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#2-codeql-analysis-codeqlyml
+name: CodeQL Analysis
+
+permissions: {}
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 17 * * 5' # Weekly scan (Friday 12:00 PM EST / 17:00 UTC)
+
+jobs:
+  analyze:
+    name: Analyze (actions)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: actions
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:actions


### PR DESCRIPTION
## Summary

- Adds the required `codeql.yml` workflow to resolve compliance finding `missing-codeql.yml` (issue #39)
- Language configured as `actions` per the CI standard: repos containing `.github/workflows/*.yml` must add the `actions` language
- Job name `Analyze (actions)` matches the required `Analyze (<lang>)` pattern for branch protection status checks
- Permissions follow least-privilege policy: `{}` top-level, per-job `actions: read`, `contents: read`, `security-events: write`
- Triggers: push/PR to `main` + weekly Friday scan (12:00 PM EST / 17:00 UTC)
- `actions/checkout` pinned to SHA (`de0fac2e...` v6.0.2) matching existing workflows; Dependabot will pin `codeql-action@v4` SHAs on its next weekly run

Closes #39

Generated with [Claude Code](https://claude.ai/code)