### PR TITLE
feat(dependabot): auto-merge major GitHub Actions updates

### DIFF
--- a/.github/workflows/dependabot-automerge-reusable.yml
+++ b/.github/workflows/dependabot-automerge-reusable.yml
@@ -4,10 +4,10 @@
 # Standard: https://github.com/petry-projects/.github/blob/main/standards/dependabot-policy.md
 #
 # Auto-approves and enables auto-merge for Dependabot PRs that are:
-#   - GitHub Actions updates (patch or minor version bumps)
+#   - GitHub Actions updates (any version bump, including major)
 #   - Security updates for any ecosystem (patch or minor)
 #   - Indirect (transitive) dependency updates
-# Major version updates are always left for human review.
+# Major version updates for non-Actions ecosystems are left for human review.
 # Uses --auto so the merge waits for all required CI checks to pass.
 #
 # Safety model: application ecosystems use open-pull-requests-limit: 0 in
@@ -52,17 +52,19 @@ jobs:
           DEP_TYPE="${{ steps.metadata.outputs.dependency-type }}"
           ECOSYSTEM="${{ steps.metadata.outputs.package-ecosystem }}"
 
-          # Must be patch, minor, or indirect
-          if [[ "$UPDATE_TYPE" != "version-update:semver-patch" && \
+          # GitHub Actions are SHA-pinned and don't affect app runtime,
+          # so all version bumps (including major) are eligible.
+          # App ecosystem PRs can only exist as security updates (limit: 0)
+          # and must be patch/minor/indirect — major requires human review.
+          if [[ "$ECOSYSTEM" != "github-actions" && \
+                "$UPDATE_TYPE" != "version-update:semver-patch" && \
                 "$UPDATE_TYPE" != "version-update:semver-minor" && \
                 "$DEP_TYPE" != "indirect" ]]; then
             echo "eligible=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping: major update requires human review"
+            echo "Skipping: major update for $ECOSYSTEM requires human review"
             exit 0
           fi
 
-          # GitHub Actions version updates are always eligible
-          # App ecosystem PRs can only exist as security updates (limit: 0)
           echo "eligible=true" >> "$GITHUB_OUTPUT"
           echo "Auto-merge eligible: ecosystem=$ECOSYSTEM update=$UPDATE_TYPE"
 

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -7,10 +7,10 @@
 #   APP_PRIVATE_KEY — GitHub App private key
 #
 # Auto-approves and enables auto-merge for Dependabot PRs that are:
-#   - GitHub Actions updates (patch or minor version bumps)
+#   - GitHub Actions updates (any version bump, including major)
 #   - Security updates for any ecosystem (patch or minor)
 #   - Indirect (transitive) dependency updates
-# Major version updates are always left for human review.
+# Major version updates for non-Actions ecosystems are left for human review.
 # Uses --auto so the merge waits for all required CI checks to pass.
 #
 # Safety model: application ecosystems use open-pull-requests-limit: 0 in
@@ -47,17 +47,19 @@ jobs:
           DEP_TYPE="${{ steps.metadata.outputs.dependency-type }}"
           ECOSYSTEM="${{ steps.metadata.outputs.package-ecosystem }}"
 
-          # Must be patch, minor, or indirect
-          if [[ "$UPDATE_TYPE" != "version-update:semver-patch" && \
+          # GitHub Actions are SHA-pinned and don't affect app runtime,
+          # so all version bumps (including major) are eligible.
+          # App ecosystem PRs can only exist as security updates (limit: 0)
+          # and must be patch/minor/indirect — major requires human review.
+          if [[ "$ECOSYSTEM" != "github-actions" && \
+                "$UPDATE_TYPE" != "version-update:semver-patch" && \
                 "$UPDATE_TYPE" != "version-update:semver-minor" && \
                 "$DEP_TYPE" != "indirect" ]]; then
             echo "eligible=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping: major update requires human review"
+            echo "Skipping: major update for $ECOSYSTEM requires human review"
             exit 0
           fi
 
-          # GitHub Actions version updates are always eligible
-          # App ecosystem PRs can only exist as security updates (limit: 0)
           echo "eligible=true" >> "$GITHUB_OUTPUT"
           echo "Auto-merge eligible: ecosystem=$ECOSYSTEM update=$UPDATE_TYPE"
 

--- a/standards/dependabot-policy.md
+++ b/standards/dependabot-policy.md
@@ -19,6 +19,7 @@ security posture than chasing every minor/patch release.
    branch protection (CODEOWNERS review bypass for bot PRs). Eligible updates:
    - **GitHub Actions**: all version bumps including major (SHA-pinned, no runtime impact)
    - **App ecosystems**: patch and minor security updates only (major requires human review)
+   - **Indirect (transitive) dependencies**: all updates regardless of version bump
    Uses `gh pr merge --auto` to wait for required checks before merging.
 5. **Vulnerability audit CI check** runs on every PR and push to `main`, failing the
    build if any dependency has a known advisory. This is a required status check.

--- a/standards/dependabot-policy.md
+++ b/standards/dependabot-policy.md
@@ -15,8 +15,10 @@ security posture than chasing every minor/patch release.
 2. **Version updates weekly** for GitHub Actions, since pinned action versions do not
    affect application stability and staying current reduces CI attack surface.
 3. **Labels** `security` and `dependencies` on every Dependabot PR for filtering and audit.
-4. **Auto-merge** security patches and minor updates after all CI checks pass, using a
-   GitHub App token to satisfy branch protection (CODEOWNERS review bypass for bot PRs).
+4. **Auto-merge** after all CI checks pass, using a GitHub App token to satisfy
+   branch protection (CODEOWNERS review bypass for bot PRs). Eligible updates:
+   - **GitHub Actions**: all version bumps including major (SHA-pinned, no runtime impact)
+   - **App ecosystems**: patch and minor security updates only (major requires human review)
    Uses `gh pr merge --auto` to wait for required checks before merging.
 5. **Vulnerability audit CI check** runs on every PR and push to `main`, failing the
    build if any dependency has a known advisory. This is a required status check.
@@ -142,10 +144,11 @@ See [`workflows/dependabot-automerge.yml`](workflows/dependabot-automerge.yml).
 Behavior:
 
 - Triggers on `pull_request_target` from `dependabot[bot]`
-- Fetches Dependabot metadata to determine update type
-- For **patch** and **minor** updates (and indirect dependency updates):
-  approves the PR and enables auto-merge (waits for all required CI checks)
-- **Major** updates are left for human review
+- Fetches Dependabot metadata to determine update type and ecosystem
+- For **GitHub Actions**: approves and auto-merges all version bumps including
+  major, since actions are SHA-pinned and CI catches breaking interface changes
+- For **app ecosystems**: approves **patch** and **minor** updates (and indirect
+  dependency updates); **major** updates are left for human review
 - Uses `gh pr merge --auto --squash` so the merge only happens after CI passes
 
 ## Update and Merge Behind PRs Workflow


### PR DESCRIPTION
## Summary

- Auto-merge major version bumps for GitHub Actions (previously required manual review)
- App ecosystem major updates still require human review (no change)
- Updated eligibility logic in both the direct and reusable automerge workflows
- Updated dependabot-policy.md to document the new behavior

**Rationale:** GitHub Actions are SHA-pinned and don't affect app runtime stability. `gh pr merge --auto` ensures CI must pass before merging, so breaking interface changes (e.g., renamed inputs) are caught automatically. This eliminates the manual review bottleneck for Action updates.

## Changed files

| File | Change |
|------|--------|
| `.github/workflows/dependabot-automerge.yml` | Skip major-version gate when ecosystem is `github-actions` |
| `.github/workflows/dependabot-automerge-reusable.yml` | Same logic change in reusable workflow |
| `standards/dependabot-policy.md` | Document Actions vs app-ecosystem auto-merge distinction |

## Test plan

- [ ] Verify existing patch/minor Action PRs still auto-merge (no regression)
- [ ] Verify a major Action update PR (if one exists) gets auto-approved
- [ ] Verify app ecosystem major updates are still blocked from auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot auto-merge policy: GitHub Actions updates now automatically merge for all version types, including major releases. Other ecosystem dependencies remain restricted to patch and minor updates, with major versions requiring manual review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->