### PR TITLE
fix: update reusable workflow header comment — secrets explicitly passed, not inherited

### DIFF
--- a/.github/workflows/dependabot-rebase-reusable.yml
+++ b/.github/workflows/dependabot-rebase-reusable.yml
@@ -29,7 +29,7 @@
 # dependabot-automerge workflow must use skip-commit-verification: true
 # in the dependabot/fetch-metadata step.
 #
-# Required org/repo secrets (passed via `secrets: inherit` from caller):
+# Required org/repo secrets (passed explicitly by caller via secrets: mapping):
 #   APP_ID         — GitHub App ID with contents:write and pull-requests:write
 #   APP_PRIVATE_KEY — GitHub App private key
 name: Dependabot update and merge (Reusable)


### PR DESCRIPTION
## Summary

Fixes a stale comment in the reusable workflow header that still described secrets as being passed via `secrets: inherit`. All caller stubs now use explicit `APP_ID`/`APP_PRIVATE_KEY` mappings.

**Change:** Line 32: `(passed via 'secrets: inherit' from caller)` → `(passed explicitly by caller via secrets: mapping)`

Raised by Copilot on [PR #187](https://github.com/petry-projects/.github/pull/187) — the reusable workflow's own header contradicted the updated standards documentation.

## Test plan
- [ ] CI passes