### PR TITLE
feat: add auto-rebase workflow for non-Dependabot PRs

### DIFF
--- a/.github/workflows/auto-rebase-reusable.yml
+++ b/.github/workflows/auto-rebase-reusable.yml
@@ -88,15 +88,15 @@ jobs:
                   echo "  Skipping — blocked comment already posted"
                 else
                   echo "  Posting manual-rebase request (workflows permission missing)"
-                  gh pr comment "$PR_NUMBER" --repo "$REPO" --body "<!-- auto-rebase-blocked -->
-**Auto-rebase blocked** — the base branch contains \`.github/workflows/\` changes that require the \`workflows\` permission to merge into this branch, but the auto-rebase workflow's token does not have that permission.
-
-Please rebase this branch manually:
-\`\`\`
-git fetch origin
-git rebase origin/$BASE_BRANCH
-git push --force-with-lease
-\`\`\`"
+                  BLOCKED_BODY="<!-- auto-rebase-blocked -->"
+                  BLOCKED_BODY+=$'\n''**Auto-rebase blocked** — the base branch contains `.github/workflows/` changes'
+                  BLOCKED_BODY+=' that require the `workflows` permission to merge into this branch,'
+                  BLOCKED_BODY+=" but the auto-rebase workflow's token does not have that permission."
+                  BLOCKED_BODY+=$'\n\n''Please rebase this branch manually:'
+                  BLOCKED_BODY+=$'\n''```'$'\n''git fetch origin'
+                  BLOCKED_BODY+=$'\n'"git rebase origin/$BASE_BRANCH"
+                  BLOCKED_BODY+=$'\n''git push --force-with-lease'$'\n''```'
+                  gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$BLOCKED_BODY"
                 fi
               elif echo "$UPDATE_OUTPUT" | grep -qi "merge conflict"; then
                 # Merge conflict — ask the author to resolve it.
@@ -110,18 +110,15 @@ git push --force-with-lease
                   echo "  Skipping — conflict comment already posted"
                 else
                   echo "  Posting conflict resolution request"
-                  gh pr comment "$PR_NUMBER" --repo "$REPO" --body "<!-- auto-rebase-conflict -->
-**Auto-rebase failed — merge conflict** — this branch has conflicts with \`$BASE_BRANCH\` that must be resolved manually.
-
-Please resolve the conflicts and push:
-\`\`\`
-git fetch origin
-git merge origin/$BASE_BRANCH
-# resolve conflicts, then:
-git add .
-git commit
-git push
-\`\`\`"
+                  CONFLICT_BODY="<!-- auto-rebase-conflict -->"
+                  CONFLICT_BODY+=$'\n''**Auto-rebase failed — merge conflict** — this branch has conflicts'
+                  CONFLICT_BODY+=" with \`$BASE_BRANCH\` that must be resolved manually."
+                  CONFLICT_BODY+=$'\n\n''Please resolve the conflicts and push:'
+                  CONFLICT_BODY+=$'\n''```'$'\n''git fetch origin'
+                  CONFLICT_BODY+=$'\n'"git merge origin/$BASE_BRANCH"
+                  CONFLICT_BODY+=$'\n''# resolve conflicts, then:'
+                  CONFLICT_BODY+=$'\n''git add .'$'\n''git commit'$'\n''git push'$'\n''```'
+                  gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$CONFLICT_BODY"
                 fi
               else
                 echo "  Warning: failed to update PR #$PR_NUMBER — $UPDATE_OUTPUT"

--- a/.github/workflows/auto-rebase-reusable.yml
+++ b/.github/workflows/auto-rebase-reusable.yml
@@ -89,13 +89,13 @@ jobs:
                 else
                   echo "  Posting manual-rebase request (workflows permission missing)"
                   BLOCKED_BODY="<!-- auto-rebase-blocked -->"
-                  BLOCKED_BODY+=$'\n''**Auto-rebase blocked** — the base branch contains `.github/workflows/` changes'
-                  BLOCKED_BODY+=' that require the `workflows` permission to merge into this branch,'
+                  BLOCKED_BODY+=$'\n'"**Auto-rebase blocked** — the base branch contains \`.github/workflows/\` changes"
+                  BLOCKED_BODY+=" that require the \`workflows\` permission to merge into this branch,"
                   BLOCKED_BODY+=" but the auto-rebase workflow's token does not have that permission."
