### PR TITLE
chore: add bot accounts to CODEOWNERS + define org standard

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # Owners are matched in order, last matching pattern wins.
 
 # Default owner for all files
-* @don-petry
+* @don-petry @petry-projects-pr-review-agent @dependabot-automerge-petry

--- a/standards/github-settings.md
+++ b/standards/github-settings.md
@@ -256,8 +256,11 @@ in the `pr-quality` ruleset:
 | `@dependabot-automerge-petry` | `dependabot-automerge-petry` | Dependabot auto-merge approver |
 
 The `pr-quality` ruleset requires **1 code owner approval**. With all three
-accounts on every pattern, approval from any one of them — human or bot —
-satisfies the requirement.
+accounts on every pattern, an approval from `@don-petry`, `@petry-projects-pr-review-agent`,
+or `@dependabot-automerge-petry` satisfies the requirement — provided the approver
+is not also the author of the last push to that branch (`require_last_push_approval`
+prevents self-approval after one's own push). For Dependabot PRs this is never an
+issue: Dependabot pushes the branch and a separate bot approves it.
 
 ### Standard Template
 

--- a/standards/github-settings.md
+++ b/standards/github-settings.md
@@ -261,7 +261,7 @@ satisfies the requirement.
 
 ### Standard Template
 
-```
+```gitignore
 # CODEOWNERS
 # Each line is a pattern followed by one or more owners.
 # Owners are matched in order, last matching pattern wins.

--- a/standards/github-settings.md
+++ b/standards/github-settings.md
@@ -136,9 +136,9 @@ rules are deprecated — migrate existing classic rules to rulesets.
 | **Allow force pushes** | No |
 | **Allow deletions** | No |
 
-> **CODEOWNERS:** Repos SHOULD add a `CODEOWNERS` file defining ownership.
-> Without one, the "Require code owner review" setting has no effect. Add
-> CODEOWNERS incrementally as team structure and domain ownership solidifies.
+> **CODEOWNERS:** All repos MUST have a `CODEOWNERS` file. Without one, the
+> "Require code owner review" setting has no effect. See the
+> [CODEOWNERS Standard](#codeowners-standard) below for the required format.
 
 ### `code-quality` — Required Checks Ruleset (All Repositories)
 
@@ -194,7 +194,8 @@ See [CI Standards](ci-standards.md) for workflow templates and patterns.
 | App | Purpose | Installed |
 |-----|---------|-----------|
 | **Claude** | AI code review and PR assistance via Claude Code Action | 2026-03-20 |
-| **dependabot-automerge-petry** | Provides approving review for Dependabot auto-merge (bypasses branch protection) | 2026-03-23 |
+| **dependabot-automerge-petry** | Provides approving review for Dependabot auto-merge; listed in CODEOWNERS so its approvals satisfy `require_code_owner_review` | 2026-03-23 |
+| **petry-projects-pr-review-agent** | General PR review agent; listed in CODEOWNERS as the org-standard automation reviewer | 2026-04-01 |
 | **SonarQube Cloud (SonarCloud)** | Code quality, security hotspots, coverage tracking | 2026-03-25 |
 | **CodeRabbit AI** | AI-powered code review on PRs | 2026-03-25 |
 
@@ -238,6 +239,43 @@ All repositories MUST have these labels configured:
 
 ---
 
+## CODEOWNERS Standard
+
+All repositories MUST have a `CODEOWNERS` file at `.github/CODEOWNERS`
+(or `CODEOWNERS` at the repo root for repos with no `.github/` directory).
+
+### Required Bot Accounts
+
+Every CODEOWNERS file MUST include these two bot accounts alongside `@don-petry`
+so that automated PR approvals satisfy the `require_code_owner_review` setting
+in the `pr-quality` ruleset:
+
+| Account | App | Role |
+|---------|-----|------|
+| `@petry-projects-pr-review-agent` | `petry-projects-pr-review-agent` | General org PR review bot |
+| `@dependabot-automerge-petry` | `dependabot-automerge-petry` | Dependabot auto-merge approver |
+
+The `pr-quality` ruleset requires **1 code owner approval**. With all three
+accounts on every pattern, approval from any one of them — human or bot —
+satisfies the requirement.
+
+### Standard Template
+
+```
+# CODEOWNERS
+# Each line is a pattern followed by one or more owners.
+# Owners are matched in order, last matching pattern wins.
+# Standard: https://github.com/petry-projects/.github/blob/main/standards/github-settings.md#codeowners-standard
+
+# Default owner for all files
+* @don-petry @petry-projects-pr-review-agent @dependabot-automerge-petry
+```
+
+Repos with finer-grained path ownership (e.g., `/apps/api/`, `/infra/`) MUST
+add the two bot accounts to every path-specific line, not just the default `*`.
+
+---
+
 ## Applying to a New Repository
 
 When creating a new repository in `petry-projects`:
@@ -245,7 +283,7 @@ When creating a new repository in `petry-projects`:
 1. **Create the repo** with standard settings (public, `main` branch, wiki disabled, discussions enabled)
 2. **Create the `pr-quality` ruleset** matching the standard configuration above
 3. **Create the `code-quality` ruleset** with required checks for the repo's stack
-4. **Add a `CODEOWNERS` file** defining ownership for the repo's key paths
+4. **Add a `CODEOWNERS` file** using the [CODEOWNERS Standard](#codeowners-standard) template, extended with any repo-specific path patterns
 5. **Add Dependabot configuration** — copy the appropriate template from
    [`standards/dependabot/`](dependabot/) and add to `.github/dependabot.yml`
 6. **Add CI workflows** — see [CI Standards](ci-standards.md) for required workflows


### PR DESCRIPTION
## Summary

- Adds `@petry-projects-pr-review-agent` and `@dependabot-automerge-petry` to `.github/CODEOWNERS` so bot approvals satisfy the `require_code_owner_review` setting in the `pr-quality` ruleset
- Defines the org CODEOWNERS standard in `standards/github-settings.md` (new **CODEOWNERS Standard** section with required template and bot account documentation)

## Why

All Dependabot PRs across the org were stuck at `REVIEW_REQUIRED` because `pr-quality` has `require_code_owner_review: true`, and the `dependabot-automerge-petry` bot was approving PRs but isn't listed in any CODEOWNERS file. GitHub requires the approver to be a defined code owner — a plain bot approval doesn't satisfy it.

## Test plan
- [ ] After merge, open a test Dependabot PR and confirm it auto-merges without requiring `@don-petry` approval
- [ ] Verify `reviewDecision` changes from `REVIEW_REQUIRED` to `APPROVED` when the bot approves

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced code ownership and review standards documentation to clarify compliance requirements for all repositories and approval workflows.
  * Updated GitHub Apps and integrations table with new automation tool entries.

* **Chores**
  * Updated code ownership configuration to expand reviewer roster for automated review processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->