### PR TITLE
fix: restore double .github path in agent-shield and claude reusable refs

### DIFF
--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   agent-shield:
-    uses: petry-projects/.github/workflows/agent-shield-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v1

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,7 +20,7 @@ permissions: {}
 
 jobs:
   claude-code:
-    uses: petry-projects/.github/workflows/claude-code-reusable.yml@main
+    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@main
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- **Root cause:** Commit 956b396 incorrectly removed the second `.github` segment from the `uses:` paths in `agent-shield.yml` and `claude.yml`, breaking both workflows since April 21, 2026
- **Symptom:** Every AgentShield and Claude Code run completes in 0 seconds with 0 jobs — GitHub's "workflow file issue" indicator
- **Fix:** Restore the correct double-`.github` path format that was working before the bad "fix"

### Why double `.github`?

The GitHub Actions path format for calling a reusable in the org's `.github` repository is:

```
{owner}/{repo}/.github/workflows/{file}.yml@{ref}
         ↑                ↑
    repo name = .github   path within repo = .github/workflows/
```

So for `petry-projects/.github`:
- ✅ `petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v1`
- ❌ `petry-projects/.github/workflows/agent-shield-reusable.yml@v1`

The `standards/workflows/` templates and `scripts/compliance-audit.sh` (lines 225–234) already document the double `.github` as correct. This PR aligns the actual `.github/workflows/` caller stubs with what the standards say.

## Test plan

- [ ] AgentShield run starts jobs (no longer 0s / 0 jobs)
- [ ] Claude Code run starts jobs
- [ ] Both pass their respective checks on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)