### PR TITLE
fix(ci): move Dependabot exclusion to job-level if in claude-code-reusable.yml

### DIFF
--- a/.github/workflows/claude-code-reusable.yml
+++ b/.github/workflows/claude-code-reusable.yml
@@ -18,7 +18,8 @@ jobs:
   claude:
     if: >-
       (github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository) ||
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.user.login != 'dependabot[bot]') ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
         github.event.comment.user.login != 'claude[bot]' &&
         contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
@@ -41,7 +42,6 @@ jobs:
           fetch-depth: 1
           token: ${{ secrets.GH_PAT_WORKFLOWS || github.token }}
       - name: Run Claude Code
-        if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'
         uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -511,13 +511,14 @@ The `dependabot-automerge.yml` workflow handles automatic merging of Dependabot 
 | **Eligible updates** | Patch, minor, and indirect dependency bumps |
 | **Major version bumps** | Require manual review and approval |
 | **Merge strategy** | `gh pr merge --squash --auto` (queues merge until all checks pass) |
-| **AI reviewers** | Claude Code is skipped on Dependabot PRs (step-level `if`); Copilot/CodeRabbit threads are auto-resolved by the workflow |
+| **AI reviewers** | Claude Code job is skipped on Dependabot PRs (job-level `if`); Copilot/CodeRabbit threads are auto-resolved by the workflow |
 | **Approval** | GitHub App token provides the required approving review |
 
 #### Claude Code Workflow on Dependabot PRs
 
-The `claude.yml` workflow skips the Claude Code action step for Dependabot PRs (`github.event.pull_request.user.login != 'dependabot[bot]'`).
-The job still runs and reports SUCCESS to satisfy required status checks, but the Claude action step is skipped since:
+The `claude-code-reusable.yml` workflow skips the entire `claude` job for Dependabot PRs
+via a job-level `if` condition (`github.event.pull_request.user.login != 'dependabot[bot]'`).
+The job shows as **skipped** (not failed) in GitHub, which satisfies required status checks. The job is skipped because:
 
 - `CLAUDE_CODE_OAUTH_TOKEN` is an Actions secret, not a Dependabot secret
 - AI code review on automated version bumps adds cost without value


### PR DESCRIPTION
## Summary

- Moves the `dependabot[bot]` exclusion from the step-level `if` on the "Run Claude Code" step to the job-level `if` on the `claude` job in `.github/workflows/claude-code-reusable.yml`
- Removes the now-redundant step-level `if`
- Updates `AGENTS.md` to accurately describe the corrected skip behavior

## Root cause

The `claude` job was starting on Dependabot PRs (the job-level `if` didn't exclude them), but the only meaningful step ("Run Claude Code") was gated by a step-level `if`. With all steps either skipped or trivial, GitHub was marking the job as **failed** rather than **skipped**.

## Fix

Moving the exclusion condition to the job-level `if` causes GitHub to mark the entire job as **skipped**, which satisfies required status checks without a failure signal.

Closes #135

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to improve automation handling.

* **Documentation**
  * Updated documentation to reflect changes to automated workflow processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->