### PR TITLE
fix: pin agent-shield reusable workflow to SHA

### DIFF
--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   agent-shield:
-    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@208ec2d69b75227d375edf8745d84fbac05a76b2 # v1

--- a/standards/workflows/agent-shield.yml
+++ b/standards/workflows/agent-shield.yml
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   agent-shield:
-    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@208ec2d69b75227d375edf8745d84fbac05a76b2 # v1


### PR DESCRIPTION
## Summary

- Pins `uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v1` to its commit SHA (`208ec2d69b75227d375edf8745d84fbac05a76b2`)
- Adds `# v1` comment for human readability per the org action-pinning policy

## Compliance

Resolves the compliance finding from the weekly audit: `unpinned-actions-agent-shield.yml`.

**Standard:** [standards/ci-standards.md#action-pinning-policy](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#action-pinning-policy)

SHA was looked up via:
```
gh api repos/petry-projects/.github/git/refs/tags/v1 --jq '.object.sha'
# → 208ec2d69b75227d375edf8745d84fbac05a76b2
```

Closes #104

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configurations to enhance build reliability and process consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->