### PR TITLE
feat(security): add codeql.yml for SAST scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+# CodeQL SAST analysis for the .github standards repository.
+# This repo contains GitHub Actions workflows, so 'actions' is the configured language.
+# Standard: https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#2-codeql-analysis-codeqlyml
+name: CodeQL Analysis
+
+permissions: {}
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 17 * * 5' # Weekly scan (Friday 12:00 PM EST / 17:00 UTC)
+
+jobs:
+  analyze:
+    name: Analyze (actions)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@0e9f55954318745b37b7933c693bc093f7336125 # v4.35.1
+        with:
+          languages: actions
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@0e9f55954318745b37b7933c693bc093f7336125 # v4.35.1
+        with:
+          category: /language:actions


### PR DESCRIPTION
## Summary

- Adds the required `codeql.yml` CodeQL Analysis workflow to resolve compliance finding #39
- Scans the `actions` ecosystem (required for repos with `.github/workflows/*.yml` per the [CI standard](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#2-codeql-analysis-codeqlyml))
- Triggers: push/PR to `main` + weekly Friday scan (12:00 PM EST)
- `codeql-action` pinned to `v4.35.1` SHA per the Action Pinning Policy

## Notes

- Job name `Analyze (actions)` matches the `Analyze (<lang>)` pattern required for branch protection checks
- `permissions: {}` top-level with least-privilege per-job scopes (`actions: read`, `security-events: write`, `contents: read`)
- All actions SHA-pinned; Dependabot will keep them updated

Closes #39

Generated with [Claude Code](https://claude.ai/code)