-                  BLOCKED_BODY+=$'\n\n''Please rebase this branch manually:'
-                  BLOCKED_BODY+=$'\n''```'$'\n''git fetch origin'
+                  BLOCKED_BODY+=$'\n\n'"Please rebase this branch manually:"
+                  BLOCKED_BODY+=$'\n'"\`\`\`"$'\n'"git fetch origin"
                   BLOCKED_BODY+=$'\n'"git rebase origin/$BASE_BRANCH"
-                  BLOCKED_BODY+=$'\n''git push --force-with-lease'$'\n''```'
+                  BLOCKED_BODY+=$'\n'"git push --force-with-lease"$'\n'"\`\`\`"
                   gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$BLOCKED_BODY"
                 fi
               elif echo "$UPDATE_OUTPUT" | grep -qi "merge conflict"; then
@@ -111,13 +111,13 @@ jobs:
                 else
                   echo "  Posting conflict resolution request"
                   CONFLICT_BODY="<!-- auto-rebase-conflict -->"
-                  CONFLICT_BODY+=$'\n''**Auto-rebase failed — merge conflict** — this branch has conflicts'
+                  CONFLICT_BODY+=$'\n'"**Auto-rebase failed — merge conflict** — this branch has conflicts"
                   CONFLICT_BODY+=" with \`$BASE_BRANCH\` that must be resolved manually."
-                  CONFLICT_BODY+=$'\n\n''Please resolve the conflicts and push:'
-                  CONFLICT_BODY+=$'\n''```'$'\n''git fetch origin'
+                  CONFLICT_BODY+=$'\n\n'"Please resolve the conflicts and push:"
+                  CONFLICT_BODY+=$'\n'"\`\`\`"$'\n'"git fetch origin"
                   CONFLICT_BODY+=$'\n'"git merge origin/$BASE_BRANCH"
-                  CONFLICT_BODY+=$'\n''# resolve conflicts, then:'
-                  CONFLICT_BODY+=$'\n''git add .'$'\n''git commit'$'\n''git push'$'\n''```'
+                  CONFLICT_BODY+=$'\n'"# resolve conflicts, then:"
+                  CONFLICT_BODY+=$'\n'"git add ."$'\n'"git commit"$'\n'"git push"$'\n'"\`\`\`"
                   gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$CONFLICT_BODY"
                 fi
               else

