### PR TITLE
fix: correct reusable workflow path syntax (remove duplicate .github)

### DIFF
--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   agent-shield:
-    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v1
+    uses: petry-projects/.github/workflows/agent-shield-reusable.yml@v1

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,7 +20,7 @@ permissions: {}
 
 jobs:
   claude-code:
-    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@main
+    uses: petry-projects/.github/workflows/claude-code-reusable.yml@main
     secrets: inherit
     permissions:
       contents: write

--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -220,6 +220,45 @@ check_action_pinning() {
 }
 
 # ---------------------------------------------------------------------------
+# Check: Reusable workflow path syntax (no duplicate .github/ segments)
+# ---------------------------------------------------------------------------
+check_reusable_workflow_paths() {
+  local repo="$1"
+
+  # List workflow files
+  local workflows
+  workflows=$(gh_api "repos/$ORG/$repo/contents/.github/workflows" --jq '.[].name' 2>/dev/null || echo "")
+
+  for wf in $workflows; do
+    [[ "$wf" != *.yml && "$wf" != *.yaml ]] && continue
+
+    local content
+    content=$(gh_api "repos/$ORG/$repo/contents/.github/workflows/$wf" --jq '.content' 2>/dev/null || echo "")
+    [ -z "$content" ] && continue
+
+    local decoded
+    decoded=$(echo "$content" | base64 -d 2>/dev/null || echo "")
+    [ -z "$decoded" ] && continue
+
+    # Check for incorrect path with duplicate .github/ segment
+    # INCORRECT: petry-projects/.github/.github/workflows/...
+    # CORRECT:   petry-projects/.github/workflows/...
+    local bad_paths
+    bad_paths=$(echo "$decoded" | grep -E 'uses:[[:space:]]*petry-projects/\.github/\.github/workflows/' || true)
+
+    if [ -n "$bad_paths" ]; then
+      local count
+      count=$(echo "$bad_paths" | wc -l | tr -d ' ')
+      local examples
+      examples=$(echo "$bad_paths" | head -2 | sed 's/^[[:space:]]*//' | paste -sd ', ' -)
+      add_finding "$repo" "workflow-syntax" "reusable-workflow-path-duplicate-github" "error" \
+        "Workflow \`$wf\` has $count reusable workflow reference(s) with duplicate \`.github/\` segment. Change \`petry-projects/.github/.github/workflows/\` to \`petry-projects/.github/workflows/\`" \
+        "standards/ci-standards.md#action-pinning-policy"
+    fi
+  done
+}
+
+# ---------------------------------------------------------------------------
 # Check: Dependabot configuration
 # ---------------------------------------------------------------------------
 check_dependabot_config() {
@@ -1234,6 +1273,7 @@ main() {
 
     check_required_workflows "$repo"
     check_action_pinning "$repo"
+    check_reusable_workflow_paths "$repo"
     check_dependabot_config "$repo"
     check_repo_settings "$repo" "$repo_json"
     check_labels "$repo"


### PR DESCRIPTION
## Summary

Fixes the root cause of failing compliance PRs across 5 petry-projects repos.

## Changes

- **claude.yml**: Changed `petry-projects/.github/.github/workflows/claude-code-reusable.yml` → `petry-projects/.github/workflows/claude-code-reusable.yml`
- **agent-shield.yml**: Changed `petry-projects/.github/.github/workflows/agent-shield-reusable.yml` → `petry-projects/.github/workflows/agent-shield-reusable.yml`

The incorrect path with duplicate `.github/` segment prevented GitHub Actions from finding the reusable workflows, causing "workflow not found" failures.

## Impact

This fix will unblock regeneration of failing PRs in:
- petry-projects/markets (#131, #120)
- petry-projects/ContentTwin (#105, #88, #71)
- petry-projects/TalkTerm (#127, #125)  
- petry-projects/bmad-bgreat-suite (#120, #108)
- petry-projects/broodly (#154 and others)

These PRs were auto-generated with the broken path from these template files.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>