### PR TITLE
Auto-respond to all PR review comments without @claude mention

### DIFF
--- a/.github/workflows/claude-code-reusable.yml
+++ b/.github/workflows/claude-code-reusable.yml
@@ -14,16 +14,16 @@ on:
         required: false
 
 jobs:
-  # Interactive mode: PR reviews and @claude mentions
+  # Interactive mode: PR reviews and comments from trusted contributors
   claude:
     if: >-
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
-        contains(github.event.comment.body, '@claude') &&
+        github.event.comment.user.login != 'claude[bot]' &&
         contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' &&
-        contains(github.event.comment.body, '@claude') &&
+        github.event.comment.user.login != 'claude[bot]' &&
         contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
## Summary
- Removed the `contains(github.event.comment.body, '@claude')` filter from the `claude` job's `if` condition
- Claude now automatically responds to **all** issue comments and PR review comments from trusted contributors (OWNER, MEMBER, COLLABORATOR)
- Added `claude[bot]` exclusion to prevent infinite feedback loops where Claude responds to its own comments

## Motivation
When Claude creates PRs from issues (via the `claude-issue` job), reviewers currently have to explicitly mention `@claude` in their review comments for Claude to pick them up. This friction slows down the review cycle. With this change, Claude automatically addresses all review feedback from trusted contributors.

## Test plan
- [ ] Verify Claude responds to a PR review comment **without** `@claude` mention
- [ ] Verify Claude does **not** trigger on its own comments (no infinite loop)
- [ ] Verify the `author_association` check still restricts triggers to OWNER/MEMBER/COLLABORATOR
- [ ] Verify the `pull_request` event trigger is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)