--- a/.github/workflows/auto-rebase-reusable.yml
+++ b/.github/workflows/auto-rebase-reusable.yml
@@ -1,0 +1,130 @@
+# Reusable auto-rebase workflow — single source of truth for the org.
+# Repo-level auto-rebase.yml files call this to avoid duplicating
+# the branch-update logic.
+# Standard: https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md
+#
+# Problem: when branch protection requires branches to be up-to-date
+# (strict status checks), merging any PR makes other open PRs fall behind.
+# Non-Dependabot PRs have no equivalent of Dependabot's scheduled rebase,
+# so they silently fall behind until a human notices.
+#
+# Solution: after every push to main (typically a merged PR), this workflow:
+#   1. Finds all open non-Dependabot PRs from the same repo (no fork PRs)
+#   2. Updates behind PRs using the merge method (not rebase)
+#
+# Skips Dependabot PRs — those are handled by dependabot-rebase-reusable.yml.
+# Skips fork PRs — update-branch requires push access to the head branch.
+#
+# Important: never use the API update-branch endpoint with rebase method —
+# it rewrites SHAs, which can confuse CI and invalidate existing approvals.
+# The merge method preserves the original commits.
+#
+# Failure modes handled gracefully:
+#   - without `workflows` permission (403): posts an idempotent comment asking
+#     the author to rebase manually (sentinel: <!-- auto-rebase-blocked -->)
+#   - merge conflict (422): posts an idempotent comment asking the author to
+#     resolve conflicts (sentinel: <!-- auto-rebase-conflict -->)
+#
+# No secrets required — uses github.token only. No auto-merge logic.
+name: Auto-rebase non-Dependabot PRs (Reusable)
+
+on:
+  workflow_call:
+
+jobs:
+  auto-rebase:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write      # needed for update-branch (may touch .github/workflows/)
+      pull-requests: write # needed to post comments on PRs
+    steps:
+      - name: Update behind non-Dependabot PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Find open non-Dependabot PRs from the same repo (exclude forks)
+          PRS=$(gh api "repos/$REPO/pulls?state=open&per_page=100" \
+            --jq '.[] | select(.user.login != "dependabot[bot]") | select(.head.repo.full_name == .base.repo.full_name) | "\(.number) \(.head.ref)"')
+
+          if [[ -z "$PRS" ]]; then
+            echo "No open non-Dependabot same-repo PRs"
+            exit 0
+          fi
+
+          while IFS=' ' read -r PR_NUMBER HEAD_REF; do
+            # Get the base branch for this PR
+            BASE_BRANCH=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.base.ref')
+
+            BEHIND=$(gh api "repos/$REPO/compare/${BASE_BRANCH}...${HEAD_REF}" \
+              --jq '.behind_by')
+
+            if [[ "$BEHIND" -eq 0 ]]; then
+              echo "PR #$PR_NUMBER ($HEAD_REF) is up to date — skipping"
+              continue
+            fi
+
+            echo "PR #$PR_NUMBER ($HEAD_REF) is $BEHIND commit(s) behind $BASE_BRANCH — updating branch"
+
+            # Capture both stdout and stderr; use if-then to avoid bash -e terminating
+            # the step on non-zero exit before we can inspect the error message.
+            if UPDATE_OUTPUT=$(gh api "repos/$REPO/pulls/$PR_NUMBER/update-branch" \
+              -X PUT -f update_method=merge 2>&1); then
+              if [[ -n "$UPDATE_OUTPUT" ]]; then echo "$UPDATE_OUTPUT"; fi
+              echo "  Branch updated"
+            else
+              HTTP_STATUS=$(echo "$UPDATE_OUTPUT" | grep -oP 'HTTP \K[0-9]+' | head -1)
+              echo "  Update failed (HTTP $HTTP_STATUS): $UPDATE_OUTPUT"
+
+              if echo "$UPDATE_OUTPUT" | grep -qF "without \`workflows\` permission"; then
+                # GitHub blocks update-branch when merging the base would add
+                # .github/workflows/ changes and the token lacks the 'workflows'
+                # permission. Ask the author to rebase manually.
+                #
+                # Idempotent: skip if sentinel comment already exists.
+                SENTINEL="<!-- auto-rebase-blocked -->"
+                ALREADY_POSTED=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+                  --jq "[.[] | select(.body | contains(\"$SENTINEL\"))] | length")
+                if [[ "$ALREADY_POSTED" -gt 0 ]]; then
+                  echo "  Skipping — blocked comment already posted"
+                else
+                  echo "  Posting manual-rebase request (workflows permission missing)"
+                  gh pr comment "$PR_NUMBER" --repo "$REPO" --body "<!-- auto-rebase-blocked -->
+**Auto-rebase blocked** — the base branch contains \`.github/workflows/\` changes that require the \`workflows\` permission to merge into this branch, but the auto-rebase workflow's token does not have that permission.
+
+Please rebase this branch manually:
+\`\`\`
+git fetch origin
+git rebase origin/$BASE_BRANCH
+git push --force-with-lease
+\`\`\`"
+                fi
+              elif echo "$UPDATE_OUTPUT" | grep -qE "HTTP 422|merge conflict"; then
+                # Merge conflict — ask the author to resolve it.
+                #
+                # Idempotent: skip if sentinel comment already exists.
+                SENTINEL="<!-- auto-rebase-conflict -->"
+                ALREADY_POSTED=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+                  --jq "[.[] | select(.body | contains(\"$SENTINEL\"))] | length")
+                if [[ "$ALREADY_POSTED" -gt 0 ]]; then
+                  echo "  Skipping — conflict comment already posted"
+                else
+                  echo "  Posting conflict resolution request"
+                  gh pr comment "$PR_NUMBER" --repo "$REPO" --body "<!-- auto-rebase-conflict -->
+**Auto-rebase failed — merge conflict** — this branch has conflicts with \`$BASE_BRANCH\` that must be resolved manually.
+
+Please resolve the conflicts and push:
+\`\`\`
+git fetch origin
+git merge origin/$BASE_BRANCH
+# resolve conflicts, then:
+git add .
+git commit
+git push
+\`\`\`"
+                fi
+              else
+                echo "  Warning: failed to update PR #$PR_NUMBER — $UPDATE_OUTPUT"
+              fi
+            fi
+          done <<< "$PRS"

--- a/.github/workflows/auto-rebase-reusable.yml
+++ b/.github/workflows/auto-rebase-reusable.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           # Find open non-Dependabot PRs from the same repo (exclude forks)
           PRS=$(gh api "repos/$REPO/pulls?state=open&per_page=100" \
-            --jq '.[] | select(.user.login != "dependabot[bot]") | select(.head.repo.full_name == .base.repo.full_name) | "\(.number) \(.head.ref)"')
+            --jq '.[] | select(.user.login != "dependabot[bot]") | select(.head.repo != null) | select(.head.repo.full_name == .base.repo.full_name) | "\(.number) \(.head.ref)"')
 
           if [[ -z "$PRS" ]]; then
             echo "No open non-Dependabot same-repo PRs"
@@ -73,8 +73,7 @@ jobs:
               if [[ -n "$UPDATE_OUTPUT" ]]; then echo "$UPDATE_OUTPUT"; fi
               echo "  Branch updated"
             else
-              HTTP_STATUS=$(echo "$UPDATE_OUTPUT" | grep -oP 'HTTP \K[0-9]+' | head -1)
-              echo "  Update failed (HTTP $HTTP_STATUS): $UPDATE_OUTPUT"
+              echo "  Update failed: $UPDATE_OUTPUT"
 
               if echo "$UPDATE_OUTPUT" | grep -qF "without \`workflows\` permission"; then
                 # GitHub blocks update-branch when merging the base would add
@@ -83,8 +82,8 @@ jobs:
                 #
                 # Idempotent: skip if sentinel comment already exists.
                 SENTINEL="<!-- auto-rebase-blocked -->"
-                ALREADY_POSTED=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
-                  --jq "[.[] | select(.body | contains(\"$SENTINEL\"))] | length")
+                ALREADY_POSTED=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+                  --json comments --jq "[.comments[] | select(.body | contains(\"$SENTINEL\"))] | length")
                 if [[ "$ALREADY_POSTED" -gt 0 ]]; then
                   echo "  Skipping — blocked comment already posted"
                 else
@@ -99,13 +98,14 @@ git rebase origin/$BASE_BRANCH
 git push --force-with-lease
 \`\`\`"
                 fi
-              elif echo "$UPDATE_OUTPUT" | grep -qE "HTTP 422|merge conflict"; then
+              elif echo "$UPDATE_OUTPUT" | grep -qi "merge conflict"; then
                 # Merge conflict — ask the author to resolve it.
+                # gh api surfaces the GitHub API error JSON: {"message":"merge conflict",...}
                 #
                 # Idempotent: skip if sentinel comment already exists.
                 SENTINEL="<!-- auto-rebase-conflict -->"
-                ALREADY_POSTED=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
-                  --jq "[.[] | select(.body | contains(\"$SENTINEL\"))] | length")
+                ALREADY_POSTED=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+                  --json comments --jq "[.comments[] | select(.body | contains(\"$SENTINEL\"))] | length")
                 if [[ "$ALREADY_POSTED" -gt 0 ]]; then
                   echo "  Skipping — conflict comment already posted"
                 else

--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -1,0 +1,44 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/auto-rebase.yml
+# Standard:        petry-projects/.github/standards/ci-standards.md
+# Reusable:        petry-projects/.github/.github/workflows/auto-rebase-reusable.yml
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. All branch-update logic lives in the
+#     reusable workflow above.
+#   • You MAY change: nothing in normal use. NOTE: this file intentionally uses
+#     a LOCAL ref (`./`) instead of a pinned SHA — this repo IS the source of
+#     truth, so a local ref is always current. Other repos use pinned SHAs
+#     (see standards/workflows/auto-rebase.yml).
+#   • You MUST NOT change: trigger event, the concurrency group name,
+#     or the job-level `permissions:` block — reusable workflows can be
+#     granted no more permissions than the calling job has, so removing
+#     the stanza breaks the reusable's gh API calls.
+#   • If you need different behaviour, open a PR against the reusable in the
+#     central repo.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Auto-rebase non-Dependabot PRs — thin caller for the org-level reusable.
+# To adopt: copy standards/workflows/auto-rebase.yml to your repo.
+# No secrets required — uses GITHUB_TOKEN only.
+name: Auto-rebase non-Dependabot PRs
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: auto-rebase
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  auto-rebase:
+    permissions:
+      contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
+      pull-requests: write # post comments on PRs
+    uses: ./.github/workflows/auto-rebase-reusable.yml  # local ref — always current
+    secrets: inherit

--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -604,6 +604,7 @@ check_centralized_workflow_stubs() {
   # workflow-filename:expected-reusable-basename
   local centralized=(
     "claude.yml:claude-code-reusable"
+    "auto-rebase.yml:auto-rebase-reusable"
     "dependency-audit.yml:dependency-audit-reusable"
     "dependabot-automerge.yml:dependabot-automerge-reusable"
     "dependabot-rebase.yml:dependabot-rebase-reusable"

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -46,7 +46,8 @@ reusable, not a local edit.
 | [`agent-shield.yml`](workflows/agent-shield.yml) | 1 | Deep agent-config security scan via `ecc-agentshield` |
 | [`claude.yml`](workflows/claude.yml) | 1 | Thin caller delegating to the org-level reusable Claude Code workflow |
 | [`dependabot-automerge.yml`](workflows/dependabot-automerge.yml) | 1 | Auto-approve and squash-merge eligible Dependabot PRs |
-| [`dependabot-rebase.yml`](workflows/dependabot-rebase.yml) | 1 | Rebase Dependabot PRs on demand |
+| [`auto-rebase.yml`](workflows/auto-rebase.yml) | 1 | Keep non-Dependabot PRs up-to-date with the base branch on every push to `main` |
+| [`dependabot-rebase.yml`](workflows/dependabot-rebase.yml) | 1 | Update and auto-merge eligible Dependabot PRs on every push to `main` |
 | [`dependency-audit.yml`](workflows/dependency-audit.yml) | 1 | Multi-ecosystem audit (npm, pnpm, gomod, cargo, pip) |
 | [`feature-ideation.yml`](workflows/feature-ideation.yml) | 1 | BMAD Method ideation pipeline (BMAD-enabled repos only) |
 
@@ -414,13 +415,30 @@ files, validates SKILL.md frontmatter, and detects permission bypasses.
 See [`workflows/agent-shield.yml`](workflows/agent-shield.yml) and the
 [Agent Configuration Standards](agent-standards.md) for full details.
 
+### 8. Auto-Rebase (`auto-rebase.yml`)
+
+Keeps open non-Dependabot PRs up-to-date with the base branch.
+A copy-paste ready template is available at [`standards/workflows/auto-rebase.yml`](workflows/auto-rebase.yml).
+
+**Trigger:** every `push` to `main` (i.e., every merged PR) plus manual `workflow_dispatch`.
+
+On each run the workflow:
+1. Lists all open same-repo PRs excluding `dependabot[bot]` and fork PRs.
+2. For each PR that is behind the base branch, calls `PUT /pulls/{n}/update-branch` with `merge` method to fast-forward it.
+3. On `workflows` permission error: posts an idempotent comment (sentinel `<!-- auto-rebase-blocked -->`) asking the author to rebase manually.
+4. On merge conflict (422): posts an idempotent comment (sentinel `<!-- auto-rebase-conflict -->`) asking the author to resolve conflicts.
+
+**No secrets required** — uses `GITHUB_TOKEN` only. Dependabot PRs are excluded because `dependabot-rebase.yml` handles those.
+
+**Compliance:** The compliance audit (`check_centralized_workflow_stubs`) verifies that repos adopting `auto-rebase.yml` use the canonical thin caller stub delegating to `petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@v1`.
+
 ---
 
 ## Conditional Workflows
 
 These workflows are required only when a specific ecosystem is detected.
 
-### 8. Feature Ideation (`feature-ideation.yml`) — BMAD Method repos
+### 9. Feature Ideation (`feature-ideation.yml`) — BMAD Method repos
 
 **Condition:** Repository has BMAD Method installed (presence of `_bmad/`,
 `_bmad-output/`, or equivalent BMAD planning artifacts).

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -75,7 +75,7 @@ below — copy and adapt the examples to each repo's tech stack. CodeQL is
 (see [§2](#2-codeql-analysis-github-managed-default-setup)).
 
 In addition, BMAD Method-enabled repositories MUST also include the conditional
-[Feature Ideation workflow](#8-feature-ideation-feature-ideationyml--bmad-method-repos)
+[Feature Ideation workflow](#9-feature-ideation-feature-ideationyml--bmad-method-repos)
 documented below — see [`standards/workflows/feature-ideation.yml`](workflows/feature-ideation.yml)
 for the template.
 
@@ -423,6 +423,7 @@ A copy-paste ready template is available at [`standards/workflows/auto-rebase.ym
 **Trigger:** every `push` to `main` (i.e., every merged PR) plus manual `workflow_dispatch`.
 
 On each run the workflow:
