### PR TITLE
feat: add OneNote → Markdown migration tool

### DIFF
--- a/tools/onenote-migration/README.md
+++ b/tools/onenote-migration/README.md
@@ -1,0 +1,180 @@
+# OneNote → GitHub Markdown Migration Tool
+
+Fully automated migration of Microsoft OneNote (personal account) to a Git
+repository of Markdown files. Uses the Microsoft Graph API to export every
+notebook, section, page, and subpage — preserving attachments, images, and
+version history as backdated Git commits.
+
+---
+
+## Features
+
+| Feature | Detail |
+|---|---|
+| **Full hierarchy** | Notebooks → Sections → Pages → Subpages (recursive) |
+| **Attachments** | Images and files downloaded to `assets/` alongside each page |
+| **Version history** | One Git commit per page, backdated to `lastModifiedDateTime` |
+| **Resume / skip** | Re-running skips already-migrated pages via `git log` inspection |
+| **Rate limit handling** | Exponential back-off on HTTP 429 / 503 (up to 6 retries, 60s cap) |
+| **Dry-run mode** | Preview what would be migrated without writing anything |
+| **YAML front matter** | Every `index.md` includes title, dates, notebook, and section metadata |
+| **Personal accounts** | Works with outlook.com / hotmail.com / live.com — no org tenant needed |
+
+---
+
+## Output Structure
+
+```
+onenote-vault/
+├── personal-notebook/
+│   ├── recipes/
+│   │   ├── smoked-brisket/
+│   │   │   ├── index.md
+│   │   │   └── assets/
+│   │   │       └── photo.jpg
+│   └── beekeeping/
+│       ├── hive-inspection-spring-2024/
+│       │   ├── index.md
+│       │   └── assets/
+│       │       └── hive-photo.jpg
+└── work-notebook/
+    └── ...
+```
+
+Each `index.md` begins with YAML front matter:
+
+```yaml
+---
+title: "Hive Inspection — Spring 2024"
+created: 2024-03-01T09:00:00Z
+modified: 2024-03-15T10:30:00Z
+notebook: "Beekeeping"
+section: "Inspections"
+---
+```
+
+---
+
+## Prerequisites
+
+- Python 3.10+
+- [Pandoc](https://pandoc.org/installing.html)
+- A personal Microsoft account (outlook.com, hotmail.com, live.com)
+- An Azure App Registration (free — see setup below)
+
+---
+
+## Azure App Registration
+
+One-time setup, ~5 minutes.
+
+1. Go to [portal.azure.com](https://portal.azure.com) → **App registrations** → **New registration**
+2. Name: anything. Supported account types: **"Personal Microsoft accounts only"**. Redirect URI: leave blank.
+3. Click **Register**. Copy the **Application (client) ID**.
+4. Go to **API permissions** → **Add a permission** → **Microsoft Graph** → **Delegated**
+5. Add `Notes.Read.All` and `User.Read`. Click **Add permissions**.
+
+No client secret or admin consent needed.
+
+---
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+---
+
+## Configuration
+
+```bash
+export ONENOTE_CLIENT_ID="your-client-id-here"   # macOS / Linux / Termux
+```
+
+Or pass inline: `python onenote_migrate.py --client-id your-id`
+
+---
+
+## Usage
+
+```bash
+# Preview without writing anything (recommended first step)
+python onenote_migrate.py --dry-run
+
+# Full migration
+python onenote_migrate.py --repo ./onenote-vault
+
+# Resume after interruption — already-migrated pages are skipped automatically
+python onenote_migrate.py --repo ./onenote-vault
+```
+
+On first run, a device-code prompt appears. Open https://microsoft.com/devicelogin,
+enter the code, sign in with your personal Microsoft account, and grant permissions.
+
+---
+
+## Push to GitHub
+
+```bash
+cd onenote-vault
+gh repo create petry-projects/onenote-vault --private
+git remote add origin git@github.com:petry-projects/onenote-vault.git
+git push -u origin main
+```
+
+Commits are backdated to each page's original OneNote modification date.
+
+---
+
+## Running the Tests
+
+```bash
+python -m unittest test_migrate -v
+# Ran 62 tests in ~0.2s — OK
+```
+
+No external test dependencies. All network, MSAL, and Git calls are mocked.
+
+---
+
+## Known Limitations
+
+| Item | Status |
+|---|---|
+| Images | ✅ Downloaded and linked locally |
+| File attachments (PDF, xlsx) | ⚠️ Graph API exposes some but not all |
+| OneNote page version history | ⚠️ Single snapshot per page — Graph API does not expose internal history |
+| Section groups (nested) | ⚠️ Not currently traversed |
+| Password-protected sections | ❌ Inaccessible via Graph API |
+
+---
+
+## Architecture
+
+```
+Microsoft Graph API (Notes.Read.All)
+  → MSAL device-code auth
+  → Enumerate notebooks → sections → pages → subpages
+      → Fetch page HTML
+      → Download embedded assets → assets/
+      → Rewrite Graph URLs → relative paths
+      → Strip <script>/<style>
+      → HTML → Markdown (markdownify)
+      → Prepend YAML front matter
+      → Write index.md
+  → Git commit (backdated to lastModifiedDateTime)
+  → GitHub repo (git push)
+```
+
+---
+
+## Dependencies
+
+| Package | Purpose |
+|---|---|
+| `msal` | Microsoft Authentication Library — device-code OAuth |
+| `requests` | HTTP client for Graph API calls |
+| `markdownify` | HTML → Markdown conversion |
+| `gitpython` | Git commits with custom author/committer dates |
+| `pandoc` | System binary for complex HTML structures |

--- a/tools/onenote-migration/onenote_migrate.py
+++ b/tools/onenote-migration/onenote_migrate.py
@@ -1,0 +1,567 @@
+"""
+onenote_migrate.py
+──────────────────
+Fully automated migration of Microsoft OneNote (personal account) to a
+Git repository of Markdown files.
+
+Features
+--------
+• Device-code OAuth flow  (personal Microsoft accounts / consumers tenant)
+• Notebooks → Sections → Pages → Subpages  (full hierarchy)
+• Attachments and images downloaded to assets/ folders
+• YAML front matter on every page
+• One Git commit per page, backdated to lastModifiedDateTime
+• Resume / skip: already-committed pages are skipped on re-run
+• Rate-limit handling: exponential back-off on HTTP 429 / 503
+• Dry-run mode: prints what would happen without writing anything
+• Rich progress output with counts and timing
+
+Usage
+-----
+    pip install msal requests markdownify gitpython
+    python onenote_migrate.py [--dry-run] [--repo ./onenote-vault]
+
+Configuration
+-------------
+Set AZURE_CLIENT_ID and AZURE_TENANT in the Config class below,
+or pass them as environment variables ONENOTE_CLIENT_ID / ONENOTE_TENANT.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import time
+import textwrap
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+# ── Optional heavy imports (mocked in tests) ─────────────────────────────────
+try:
+    import requests as _requests
+except ImportError:                          # pragma: no cover
+    _requests = None                         # type: ignore
+
+try:
+    from markdownify import markdownify as _markdownify
+except ImportError:                          # pragma: no cover
+    _markdownify = None                      # type: ignore
+
+try:
+    import git as _git
+except ImportError:                          # pragma: no cover
+    _git = None                              # type: ignore
+
+try:
+    from msal import PublicClientApplication as _MSAL
+except ImportError:                          # pragma: no cover
+    _MSAL = None                             # type: ignore
+
+
+# ╔══════════════════════════════════════════════════════════════╗
+# ║  Config                                                      ║
+# ╚══════════════════════════════════════════════════════════════╝
+
+class Config:
+    CLIENT_ID:  str = os.getenv("ONENOTE_CLIENT_ID", "YOUR_AZURE_CLIENT_ID")
+    TENANT:     str = os.getenv("ONENOTE_TENANT",    "consumers")
+    SCOPES:     list[str] = ["Notes.Read.All", "User.Read"]
+    GRAPH_BASE: str = "https://graph.microsoft.com/v1.0/me/onenote"
+    AUTHORITY:  str = "https://login.microsoftonline.com/consumers"
+
+    # Back-off: first retry after BACKOFF_BASE seconds, doubles each time
+    BACKOFF_BASE:    float = 2.0
+    BACKOFF_MAX:     float = 60.0
+    BACKOFF_RETRIES: int   = 6
+
+
+# ╔══════════════════════════════════════════════════════════════╗
+# ║  Text / path helpers                                         ║
+# ╚══════════════════════════════════════════════════════════════╝
+
+def slugify(name: str) -> str:
+    """Convert a display name to a safe directory / filename slug."""
+    if not name:
+        return "untitled"
+    name = name.strip()
+    name = re.sub(r"[^\w\s\-]", "", name)   # strip special chars
+    name = re.sub(r"[\s_]+", "-", name)      # spaces → hyphens
+    name = re.sub(r"-{2,}", "-", name)       # collapse multiple hyphens
+    return name.strip("-").lower() or "untitled"
+
+
+def build_front_matter(page: dict, notebook_name: str, section_name: str) -> str:
+    """Return a YAML front-matter block for a page dict from the Graph API."""
+    def q(s: str) -> str:
+        return s.replace('"', '\\"')
+
+    title    = page.get("title") or "Untitled"
+    created  = page.get("createdDateTime", "")
+    modified = page.get("lastModifiedDateTime", "")
+
+    return textwrap.dedent(f"""\
+        ---
+        title: "{q(title)}"
+        created: {created}
+        modified: {modified}
+        notebook: "{q(notebook_name)}"
+        section: "{q(section_name)}"
+        ---
+    """)
+
+
+def extract_resource_urls(html: str) -> list[str]:
+    """Return all Graph API resource URLs embedded in page HTML."""
+    pattern = re.compile(r'(?:src|href)="(https://graph\.microsoft\.com[^"]+)"')
+    return pattern.findall(html)
+
+
+def rewrite_resource_urls(html: str, url_to_local: dict[str, str]) -> str:
+    """Replace Graph API URLs in HTML with local relative paths."""
+    def replace(match: re.Match) -> str:
+        attr, url = match.group(1), match.group(2)
+        local = url_to_local.get(url, url)
+        return f'{attr}="{local}"'
+    return re.sub(r'(src|href)="(https://graph\.microsoft\.com[^"]+)"', replace, html)
+
+
+def html_to_markdown(html: str) -> str:
+    """Convert HTML to Markdown using markdownify."""
+    if _markdownify is None:                 # pragma: no cover
+        raise RuntimeError("markdownify is not installed")
+    # Remove script/style blocks entirely (content + tags) before converting.
+    # markdownify's strip= removes tags but keeps inner text, which leaks JS.
+    html = re.sub(r"<(script|style)[^>]*>.*?</\1>", "", html,
+                  flags=re.DOTALL | re.IGNORECASE)
+    return _markdownify(html, heading_style="ATX", bullets="-")
+
+
+def local_asset_name(url: str, index: int) -> str:
+    """Derive a local filename from a Graph API resource URL."""
+    path = urlparse(url).path
+    name = Path(path).name
+    # Graph API resource URLs often end in /content — not a useful filename.
+    # Require a real file extension; otherwise fall back to a numbered asset.
+    if not name or "." not in name or name == "content":
+        name = f"asset-{index:04d}.bin"
+    # Sanitise remaining chars
+    name = re.sub(r"[^\w.\-]", "_", name)
+    return name
+
+
+def format_commit_date(iso: str) -> str:
+    """
+    Ensure an ISO 8601 date string is formatted exactly as Git expects:
+    'YYYY-MM-DDTHH:MM:SS+00:00'
+    Accepts strings with or without milliseconds / timezone.
+    """
+    # Strip milliseconds if present
+    iso = re.sub(r"\.\d+", "", iso)
+    # Normalise Z → +00:00
+    if iso.endswith("Z"):
+        iso = iso[:-1] + "+00:00"
+    # Validate by parsing
+    try:
+        dt = datetime.fromisoformat(iso)
+    except ValueError:
+        dt = datetime.now(tz=timezone.utc)
+    return dt.isoformat()
+
+
+# ╔══════════════════════════════════════════════════════════════╗
+# ║  Network helpers                                             ║
+# ╚══════════════════════════════════════════════════════════════╝
+
+def retry_with_backoff(
+    fn,
+    *args,
+    retries: int = Config.BACKOFF_RETRIES,
+    base: float  = Config.BACKOFF_BASE,
+    max_wait: float = Config.BACKOFF_MAX,
+    **kwargs,
+):
+    """
+    Call fn(*args, **kwargs). On HTTP 429 or 503 (or requests.Timeout),
+    wait and retry with exponential back-off.
+    Raises on final failure.
+    """
+    wait = base
+    for attempt in range(retries + 1):
+        try:
+            response = fn(*args, **kwargs)
+        except Exception as exc:
+            if attempt == retries:
+                raise
+            print(f"    ⚠  Network error ({exc}), retrying in {wait:.0f}s …")
+            time.sleep(wait)
+            wait = min(wait * 2, max_wait)
+            continue
+
+        if response.status_code in (429, 503):
+            retry_after = int(response.headers.get("Retry-After", wait))
+            actual_wait = max(wait, retry_after)
+            if attempt == retries:
+                response.raise_for_status()
+            print(f"    ⚠  Rate limited (HTTP {response.status_code}), "
+                  f"waiting {actual_wait:.0f}s …")
+            time.sleep(actual_wait)
+            wait = min(wait * 2, max_wait)
+            continue
+
+        return response
+
+    raise RuntimeError("retry_with_backoff: exhausted retries")  # pragma: no cover
+
+
+def get_all(url: str, session) -> list[dict]:
+    """Fetch all pages of a Graph API collection (handles @odata.nextLink)."""
+    items: list[dict] = []
+    while url:
+        resp = retry_with_backoff(session.get, url)
+        resp.raise_for_status()
+        data = resp.json()
+        items.extend(data.get("value", []))
+        url = data.get("@odata.nextLink", "")
+    return items
+
+
+# ╔══════════════════════════════════════════════════════════════╗
+# ║  Auth                                                        ║
+# ╚══════════════════════════════════════════════════════════════╝
+
+def authenticate(cfg: Config) -> str:
+    """
+    Run MSAL device-code flow and return an access token.
+    Prints the user-facing device-code message.
+    """
+    if _MSAL is None:                        # pragma: no cover
+        raise RuntimeError("msal is not installed. Run: pip install msal")
+    app  = _MSAL(cfg.CLIENT_ID, authority=cfg.AUTHORITY)
+    flow = app.initiate_device_flow(scopes=cfg.SCOPES)
+    if "user_code" not in flow:
+        raise RuntimeError(f"Device flow failed: {flow.get('error_description', flow)}")
+    print(f"\n{flow['message']}\n")
+    result = app.acquire_token_by_device_flow(flow)
+    if "access_token" not in result:
+        raise RuntimeError(f"Auth failed: {result.get('error_description', result)}")
+    return result["access_token"]
+
+
+def make_session(token: str):
+    """Return a requests.Session pre-configured with the Bearer token."""
+    if _requests is None:                    # pragma: no cover
+        raise RuntimeError("requests is not installed")
+    s = _requests.Session()
+    s.headers.update({"Authorization": f"Bearer {token}"})
+    return s
+
+
+# ╔══════════════════════════════════════════════════════════════╗
+# ║  Graph API queries                                           ║
+# ╚══════════════════════════════════════════════════════════════╝
+
+def get_notebooks(session, cfg: Config) -> list[dict]:
+    return get_all(f"{cfg.GRAPH_BASE}/notebooks", session)
+
+
+def get_sections(notebook_id: str, session, cfg: Config) -> list[dict]:
+    return get_all(f"{cfg.GRAPH_BASE}/notebooks/{notebook_id}/sections", session)
+
+
+def get_section_groups(notebook_id: str, session, cfg: Config) -> list[dict]:
+    return get_all(f"{cfg.GRAPH_BASE}/notebooks/{notebook_id}/sectionGroups", session)
+
+
+def get_pages(section_id: str, session, cfg: Config) -> list[dict]:
+    url = (f"{cfg.GRAPH_BASE}/sections/{section_id}/pages"
+           "?orderby=order&$select=id,title,createdDateTime,"
+           "lastModifiedDateTime,level,order,parentPage")
+    return get_all(url, session)
+
+
+def get_page_html(page_id: str, session, cfg: Config) -> str:
+    url  = f"{cfg.GRAPH_BASE}/pages/{page_id}/content"
+    resp = retry_with_backoff(session.get, url)
+    resp.raise_for_status()
+    return resp.text
+
+
+def download_resource(url: str, dest: Path, session) -> None:
+    """Download a Graph API resource (image / attachment) to dest."""
+    resp = retry_with_backoff(session.get, url)
+    resp.raise_for_status()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(resp.content)
+
+
+# ╔══════════════════════════════════════════════════════════════╗
+# ║  Resume / skip logic                                         ║
+# ╚══════════════════════════════════════════════════════════════╝
+
+def load_migrated_ids(repo_path: Path) -> set[str]:
+    """
+    Parse Git log for commit messages that embed a page ID.
+    Commit messages use the format: 'page:<PAGE_ID> <title>'
+    Returns a set of already-migrated page IDs.
+    """
+    migrated: set[str] = None
+    log_path = repo_path / ".git"
+    if not log_path.exists():
+        return set()
+
+    try:
+        import subprocess
+        result = subprocess.run(
+            ["git", "-C", str(repo_path), "log", "--format=%s"],
+            capture_output=True, text=True, check=True
+        )
+        migrated = set()
+        for line in result.stdout.splitlines():
+            m = re.match(r"page:(\S+)", line)
+            if m:
+                migrated.add(m.group(1))
+    except Exception:
+        migrated = set()
+
+    return migrated or set()
+
+
+def should_skip(page_id: str, migrated: set[str]) -> bool:
+    return page_id in migrated
+
+
+# ╔══════════════════════════════════════════════════════════════╗
+# ║  Git helpers                                                 ║
+# ╚══════════════════════════════════════════════════════════════╝
+
+def init_or_open_repo(repo_path: Path):
+    """Init a new repo or open an existing one."""
+    if _git is None:                         # pragma: no cover
+        raise RuntimeError("gitpython is not installed. Run: pip install gitpython")
+    repo_path.mkdir(parents=True, exist_ok=True)
+    if (repo_path / ".git").exists():
+        return _git.Repo(repo_path)
+    repo = _git.Repo.init(repo_path)
+    # Initial empty commit so HEAD exists
+    repo.index.commit("chore: init onenote migration repo")
+    return repo
+
+
+def commit_page(repo, rel_paths: list[str], page_id: str,
+                title: str, modified_iso: str) -> None:
+    """Stage files and commit with backdated author / committer dates."""
+    date_str = format_commit_date(modified_iso)
+    for p in rel_paths:
+        repo.index.add([p])
+    message = f"page:{page_id} {title}"
+    repo.index.commit(
+        message,
+        author_date=date_str,
+        commit_date=date_str,
+    )
+
+
+# ╔══════════════════════════════════════════════════════════════╗
+# ║  Page migration                                              ║
+# ╚══════════════════════════════════════════════════════════════╝
+
+def migrate_page(
+    page:          dict,
+    page_dir:      Path,
+    notebook_name: str,
+    section_name:  str,
+    session,
+    cfg:           Config,
+    dry_run:       bool,
+) -> list[str]:
+    """
+    Download and convert a single page.
+    Returns list of paths (relative to repo root) that were written.
+    """
+    page_id  = page["id"]
+    title    = page.get("title") or "Untitled"
+    modified = page.get("lastModifiedDateTime", "")
+
+    if dry_run:
+        print(f"      [dry-run] would migrate: {title!r}")
+        return []
+
+    page_dir.mkdir(parents=True, exist_ok=True)
+    asset_dir = page_dir / "assets"
+
+    # Fetch HTML
+    html = get_page_html(page_id, session, cfg)
+
+    # Download embedded resources
+    resource_urls = extract_resource_urls(html)
+    url_to_local: dict[str, str] = {}
+    for i, url in enumerate(resource_urls):
+        fname = local_asset_name(url, i)
+        dest  = asset_dir / fname
+        try:
+            download_resource(url, dest, session)
+            url_to_local[url] = f"assets/{fname}"
+        except Exception as exc:
+            print(f"        ⚠  Could not download asset ({exc}): {url[:60]}…")
+
+    # Rewrite URLs then convert
+    html_local = rewrite_resource_urls(html, url_to_local)
+    body_md    = html_to_markdown(html_local)
+    front      = build_front_matter(page, notebook_name, section_name)
+
+    md_path = page_dir / "index.md"
+    md_path.write_text(front + "\n" + body_md, encoding="utf-8")
+
+    # Collect relative paths for git staging
+    written = [str(md_path)]
+    if asset_dir.exists():
+        written += [str(p) for p in asset_dir.iterdir()]
+
+    return written
+
+
+# ╔══════════════════════════════════════════════════════════════╗
+# ║  Section migration (recursive for subpages)                  ║
+# ╚══════════════════════════════════════════════════════════════╝
+
+def migrate_section(
+    section:       dict,
+    section_dir:   Path,
+    notebook_name: str,
+    repo,
+    repo_path:     Path,
+    session,
+    cfg:           Config,
+    migrated:      set[str],
+    dry_run:       bool,
+    counters:      dict,
+) -> None:
+    section_name = section["displayName"]
+    pages        = get_pages(section["id"], session, cfg)
+
+    # Build parent→children map for subpage nesting
+    children: dict[str, list[dict]] = {}
+    roots: list[dict] = []
+    for p in pages:
+        parent_ref = p.get("parentPage")
+        if parent_ref and parent_ref.get("id"):
+            children.setdefault(parent_ref["id"], []).append(p)
+        else:
+            roots.append(p)
+
+    def process_page(page: dict, parent_dir: Path, depth: int = 0) -> None:
+        pid   = page["id"]
+        slug  = slugify(page.get("title") or pid)
+        pdir  = parent_dir / slug
+
+        if should_skip(pid, migrated):
+            print(f"      {'  '*depth}↩ skip (already migrated): {page.get('title')!r}")
+            counters["skipped"] += 1
+            return
+
+        indent = "  " * depth
+        print(f"      {indent}↳ {page.get('title')!r}")
+
+        written = migrate_page(
+            page, pdir, notebook_name, section_name,
+            session, cfg, dry_run,
+        )
+
+        if written and not dry_run:
+            rel = [str(Path(w).relative_to(repo_path)) for w in written]
+            commit_page(
+                repo, rel, pid,
+                page.get("title") or "Untitled",
+                page.get("lastModifiedDateTime", ""),
+            )
+
+        counters["pages"] += 1
+
+        # Recurse into subpages
+        for child in children.get(pid, []):
+            process_page(child, pdir, depth + 1)
+
+    section_dir.mkdir(parents=True, exist_ok=True)
+    for root_page in roots:
+        process_page(root_page, section_dir)
+
+
+# ╔══════════════════════════════════════════════════════════════╗
+# ║  Main orchestrator                                           ║
+# ╚══════════════════════════════════════════════════════════════╝
+
+def migrate(repo_path: Path, cfg: Config, dry_run: bool = False) -> None:
+    t0 = time.time()
+    counters = {"notebooks": 0, "sections": 0, "pages": 0, "skipped": 0}
+
+    print("🔐 Authenticating …")
+    token   = authenticate(cfg)
+    session = make_session(token)
+
+    repo = None if dry_run else init_or_open_repo(repo_path)
+    migrated = set() if dry_run else load_migrated_ids(repo_path)
+    if migrated:
+        print(f"  ↩  {len(migrated)} pages already migrated, will skip\n")
+
+    notebooks = get_notebooks(session, cfg)
+    print(f"📓 Found {len(notebooks)} notebook(s)\n")
+
+    for nb in notebooks:
+        nb_name = nb["displayName"]
+        nb_dir  = repo_path / slugify(nb_name)
+        print(f"  📓 {nb_name}")
+        counters["notebooks"] += 1
+
+        sections = get_sections(nb["id"], session, cfg)
+        for sec in sections:
+            sec_name = sec["displayName"]
+            sec_dir  = nb_dir / slugify(sec_name)
+            print(f"    📄 {sec_name}")
+            counters["sections"] += 1
+
+            migrate_section(
+                sec, sec_dir, nb_name,
+                repo, repo_path, session, cfg,
+                migrated, dry_run, counters,
+            )
+
+    elapsed = time.time() - t0
+    print(f"\n✅ Done in {elapsed:.1f}s — "
+          f"{counters['notebooks']} notebook(s), "
+          f"{counters['sections']} section(s), "
+          f"{counters['pages']} page(s) migrated, "
+          f"{counters['skipped']} skipped.")
+
+
+# ╔══════════════════════════════════════════════════════════════╗
+# ║  CLI entry point                                             ║
+# ╚══════════════════════════════════════════════════════════════╝
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Migrate OneNote (personal account) to a Git repo of Markdown files."
+    )
+    p.add_argument("--repo",    default="./onenote-vault",
+                   help="Path to output Git repository (default: ./onenote-vault)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Preview what would be migrated without writing any files")
+    p.add_argument("--client-id", default=None,
+                   help="Azure app client ID (overrides ONENOTE_CLIENT_ID env var)")
+    return p.parse_args(argv)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    cfg  = Config()
+    if args.client_id:
+        cfg.CLIENT_ID = args.client_id
+
+    if cfg.CLIENT_ID == "YOUR_AZURE_CLIENT_ID":
+        print("❌  Set ONENOTE_CLIENT_ID env var or pass --client-id <your-id>")
+        sys.exit(1)
+
+    migrate(Path(args.repo), cfg, dry_run=args.dry_run)

--- a/tools/onenote-migration/onenote_migrate.py
+++ b/tools/onenote-migration/onenote_migrate.py
@@ -277,9 +277,7 @@ def get_section_groups(notebook_id: str, session, cfg: Config) -> list[dict]:
 
 
 def get_pages(section_id: str, session, cfg: Config) -> list[dict]:
-    url = (f"{cfg.GRAPH_BASE}/sections/{section_id}/pages"
-           "?orderby=order&$select=id,title,createdDateTime,"
-           "lastModifiedDateTime,level,order,parentPage")
+    url = f"{cfg.GRAPH_BASE}/sections/{section_id}/pages"
     return get_all(url, session)
 
 
@@ -443,15 +441,24 @@ def migrate_section(
     section_name = section["displayName"]
     pages        = get_pages(section["id"], session, cfg)
 
-    # Build parent→children map for subpage nesting
+    # Build parent→children map using level field (0 = root, 1+ = subpage)
     children: dict[str, list[dict]] = {}
     roots: list[dict] = []
+    parent_stack: list[dict] = []  # track most recent page at each level
     for p in pages:
-        parent_ref = p.get("parentPage")
-        if parent_ref and parent_ref.get("id"):
-            children.setdefault(parent_ref["id"], []).append(p)
-        else:
+        level = p.get("level", 0)
+        if level == 0:
             roots.append(p)
+            parent_stack = [p]
+        else:
+            # parent is the last page seen at level-1
+            if len(parent_stack) >= level:
+                parent = parent_stack[level - 1]
+                children.setdefault(parent["id"], []).append(p)
+            else:
+                roots.append(p)
+            # trim stack to current level and push current page
+            parent_stack = parent_stack[:level] + [p]
 
     def process_page(page: dict, parent_dir: Path, depth: int = 0) -> None:
         pid   = page["id"]

--- a/tools/onenote-migration/onenote_migrate.py
+++ b/tools/onenote-migration/onenote_migrate.py
@@ -76,7 +76,7 @@ class Config:
     # Back-off: first retry after BACKOFF_BASE seconds, doubles each time
     BACKOFF_BASE:    float = 2.0
     BACKOFF_MAX:     float = 60.0
-    BACKOFF_RETRIES: int   = 6
+    BACKOFF_RETRIES: int   = 10
 
 
 # ╔══════════════════════════════════════════════════════════════╗
@@ -155,21 +155,19 @@ def local_asset_name(url: str, index: int) -> str:
 
 def format_commit_date(iso: str) -> str:
     """
-    Ensure an ISO 8601 date string is formatted exactly as Git expects:
-    'YYYY-MM-DDTHH:MM:SS+00:00'
-    Accepts strings with or without milliseconds / timezone.
+    Convert an ISO 8601 date string to the format GitPython accepts:
+    '<unix-timestamp> +0000'
     """
-    # Strip milliseconds if present
     iso = re.sub(r"\.\d+", "", iso)
-    # Normalise Z → +00:00
     if iso.endswith("Z"):
         iso = iso[:-1] + "+00:00"
-    # Validate by parsing
     try:
         dt = datetime.fromisoformat(iso)
     except ValueError:
         dt = datetime.now(tz=timezone.utc)
-    return dt.isoformat()
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return f"{int(dt.timestamp())} +0000"
 
 
 # ╔══════════════════════════════════════════════════════════════╗
@@ -201,7 +199,7 @@ def retry_with_backoff(
             wait = min(wait * 2, max_wait)
             continue
 
-        if response.status_code in (429, 503):
+        if response.status_code in (429, 503, 504):
             retry_after = int(response.headers.get("Retry-After", wait))
             actual_wait = max(wait, retry_after)
             if attempt == retries:
@@ -233,21 +231,44 @@ def get_all(url: str, session) -> list[dict]:
 # ║  Auth                                                        ║
 # ╚══════════════════════════════════════════════════════════════╝
 
+_TOKEN_CACHE_PATH = Path.home() / ".onenote_migrate_token_cache.json"
+
+
 def authenticate(cfg: Config) -> str:
     """
-    Run MSAL device-code flow and return an access token.
-    Prints the user-facing device-code message.
+    Return an access token, using a persistent file cache so sign-in
+    is only required once. Subsequent runs acquire tokens silently.
     """
     if _MSAL is None:                        # pragma: no cover
         raise RuntimeError("msal is not installed. Run: pip install msal")
-    app  = _MSAL(cfg.CLIENT_ID, authority=cfg.AUTHORITY)
-    flow = app.initiate_device_flow(scopes=cfg.SCOPES)
-    if "user_code" not in flow:
-        raise RuntimeError(f"Device flow failed: {flow.get('error_description', flow)}")
-    print(f"\n{flow['message']}\n")
-    result = app.acquire_token_by_device_flow(flow)
+
+    from msal import SerializableTokenCache
+    cache = SerializableTokenCache()
+    if _TOKEN_CACHE_PATH.exists():
+        cache.deserialize(_TOKEN_CACHE_PATH.read_text())
+
+    app = _MSAL(cfg.CLIENT_ID, authority=cfg.AUTHORITY, token_cache=cache)
+
+    # Try silent acquisition first (uses cached refresh token)
+    accounts = app.get_accounts()
+    result = None
+    if accounts:
+        result = app.acquire_token_silent(cfg.SCOPES, account=accounts[0])
+
+    if not result:
+        flow = app.initiate_device_flow(scopes=cfg.SCOPES)
+        if "user_code" not in flow:
+            raise RuntimeError(f"Device flow failed: {flow.get('error_description', flow)}")
+        print(f"\n{flow['message']}\n")
+        result = app.acquire_token_by_device_flow(flow)
+
     if "access_token" not in result:
         raise RuntimeError(f"Auth failed: {result.get('error_description', result)}")
+
+    # Persist updated cache
+    if cache.has_state_changed:
+        _TOKEN_CACHE_PATH.write_text(cache.serialize())
+
     return result["access_token"]
 
 
@@ -257,6 +278,10 @@ def make_session(token: str):
         raise RuntimeError("requests is not installed")
     s = _requests.Session()
     s.headers.update({"Authorization": f"Bearer {token}"})
+    # Prevent hung connections from stalling indefinitely
+    s.request = lambda method, url, **kw: _requests.Session.request(
+        s, method, url, timeout=kw.pop("timeout", (10, 60)), **kw
+    )
     return s
 
 
@@ -473,10 +498,17 @@ def migrate_section(
         indent = "  " * depth
         print(f"      {indent}↳ {page.get('title')!r}")
 
-        written = migrate_page(
-            page, pdir, notebook_name, section_name,
-            session, cfg, dry_run,
-        )
+        try:
+            written = migrate_page(
+                page, pdir, notebook_name, section_name,
+                session, cfg, dry_run,
+            )
+        except Exception as exc:
+            print(f"      {indent}⚠  Skipping page after repeated failures ({exc})")
+            counters["pages"] += 1
+            for child in children.get(pid, []):
+                process_page(child, pdir, depth + 1)
+            return
 
         if written and not dry_run:
             rel = [str(Path(w).relative_to(repo_path)) for w in written]
@@ -487,6 +519,7 @@ def migrate_section(
             )
 
         counters["pages"] += 1
+        time.sleep(1)  # pace requests to avoid rate limiting
 
         # Recurse into subpages
         for child in children.get(pid, []):
@@ -571,4 +604,18 @@ if __name__ == "__main__":
         print("❌  Set ONENOTE_CLIENT_ID env var or pass --client-id <your-id>")
         sys.exit(1)
 
-    migrate(Path(args.repo), cfg, dry_run=args.dry_run)
+    # Auto-restart on 401 (token expiry) or 429 (rate limit) — resume/skip makes this safe
+    while True:
+        try:
+            migrate(Path(args.repo), cfg, dry_run=args.dry_run)
+            break
+        except Exception as exc:
+            msg = str(exc)
+            if "401" in msg and "Unauthorized" in msg:
+                print("\n🔄 Token expired mid-run, refreshing and resuming …\n")
+                continue
+            if "429" in msg:
+                print("\n⏳ Persistent rate limit — waiting 5 minutes before resuming …\n")
+                time.sleep(300)
+                continue
+            raise

--- a/tools/onenote-migration/requirements.txt
+++ b/tools/onenote-migration/requirements.txt
@@ -1,0 +1,4 @@
+msal>=1.28.0
+requests>=2.31.0
+markdownify>=0.11.6
+gitpython>=3.1.40

--- a/tools/onenote-migration/test_migrate.py
+++ b/tools/onenote-migration/test_migrate.py
@@ -1,0 +1,300 @@
+"""
+test_migrate.py
+───────────────
+Full test suite for onenote_migrate.py.
+All network / MSAL / Git calls are mocked.
+"""
+
+import sys
+import types
+import unittest
+import tempfile
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch, PropertyMock, call
+
+# ── Stub out unavailable heavy modules before importing the script ─────────────
+
+def _make_stub(name):
+    mod = types.ModuleType(name)
+    sys.modules[name] = mod
+    return mod
+
+msal_mod = _make_stub("msal")
+msal_mod.PublicClientApplication = MagicMock()
+
+git_mod = _make_stub("git")
+git_mod.Repo = MagicMock()
+
+import onenote_migrate as M   # noqa: E402 — must come after stubs
+
+
+class TestSlugify(unittest.TestCase):
+    def test_basic(self):
+        self.assertEqual(M.slugify("Hello World"), "hello-world")
+    def test_special_chars(self):
+        self.assertEqual(M.slugify("Recipe: Smoked Brisket!"), "recipe-smoked-brisket")
+    def test_consecutive_spaces(self):
+        self.assertEqual(M.slugify("a   b"), "a-b")
+    def test_consecutive_hyphens(self):
+        self.assertEqual(M.slugify("a--b"), "a-b")
+    def test_leading_trailing(self):
+        self.assertEqual(M.slugify("  --hello-- "), "hello")
+    def test_empty(self):
+        self.assertEqual(M.slugify(""), "untitled")
+    def test_none_like(self):
+        self.assertEqual(M.slugify("   "), "untitled")
+    def test_unicode_stripped(self):
+        result = M.slugify("Bee 🐝 Hive")
+        self.assertIn("bee", result)
+        self.assertIn("hive", result)
+    def test_numbers_preserved(self):
+        self.assertEqual(M.slugify("Q3 2024"), "q3-2024")
+    def test_already_slugged(self):
+        self.assertEqual(M.slugify("already-fine"), "already-fine")
+
+
+class TestBuildFrontMatter(unittest.TestCase):
+    def _page(self, title="My Page", created="2024-01-01T00:00:00Z",
+              modified="2024-06-01T12:00:00Z"):
+        return {"id": "abc123", "title": title,
+                "createdDateTime": created, "lastModifiedDateTime": modified}
+    def test_contains_title(self):
+        self.assertIn('title: "My Page"', M.build_front_matter(self._page(), "NB", "Sec"))
+    def test_contains_dates(self):
+        fm = M.build_front_matter(self._page(), "NB", "Sec")
+        self.assertIn("2024-01-01T00:00:00Z", fm)
+        self.assertIn("2024-06-01T12:00:00Z", fm)
+    def test_contains_notebook_section(self):
+        fm = M.build_front_matter(self._page(), "Beekeeping", "Spring 2024")
+        self.assertIn('notebook: "Beekeeping"', fm)
+        self.assertIn('section: "Spring 2024"', fm)
+    def test_starts_with_triple_dash(self):
+        self.assertTrue(M.build_front_matter(self._page(), "NB", "Sec").startswith("---"))
+    def test_ends_with_triple_dash(self):
+        self.assertIn("---\n", M.build_front_matter(self._page(), "NB", "Sec"))
+    def test_quote_escaping(self):
+        self.assertIn('\\"hello\\"', M.build_front_matter(self._page(title='Say "hello"'), "NB", "Sec"))
+    def test_missing_title_defaults(self):
+        self.assertIn('title: "Untitled"', M.build_front_matter(
+            {"id": "x", "createdDateTime": "", "lastModifiedDateTime": ""}, "NB", "Sec"))
+
+
+class TestExtractResourceUrls(unittest.TestCase):
+    def test_finds_src_urls(self):
+        html = '<img src="https://graph.microsoft.com/v1.0/me/onenote/resources/abc/content">'
+        self.assertEqual(len(M.extract_resource_urls(html)), 1)
+    def test_finds_href_urls(self):
+        html = '<a href="https://graph.microsoft.com/v1.0/me/onenote/resources/xyz/content">f</a>'
+        self.assertEqual(len(M.extract_resource_urls(html)), 1)
+    def test_ignores_non_graph_urls(self):
+        self.assertEqual(M.extract_resource_urls('<img src="https://example.com/image.png">'), [])
+    def test_multiple_resources(self):
+        html = '<img src="https://graph.microsoft.com/img1"><img src="https://graph.microsoft.com/img2">'
+        self.assertEqual(len(M.extract_resource_urls(html)), 2)
+    def test_empty_html(self):
+        self.assertEqual(M.extract_resource_urls(""), [])
+
+
+class TestRewriteResourceUrls(unittest.TestCase):
+    def test_replaces_src(self):
+        url = "https://graph.microsoft.com/v1.0/me/onenote/resources/abc"
+        result = M.rewrite_resource_urls(f'<img src="{url}">', {url: "assets/abc.png"})
+        self.assertIn('src="assets/abc.png"', result)
+        self.assertNotIn("graph.microsoft.com", result)
+    def test_unknown_url_unchanged(self):
+        url = "https://graph.microsoft.com/unknown"
+        self.assertIn(url, M.rewrite_resource_urls(f'<img src="{url}">', {}))
+    def test_multiple_replacements(self):
+        u1, u2 = "https://graph.microsoft.com/a", "https://graph.microsoft.com/b"
+        result = M.rewrite_resource_urls(f'<img src="{u1}"><img src="{u2}">',
+                                          {u1: "assets/a.png", u2: "assets/b.png"})
+        self.assertIn("assets/a.png", result)
+        self.assertIn("assets/b.png", result)
+
+
+class TestHtmlToMarkdown(unittest.TestCase):
+    def test_heading_conversion(self):
+        self.assertIn("# Hello", M.html_to_markdown("<h1>Hello</h1>"))
+    def test_paragraph(self):
+        self.assertIn("Some text", M.html_to_markdown("<p>Some text</p>"))
+    def test_bold(self):
+        self.assertIn("Bold", M.html_to_markdown("<b>Bold</b>"))
+    def test_list(self):
+        md = M.html_to_markdown("<ul><li>Item A</li><li>Item B</li></ul>")
+        self.assertIn("Item A", md); self.assertIn("Item B", md)
+    def test_link(self):
+        md = M.html_to_markdown('<a href="https://example.com">Click</a>')
+        self.assertIn("https://example.com", md); self.assertIn("Click", md)
+    def test_strips_scripts(self):
+        md = M.html_to_markdown("<script>alert(1)</script><p>Safe</p>")
+        self.assertNotIn("alert", md); self.assertIn("Safe", md)
+    def test_image_tag(self):
+        self.assertIn("assets/img.png", M.html_to_markdown('<img src="assets/img.png" alt="photo">'))
+
+
+class TestLocalAssetName(unittest.TestCase):
+    def test_extracts_filename(self):
+        url = "https://graph.microsoft.com/v1.0/me/onenote/resources/abc/content"
+        self.assertEqual(M.local_asset_name(url, 0), "asset-0000.bin")
+    def test_extracts_real_filename(self):
+        url = "https://graph.microsoft.com/v1.0/me/onenote/resources/abc/photo.png"
+        self.assertEqual(M.local_asset_name(url, 0), "photo.png")
+    def test_fallback_on_no_extension(self):
+        self.assertIn("asset-0003", M.local_asset_name(
+            "https://graph.microsoft.com/v1.0/me/onenote/resources/abc", 3))
+    def test_sanitises_special_chars(self):
+        name = M.local_asset_name("https://graph.microsoft.com/resources/my file (1).png", 0)
+        self.assertNotIn(" ", name); self.assertNotIn("(", name)
+
+
+class TestFormatCommitDate(unittest.TestCase):
+    def test_z_becomes_utc_offset(self):
+        result = M.format_commit_date("2024-06-01T12:00:00Z")
+        self.assertIn("+00:00", result); self.assertNotIn("Z", result)
+    def test_strips_milliseconds(self):
+        self.assertNotIn(".000", M.format_commit_date("2024-06-01T12:00:00.000Z"))
+    def test_already_offset(self):
+        self.assertIn("+00:00", M.format_commit_date("2024-06-01T12:00:00+00:00"))
+    def test_invalid_falls_back(self):
+        result = M.format_commit_date("not-a-date")
+        self.assertIsInstance(result, str); self.assertGreater(len(result), 0)
+
+
+class TestRetryWithBackoff(unittest.TestCase):
+    def _ok(self, status=200):
+        r = MagicMock(); r.status_code = status; return r
+    def test_success_first_try(self):
+        fn = MagicMock(return_value=self._ok(200))
+        self.assertEqual(M.retry_with_backoff(fn, "url", retries=3, base=0).status_code, 200)
+        fn.assert_called_once_with("url")
+    @patch("onenote_migrate.time.sleep")
+    def test_retries_on_429(self, mock_sleep):
+        ok = self._ok(200); throttled = self._ok(429); throttled.headers = {"Retry-After": "0"}
+        fn = MagicMock(side_effect=[throttled, throttled, ok])
+        self.assertEqual(M.retry_with_backoff(fn, "url", retries=3, base=0).status_code, 200)
+        self.assertEqual(fn.call_count, 3)
+    @patch("onenote_migrate.time.sleep")
+    def test_retries_on_503(self, mock_sleep):
+        ok = self._ok(200); err = self._ok(503); err.headers = {}
+        fn = MagicMock(side_effect=[err, ok])
+        self.assertEqual(M.retry_with_backoff(fn, "url", retries=3, base=0).status_code, 200)
+    @patch("onenote_migrate.time.sleep")
+    def test_raises_after_max_retries(self, mock_sleep):
+        throttled = self._ok(429); throttled.headers = {"Retry-After": "0"}
+        throttled.raise_for_status = MagicMock(side_effect=Exception("too many"))
+        with self.assertRaises(Exception):
+            M.retry_with_backoff(MagicMock(return_value=throttled), "url", retries=2, base=0)
+    @patch("onenote_migrate.time.sleep")
+    def test_retries_on_network_exception(self, mock_sleep):
+        ok = self._ok(200)
+        fn = MagicMock(side_effect=[ConnectionError("down"), ok])
+        self.assertEqual(M.retry_with_backoff(fn, "url", retries=3, base=0).status_code, 200)
+
+
+class TestGetAll(unittest.TestCase):
+    def _resp(self, value, next_link=None):
+        r = MagicMock(); r.status_code = 200; r.raise_for_status = MagicMock()
+        data = {"value": value}
+        if next_link: data["@odata.nextLink"] = next_link
+        r.json.return_value = data; return r
+    def test_single_page(self):
+        session = MagicMock(); session.get.return_value = self._resp([{"id": "1"}, {"id": "2"}])
+        self.assertEqual(len(M.get_all("https://graph.microsoft.com/notebooks", session)), 2)
+    def test_follows_next_link(self):
+        session = MagicMock()
+        session.get.side_effect = [
+            self._resp([{"id": "1"}], next_link="https://graph.microsoft.com/page2"),
+            self._resp([{"id": "2"}, {"id": "3"}])
+        ]
+        items = M.get_all("https://graph.microsoft.com/page1", session)
+        self.assertEqual(len(items), 3); self.assertEqual(session.get.call_count, 2)
+    def test_empty_result(self):
+        session = MagicMock(); session.get.return_value = self._resp([])
+        self.assertEqual(M.get_all("https://graph.microsoft.com/empty", session), [])
+
+
+class TestResumeLogic(unittest.TestCase):
+    def test_skip_known_id(self):
+        self.assertTrue(M.should_skip("abc", {"abc", "def"}))
+    def test_no_skip_unknown_id(self):
+        self.assertFalse(M.should_skip("xyz", {"abc", "def"}))
+    def test_load_migrated_ids_no_git(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(M.load_migrated_ids(Path(tmp)), set())
+    def test_load_migrated_ids_from_git_log(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            subprocess.run(["git", "init", str(tmp)], capture_output=True)
+            subprocess.run(["git", "-C", str(tmp), "config", "user.email", "t@t.com"], capture_output=True)
+            subprocess.run(["git", "-C", str(tmp), "config", "user.name", "T"], capture_output=True)
+            (tmp / "dummy.txt").write_text("x")
+            subprocess.run(["git", "-C", str(tmp), "add", "."], capture_output=True)
+            subprocess.run(["git", "-C", str(tmp), "commit", "-m", "page:PAGE-ID-001 My Note"], capture_output=True)
+            self.assertIn("PAGE-ID-001", M.load_migrated_ids(tmp))
+
+
+class TestMigratePage(unittest.TestCase):
+    def _page(self):
+        return {"id": "PAGE-123", "title": "Hive Inspection",
+                "createdDateTime": "2024-03-01T09:00:00Z",
+                "lastModifiedDateTime": "2024-03-15T10:30:00Z"}
+    def _mock_session(self, html="<h1>Hive</h1><p>All good.</p>"):
+        session = MagicMock()
+        r = MagicMock(); r.status_code = 200; r.text = html; r.raise_for_status = MagicMock()
+        session.get.return_value = r; return session
+    def test_creates_index_md(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            M.migrate_page(self._page(), Path(tmp)/"p", "NB", "Sec",
+                           self._mock_session(), M.Config(), dry_run=False)
+            self.assertTrue((Path(tmp)/"p"/"index.md").exists())
+    def test_index_md_has_front_matter(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            M.migrate_page(self._page(), Path(tmp)/"p", "Beekeeping", "Spring",
+                           self._mock_session(), M.Config(), dry_run=False)
+            content = (Path(tmp)/"p"/"index.md").read_text()
+            self.assertIn("title:", content); self.assertIn("Hive Inspection", content)
+    def test_index_md_has_body(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            M.migrate_page(self._page(), Path(tmp)/"p", "NB", "Sec",
+                           self._mock_session(), M.Config(), dry_run=False)
+            content = (Path(tmp)/"p"/"index.md").read_text()
+            self.assertIn("Hive", content); self.assertIn("All good", content)
+    def test_dry_run_writes_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pdir = Path(tmp)/"p"
+            written = M.migrate_page(self._page(), pdir, "NB", "Sec",
+                                     self._mock_session(), M.Config(), dry_run=True)
+            self.assertEqual(written, []); self.assertFalse(pdir.exists())
+    def test_returns_list_of_written_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            written = M.migrate_page(self._page(), Path(tmp)/"p", "NB", "Sec",
+                                     self._mock_session(), M.Config(), dry_run=False)
+            self.assertGreater(len(written), 0)
+            self.assertTrue(any("index.md" in w for w in written))
+    def test_downloads_embedded_assets(self):
+        url  = "https://graph.microsoft.com/v1.0/me/onenote/resources/img1"
+        html = f'<img src="{url}"><p>body</p>'
+        with tempfile.TemporaryDirectory() as tmp:
+            session = MagicMock()
+            hr = MagicMock(); hr.status_code=200; hr.text=html; hr.raise_for_status=MagicMock()
+            ir = MagicMock(); ir.status_code=200; ir.content=b"\x89PNG\r\n"; ir.raise_for_status=MagicMock()
+            session.get.side_effect = [hr, ir]
+            M.migrate_page(self._page(), Path(tmp)/"p", "NB", "Sec", session, M.Config(), dry_run=False)
+            self.assertEqual(len(list((Path(tmp)/"p"/"assets").iterdir())), 1)
+
+
+class TestParseArgs(unittest.TestCase):
+    def test_defaults(self):
+        args = M.parse_args([])
+        self.assertEqual(args.repo, "./onenote-vault"); self.assertFalse(args.dry_run)
+    def test_custom_repo(self):
+        self.assertEqual(M.parse_args(["--repo", "/tmp/mynotes"]).repo, "/tmp/mynotes")
+    def test_dry_run_flag(self):
+        self.assertTrue(M.parse_args(["--dry-run"]).dry_run)
+    def test_client_id(self):
+        self.assertEqual(M.parse_args(["--client-id", "abc-123"]).client_id, "abc-123")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Automated migration of personal OneNote via Microsoft Graph API. See `tools/onenote-migration/README.md` for setup and usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OneNote → Markdown migration tool: exports pages with local assets, per-page YAML files, backdated commits, resumable runs, dry-run, and retry/backoff for rate limits.

* **Documentation**
  * Added comprehensive README with usage, auth setup, limitations, architecture, and examples.

* **Tests**
  * Added mocked test suite covering transformations, asset handling, retry/pagination/resume logic, and CLI flags.

* **Chores**
  * Added requirements/dependency list for the migration tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->