### PR TITLE
feat(dependabot-rebase): add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -27,6 +27,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: # allow manual trigger to flush Dependabot PR queue
 
 concurrency:
   group: dependabot-update-and-merge

--- a/standards/workflows/dependabot-rebase.yml
+++ b/standards/workflows/dependabot-rebase.yml
@@ -27,6 +27,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: # allow manual trigger to flush Dependabot PR queue
 
 concurrency:
   group: dependabot-update-and-merge


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` to the rebase workflow so the Dependabot PR queue can be flushed manually without needing an organic push to main

## Why

The rebase workflow self-chains when merging one Dependabot PR pushes to main, triggering it again for the next. But after a branch-update cycle (where all PRs fell behind and got updated together), there's no follow-up push to main to trigger the merge pass. `workflow_dispatch` lets us kick it off on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Dependabot rebase automation by adding manual invocation capability to workflow configurations. Users can now trigger the rebase process on-demand through workflow dispatch in addition to existing automatic triggers activated when updates are pushed to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->