+
 1. Lists all open same-repo PRs excluding `dependabot[bot]` and fork PRs.
 2. For each PR that is behind the base branch, calls `PUT /pulls/{n}/update-branch` with `merge` method to fast-forward it.
 3. On `workflows` permission error: posts an idempotent comment (sentinel `<!-- auto-rebase-blocked -->`) asking the author to rebase manually.

--- a/standards/workflows/auto-rebase.yml
+++ b/standards/workflows/auto-rebase.yml
@@ -1,0 +1,42 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/auto-rebase.yml
+# Standard:        petry-projects/.github/standards/ci-standards.md
+# Reusable:        petry-projects/.github/.github/workflows/auto-rebase-reusable.yml
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. All branch-update logic lives in the
+#     reusable workflow above.
+#   • You MAY change: the SHA in the `uses:` line when upgrading the reusable
+#     workflow version (bump SHA to latest main of petry-projects/.github).
+#   • You MUST NOT change: trigger event, the concurrency group name,
+#     or the job-level `permissions:` block — reusable workflows can be
+#     granted no more permissions than the calling job has, so removing
+#     the stanza breaks the reusable's gh API calls.
+#   • If you need different behaviour, open a PR against the reusable in the
+#     central repo.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Auto-rebase non-Dependabot PRs — thin caller for the org-level reusable.
+# To adopt: copy this file to .github/workflows/auto-rebase.yml in your repo.
+# No secrets required — uses GITHUB_TOKEN only.
+name: Auto-rebase non-Dependabot PRs
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: auto-rebase
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  auto-rebase:
+    permissions:
+      contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
+      pull-requests: write # post comments on PRs
+    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@v1
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/auto-rebase-reusable.yml` — new org-level reusable that updates non-Dependabot PRs behind the base branch on every push to `main`
- Adds `.github/workflows/auto-rebase.yml` — thin caller for this repo (adopts immediately)
- Adds `standards/workflows/auto-rebase.yml` — template for other repos to adopt

## Why separate from `claude.yml`

Rebasing is a mechanical git operation — it doesn't need an LLM on the happy path. Running Claude just to call `update-branch` wastes credits and conflates AI review with branch hygiene. The `dependabot-rebase` workflow already establishes this pattern; this PR extends it to all PRs.

## Behaviour

On `push` to `main`:
1. Lists all open non-Dependabot PRs with `head.repo == base.repo` (no fork PRs)
2. For each one `behind_by > 0`, calls `PUT /pulls/{n}/update-branch` with `merge` method
3. On `workflows` permission error → posts a one-time comment with manual rebase instructions
4. On merge-conflict 422 → posts a one-time comment asking the author to resolve conflicts
5. Idempotent: skips PRs that already have the sentinel comment to avoid spam

## Test plan

- [ ] Push a commit to `main`; verify the workflow runs and updates a behind PR
- [ ] Verify Dependabot PRs are skipped
- [ ] Verify fork PRs are skipped
- [ ] Force a conflict and verify the comment is posted exactly once