### PR TITLE
fix(compliance-audit): handle boolean false in settings checks

### DIFF
--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -300,7 +300,7 @@ check_repo_settings() {
   for entry in "${REQUIRED_SETTINGS_BOOL[@]}"; do
     IFS=':' read -r key expected severity detail <<< "$entry"
     local actual
-    actual=$(echo "$settings" | jq -r ".$key // \"null\"")
+    actual=$(echo "$settings" | jq -r ".$key | if . == null then \"null\" else tostring end")
     if [ "$actual" != "$expected" ]; then
       add_finding "$repo" "settings" "$key" "$severity" \
         "$detail (current: \`$actual\`, expected: \`$expected\`)" \


### PR DESCRIPTION
## Summary

The jq alternative operator (`//`) treats boolean `false` as falsy, so `jq -r '.$key // "null"'` returns `"null"` when the setting value is `false`. This causes any boolean-false check (e.g. `has_wiki: false`) to always fire as a finding, even when the repository setting is correctly set.

**Before:**
```bash
actual=$(echo "$settings" | jq -r ".$key // \"null\"")
```

**After:**
```bash
actual=$(echo "$settings" | jq -r ".$key | if . == null then \"null\" else tostring end")
```

This uses an explicit null guard and `tostring` conversion, so boolean `false` → `"false"` and boolean `true` → `"true"`, while `null` still maps to `"null"`.

## Impact

- `has_wiki: false` no longer generates a false-positive finding for repos that already have wiki disabled
- All other boolean settings checks are also fixed (any future `expected: false` checks will work correctly)

## Test plan

- [ ] Run the compliance audit after merging — `bmad-bgreat-suite` should no longer report `has_wiki` as a finding since its wiki is already disabled

Closes petry-projects/bmad-bgreat-suite#89

Generated with [Claude Code](https://claude.ai/code)