### PR TITLE
fix: add dedup pre-flight to claude-issue to prevent duplicate PRs

### DIFF
--- a/.github/workflows/claude-code-reusable.yml
+++ b/.github/workflows/claude-code-reusable.yml
@@ -142,7 +142,41 @@ jobs:
         with:
           fetch-depth: 1
           token: ${{ secrets.GH_PAT_WORKFLOWS || github.token }}
+      - name: Check for existing open PR
+        id: dedup
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS || github.token }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          # Search by branch prefix (claude/issue-NNN-*)
+          PR_URL=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --json number,url,headRefName \
+            --jq ".[] | select(.headRefName | startswith(\"claude/issue-${ISSUE}-\")) | .url" \
+            | head -1)
+
+          # Fallback: search PR body for "Closes #NNN"
+          if [ -z "$PR_URL" ]; then
+            PR_URL=$(gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --state open \
+              --search "Closes #${ISSUE} in:body" \
+              --json url \
+              --jq '.[0].url' 2>/dev/null || true)
+          fi
+
+          if [ -n "$PR_URL" ]; then
+            echo "existing_pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+            gh issue comment "$ISSUE" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body "An open PR already addresses this issue: $PR_URL — skipping new Claude run to avoid duplicates."
+            echo "Skipping: existing PR found at $PR_URL"
+          else
+            echo "No existing open PR found — proceeding with Claude."
+          fi
       - name: Run Claude Code
+        if: steps.dedup.outputs.existing_pr_url == ''
         uses: anthropics/claude-code-action@905d4eb99ab3d43143d74fb0dcae537f29ac330a # v1.0.97
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- Inserts a **Check for existing open PR** step before **Run Claude Code** in the `claude-issue` job
- Searches for open PRs by branch prefix (`claude/issue-NNN-*`), with a fallback body search (`Closes #NNN in:body`)
- If a match is found: posts a dedup comment on the issue linking to the existing PR, then skips **Run Claude Code** via `if: steps.dedup.outputs.existing_pr_url == ''`

## Motivation

The existing `concurrency: cancel-in-progress: true` only prevents *parallel* runs. When the `claude` label is re-applied on a separate day (or after a partial run), a fresh sequential run starts with no awareness of prior attempts and creates another duplicate PR.

This was observed in `petry-projects/google-app-scripts` where issue #171 accumulated PRs #190, #198, #215, and #240 across multiple label re-applications. The same fix was previously deployed to `don-petry/pr-review-agent`'s local `claude.yml` (PR [don-petry/pr-review-agent#26](https://github.com/don-petry/pr-review-agent/pull/26)); this PR applies it to the org-level reusable so all repos benefit.

## Test plan

- [ ] Re-apply the `claude` label to `petry-projects/google-app-scripts` issue #171 (already has open PR #215) — the run should skip Claude and post a dedup comment on the issue
- [ ] Apply the `claude` label to a fresh issue with no open PR — Claude should run normally

🤖 Generated with [Claude Code](https://claude.ai/code)