### PR TITLE
docs: update standards with Dependabot auto-merge learnings

### DIFF
--- a/standards/dependabot-policy.md
+++ b/standards/dependabot-policy.md
@@ -203,7 +203,7 @@ jobs:
     permissions:
       contents: write   # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write  # re-approve PRs after branch update
-    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@2f6d246fd7cc8740f5d7e2e4d12f087889c58365 # v1
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/standards/dependabot-policy.md
+++ b/standards/dependabot-policy.md
@@ -45,12 +45,13 @@ Each repository must have the following baseline files:
 | `.github/dependabot.yml` | Dependabot config scoped to the repo's ecosystems |
 | `.github/workflows/dependabot-automerge.yml` | Auto-approve + squash-merge security PRs |
 | `.github/workflows/dependency-audit.yml` | CI check — fail on known vulnerabilities |
+| `.github/workflows/dependabot-rebase.yml` | Keep Dependabot PRs up-to-date and merge them serially |
 
-The following file is conditional:
-
-| File | When required |
-|------|--------------|
-| `.github/workflows/dependabot-rebase.yml` | Required when strict required-status-checks (`strict_required_status_checks_policy: true`) applies — without it, Dependabot PRs fall behind after each merge and stall. **Not** required for CODEOWNERS enforcement; bot accounts in `CODEOWNERS` handle that. See [Applying to a Repository](#applying-to-a-repository) for details. |
+The `dependabot-rebase.yml` is required for all repos using the `code-quality`
+ruleset (which enforces `require_branches_to_be_up_to_date: true`). Without it,
+each merge to `main` leaves remaining Dependabot PRs behind and they stall
+indefinitely — Dependabot only rebases on its weekly schedule or on merge conflicts,
+not when a branch merely falls behind.
 
 ## Dependabot Templates
 
@@ -172,7 +173,8 @@ may not trigger when rulesets cause `mergeable_state` to report "blocked" even
 when all requirements are met. Together, these issues stall Dependabot PR
 merges indefinitely.
 
-This workflow fires on every push to `main` and:
+This workflow fires on every push to `main` (and can be triggered manually via
+`workflow_dispatch` to flush the queue) and:
 
 1. **Updates behind PRs** — uses the GitHub API `update-branch` endpoint with
    the **merge** method to bring Dependabot PR branches up to date with `main`.
@@ -189,6 +191,52 @@ future operations ("edited by someone other than Dependabot"). The merge method
 preserves the original commits. The automerge workflow must use
 `skip-commit-verification: true` in `dependabot/fetch-metadata` since the merge
 commit is authored by GitHub, not Dependabot.
+
+### Caller Stub Format
+
+The repo-level `dependabot-rebase.yml` is a thin caller stub. It must use
+**explicit secrets** (not `secrets: inherit`) and **write permissions**:
+
+```yaml
+jobs:
+  dependabot-rebase:
+    permissions:
+      contents: write   # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
+      pull-requests: write  # re-approve PRs after branch update
+    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@v1
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+```
+
+> **Why not `secrets: inherit`?** GitHub reusable workflows receive no more
+> permissions than the calling job grants them. A caller with `permissions: read`
+> prevents the reusable from making any write API calls — branch updates and
+> PR approvals silently fail. Additionally, `secrets: inherit` with mismatched
+> permission levels can cause `startup_failure` on the reusable job. Always use
+> explicit secrets and grant write permissions.
+
+To manually flush the Dependabot PR queue after fixing a stalled pipeline:
+
+```bash
+gh workflow run dependabot-rebase.yml --repo petry-projects/<repo>
+```
+
+### CODEOWNERS Approval Timing
+
+GitHub evaluates code owner status **at the time an approval is submitted**, not
+retroactively. If `CODEOWNERS` is updated (e.g., bot accounts are added), existing
+approvals from those accounts on open PRs are not retroactively credited.
+
+To re-trigger fresh approvals after a CODEOWNERS change:
+
+```bash
+# Comment @dependabot rebase on each blocked PR to trigger a new commit,
+# which causes the automerge workflow to fire and re-approve:
+gh pr list --repo petry-projects/<repo> --label dependencies --json number \
+  --jq '.[].number' | xargs -I{} gh pr comment {} --repo petry-projects/<repo> \
+  --body "@dependabot rebase"
+```
 
 ## Vulnerability Audit CI Check
 
@@ -212,11 +260,10 @@ The workflow fails if any known vulnerability is found, blocking the PR from mer
 1. Copy the appropriate `dependabot.yml` template to `.github/dependabot.yml`,
    adjusting `directory` paths as needed.
 2. Add `workflows/dependabot-automerge.yml` to `.github/workflows/`.
-3. Add `workflows/dependabot-rebase.yml` to `.github/workflows/` if the repo
-   enforces **strict required-status-checks** (`strict_required_status_checks_policy: true`
-   or classic branch protection `required_status_checks.strict: true`) — without
-   this workflow, Dependabot PRs fall behind after each merge to `main` and stall.
-   If the repo does not use strict status checks, the rebase workflow is unnecessary.
+3. Add `workflows/dependabot-rebase.yml` to `.github/workflows/` (required for
+   all repos using the `code-quality` ruleset with `require_branches_to_be_up_to_date: true`).
+   Copy verbatim from [`standards/workflows/dependabot-rebase.yml`](workflows/dependabot-rebase.yml)
+   — do **not** modify the secrets block or permissions.
 
    > **Note:** The rebase workflow is **not** required for `require_code_owner_review`.
    > The correct solution for CODEOWNERS enforcement is to list the bot accounts
@@ -228,9 +275,15 @@ The workflow fails if any known vulnerability is found, blocking the PR from mer
 4. Add `workflows/dependency-audit.yml` to `.github/workflows/`.
 5. **GitHub App secrets** — `APP_ID` and `APP_PRIVATE_KEY` are managed at the
    **organization level** (`gh secret set <name> --org petry-projects --visibility all`),
-   not per-repo. Caller stubs use `secrets: inherit` so any repo with at least
-   one centralized dependabot workflow picks them up automatically. Per-repo
-   `APP_ID` / `APP_PRIVATE_KEY` settings are deprecated drift — once the org
+   not per-repo. The caller stubs pass these explicitly via:
+
+   ```yaml
+   secrets:
+     APP_ID: ${{ secrets.APP_ID }}
+     APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+   ```
+
+   Per-repo `APP_ID` / `APP_PRIVATE_KEY` settings are deprecated drift — once the org
    secrets are confirmed in place, delete any per-repo copies so there's a
    single source of truth and rotations propagate everywhere.
 
@@ -240,14 +293,10 @@ The workflow fails if any known vulnerability is found, blocking the PR from mer
    gh secret list --org petry-projects | grep -E '^(APP_ID|APP_PRIVATE_KEY)\s'
    ```
 
-   to confirm both org-level secrets exist with `visibility: all`. Then
-   confirm the dependabot caller stubs in the target repo include
-   `secrets: inherit` (they will if copied verbatim from
-   `standards/workflows/dependabot-automerge.yml` and
-   `standards/workflows/dependabot-rebase.yml`). Only after both checks
-   pass should you run `gh secret delete APP_ID --repo <repo>` etc. to
-   clean up the per-repo copies — otherwise the workflow falls back to
-   nothing and `gh pr review` calls fail with `Secret APP_ID is required`.
+   to confirm both org-level secrets exist with `visibility: all`. Only after
+   both secrets are confirmed should you run `gh secret delete APP_ID --repo <repo>`
+   to clean up per-repo copies — otherwise `gh pr review` calls fail with
+   `Secret APP_ID is required`.
 6. Create the `security` and `dependencies` labels in the repository if they
    don't already exist.
 7. Add `dependency-audit / Detect ecosystems` as a required status check in

--- a/standards/github-settings.md
+++ b/standards/github-settings.md
@@ -140,6 +140,35 @@ rules are deprecated — migrate existing classic rules to rulesets.
 > "Require code owner review" setting has no effect. See the
 > [CODEOWNERS Standard](#codeowners-standard) below for the required format.
 
+#### Bypass Actors
+
+The `pr-quality` ruleset MUST include the following bypass actors:
+
+| Actor | Type | `bypass_mode` | Reason |
+|-------|------|--------------|--------|
+| `dependabot-automerge-petry` | GitHub App | `always` | Approves and merges Dependabot PRs; must bypass review gate |
+| `OrganizationAdmin` | Role | `always` | Emergency admin override |
+
+> **Critical:** `bypass_mode: pull_request` does **not** work for Dependabot PRs.
+> That mode only bypasses review requirements when the bypass actor *opens* the PR
+> via the PR flow. Since `dependabot[bot]` opens Dependabot PRs, the
+> `dependabot-automerge-petry` app cannot use `pull_request` bypass for them —
+> its merge API calls are rejected with `Required status check` errors.
+> Use `bypass_mode: always` so the app can call `gh api .../merge` directly
+> after manually verifying CI. The rebase workflow verifies CI before merging,
+> so `always` does not bypass safety checks.
+
+#### CODEOWNERS Approval Timing
+
+GitHub evaluates code owner status **at the time an approval is submitted**, not
+retroactively. If `CODEOWNERS` is updated (e.g., adding bot accounts), approvals
+already on open PRs from those accounts are not retroactively credited as code
+owner approvals.
+
+**Recovery:** comment `@dependabot rebase` on blocked PRs. This triggers
+Dependabot to push a new commit, which fires the automerge workflow and submits
+a fresh approval under the current CODEOWNERS.
+
 ### `code-quality` — Required Checks Ruleset (All Repositories)
 
 Every repository MUST have the following quality checks configured and
@@ -156,6 +185,15 @@ but the categories are universal.
 | **CI Pipeline** | All repos | Repo-specific (e.g., `build-and-test`, `TypeScript`, `Go`) | Lint, format, typecheck, test |
 | **Coverage** | All repos | `coverage` or embedded in CI job | Must meet repo-defined thresholds |
 | **Secret Scan** | All repos | `Secret scan (gitleaks)` | Full-history gitleaks scan — see [Push Protection Standard](push-protection.md#layer-3--ci-secret-scanning-secondary-defense) |
+
+> **Check names must match exactly.** GitHub-managed CodeQL produces a check named
+> `CodeQL` — **not** `Analyze (actions)`, `Analyze (javascript-typescript)`, or
+> `CodeQL / Analyze (go)`. Requiring a check name that no job produces permanently
+> blocks every PR. Verify check names against actual workflow runs:
+>
+> ```bash
+> gh pr checks <PR-number> --repo petry-projects/<repo>
+> ```
 
 #### Ecosystem-Specific Configuration
 
@@ -219,7 +257,7 @@ all repos automatically — no per-repo setup needed:
 | `CLAUDE_CODE_OAUTH_TOKEN` | Authentication for Claude Code Action |
 | `SONAR_TOKEN` | SonarCloud analysis authentication |
 
-Repos's may require repo-specific secrets beyond this standard set.
+Repos may require repo-specific secrets beyond this standard set.
 
 ---
 
@@ -284,8 +322,8 @@ add the two bot accounts to every path-specific line, not just the default `*`.
 When creating a new repository in `petry-projects`:
 
 1. **Create the repo** with standard settings (public, `main` branch, wiki disabled, discussions enabled)
-2. **Create the `pr-quality` ruleset** matching the standard configuration above
-3. **Create the `code-quality` ruleset** with required checks for the repo's stack
+2. **Create the `pr-quality` ruleset** matching the standard configuration above, including bypass actors with `bypass_mode: always` for `dependabot-automerge-petry`
+3. **Create the `code-quality` ruleset** with required checks for the repo's stack — verify check names against actual workflow runs before requiring them
 4. **Add a `CODEOWNERS` file** using the [CODEOWNERS Standard](#codeowners-standard) template, extended with any repo-specific path patterns
 5. **Add Dependabot configuration** — copy the appropriate template from
    [`standards/dependabot/`](dependabot/) and add to `.github/dependabot.yml`
@@ -305,21 +343,17 @@ When creating a new repository in `petry-projects`:
 **Repository settings:** All 7 repos are fully compliant as of 2026-04-05
 (remediated via `scripts/apply-repo-settings.sh --all`).
 
-**Ruleset status:**
+**Ruleset status (as of 2026-05-04):**
 
 | Repository | `pr-quality` | `code-quality` | Notes |
 |------------|:---:|:---:|-------|
-| **.github** | — | — | No rulesets yet |
-| **bmad-bgreat-suite** | — | — | No rulesets yet |
-| **ContentTwin** | ✅ | — | |
-| **broodly** | ✅ | — | |
-| **TalkTerm** | ✅ | — | |
-| **markets** | ✅ | — | |
-| **google-app-scripts** | — | — | Has non-standard `protect-branches` ruleset — migrate to `pr-quality` |
-
-> **Next steps:** Run `scripts/apply-rulesets.sh --all` to create both `pr-quality`
-> and `code-quality` rulesets across all repos.
-> Migrate `google-app-scripts` from its legacy `protect-branches` ruleset.
+| **.github** | ✅ | — | `pr-quality` added; `code-quality` not yet configured |
+| **bmad-bgreat-suite** | ✅ | ✅ | Both rulesets present; CodeQL check fixed (`CodeQL` not `Analyze (actions)`) |
+| **ContentTwin** | ✅ | ✅ | `dependabot-automerge-petry` bypass actor added; CodeQL check fixed |
+| **broodly** | ✅ | — | `code-quality` not yet configured |
+| **TalkTerm** | ✅ | ✅ | Both rulesets present; stale CI check names removed |
+| **markets** | ✅ | — | `code-quality` not yet configured |
+| **google-app-scripts** | ✅ | — | Migrated from `protect-branches` to `pr-quality`; legacy CodeQL check removed |
 
 ---
 

--- a/standards/workflows/dependabot-rebase.yml
+++ b/standards/workflows/dependabot-rebase.yml
@@ -41,7 +41,7 @@ jobs:
     permissions:
       contents: write   # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write  # re-approve PRs after branch update
-    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@3c6335c6ee3e2f1a37f3e27e065e28d36d9c0dde # v1
+    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@2f6d246fd7cc8740f5d7e2e4d12f087889c58365 # v1
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/standards/workflows/dependabot-rebase.yml
+++ b/standards/workflows/dependabot-rebase.yml
@@ -6,20 +6,21 @@
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All rebase/merge serialization logic
 #     lives in the reusable workflow above.
-#   • You MAY change: the SHA in the `uses:` line when upgrading the reusable
-#     workflow version (bump SHA to latest main of petry-projects/.github).
-#   • You MUST NOT change: trigger event, the concurrency group name,
-#     the explicit secrets block, or the job-level `permissions:` block —
-#     reusable workflows can be granted no more permissions than the calling
-#     job has, so removing the stanza breaks
-#     the reusable's gh API calls.
+#   • You MAY change: the ref in the `uses:` line when upgrading the reusable
+#     workflow version (bump to latest commit SHA or tag of petry-projects/.github).
+#   • You MUST NOT change: the concurrency group name, the explicit secrets
+#     block, or the job-level `permissions:` block — reusable workflows can be
+#     granted no more permissions than the calling job has, so removing the
+#     stanza breaks the reusable’s gh API calls. Do not remove either trigger
+#     (`push` keeps the self-sustaining chain; `workflow_dispatch` allows
+#     manual queue flushes).
 #   • If you need different behaviour, open a PR against the reusable in the
 #     central repo.
 # ─────────────────────────────────────────────────────────────────────────────
 #
 # Dependabot update-and-merge — thin caller for the org-level reusable.
 # To adopt: copy this file to .github/workflows/dependabot-rebase.yml in your repo.
-# Required org/repo secrets (inherited):
+# Required org secrets (passed explicitly):
 #   APP_ID         — GitHub App ID with contents:write and pull-requests:write
 #   APP_PRIVATE_KEY — GitHub App private key
 name: Dependabot update and merge

--- a/standards/workflows/dependabot-rebase.yml
+++ b/standards/workflows/dependabot-rebase.yml
@@ -11,7 +11,7 @@
 #   • You MUST NOT change: the concurrency group name, the explicit secrets
 #     block, or the job-level `permissions:` block — reusable workflows can be
 #     granted no more permissions than the calling job has, so removing the
-#     stanza breaks the reusable’s gh API calls. Do not remove either trigger
+#     stanza breaks the reusable's gh API calls. Do not remove either trigger
 #     (`push` keeps the self-sustaining chain; `workflow_dispatch` allows
 #     manual queue flushes).
 #   • If you need different behaviour, open a PR against the reusable in the
@@ -40,8 +40,8 @@ permissions: {}
 jobs:
   dependabot-rebase:
     permissions:
-      contents: write   # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
-      pull-requests: write  # re-approve PRs after branch update
+      contents: write # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
+      pull-requests: write # re-approve PRs after branch update
     uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@2f6d246fd7cc8740f5d7e2e4d12f087889c58365 # v1
     secrets:
       APP_ID: ${{ secrets.APP_ID }}


### PR DESCRIPTION
## Summary

Documents hard-won lessons from diagnosing and fixing Dependabot PR auto-merge failures across the org (May 2026).

### `standards/dependabot-policy.md`

- **`dependabot-rebase.yml` is required for all repos** (not just ones with strict status checks) — all repos use `code-quality` ruleset with `require_branches_to_be_up_to_date: true`, so without it every merge leaves remaining Dependabot PRs behind permanently
- **Explicit secrets format required** — documents that `secrets: inherit` + `permissions: read` causes `startup_failure` on the reusable workflow; the correct format uses explicit `APP_ID`/`APP_PRIVATE_KEY` and `permissions: write`
- **CODEOWNERS approval timing** — documents that GitHub evaluates code owner status at the time of approval submission, not retroactively; adds recovery procedure (`@dependabot rebase`)
- Updates step 5 in "Applying to a Repository" to reflect explicit secrets (not `secrets: inherit`)
- Removes the confusing note suggesting `secrets: inherit` was ever correct
- Adds `workflow_dispatch` trigger mention for manual queue flushing

### `standards/github-settings.md`

- **Bypass actors table for `pr-quality`** — documents that `dependabot-automerge-petry` must use `bypass_mode: always`, not `pull_request`; explains why `pull_request` fails for Dependabot PRs (the bot doesn't open them, `dependabot[bot]` does)
- **CODEOWNERS approval timing** — adds recovery note under the `pr-quality` ruleset section
- **Check name validation** — adds warning that required check names must exactly match what CI produces; GitHub-managed CodeQL produces `CodeQL`, not `Analyze (actions)` or `Analyze (javascript-typescript)`
- **Compliance status table** — updated to reflect current state of all 7 repos as of 2026-05-04
- Minor typo fix: "Repos's" → "Repos"

## Test plan
- [ ] Proofread for accuracy against current repo state
- [ ] Confirm no broken links to other standards files