### PR TITLE
fix: use @dependabot rebase instead of update-branch to trigger CI

### DIFF
--- a/.github/workflows/dependabot-rebase-reusable.yml
+++ b/.github/workflows/dependabot-rebase-reusable.yml
@@ -12,22 +12,26 @@
 # are actually met.
 #
 # Solution: after every push to main (typically a merged PR), this workflow:
-#   1. Updates behind Dependabot PRs using the merge method (not rebase)
-#   2. Merges any Dependabot PR that is up-to-date, approved, and passing CI
+#   1. Posts "@dependabot rebase" on behind Dependabot PRs so Dependabot
+#      updates the branch with its own identity — this triggers CI normally.
+#      (Using the API update-branch endpoint with GITHUB_TOKEN does NOT
+#      trigger CI workflow runs due to GitHub's recursive-trigger guard.)
+#   2. Merges any Dependabot PR that is up-to-date, approved, and passing CI.
 #
-# Using the app token for merges ensures the resulting push to main triggers
-# this workflow again, creating a self-sustaining chain that serializes
-# Dependabot PR merges one at a time.
+# Why @dependabot rebase instead of the update-branch API:
+#   GitHub's GITHUB_TOKEN is subject to a security guard that prevents
+#   events triggered by GITHUB_TOKEN from starting new workflow runs. When
+#   update-branch is called with GITHUB_TOKEN, the resulting push to the PR
+#   branch never triggers CI — the required checks (SonarCloud, build-and-
+#   test, etc.) don't run, so the PR stays blocked. Dependabot's own push
+#   (triggered by @dependabot rebase) bypasses this guard and CI runs
+#   normally. The pull_request_target/synchronize event then fires and the
+#   automerge workflow re-approves the PR.
 #
-# Important: never use the API update-branch endpoint with rebase method on
-# Dependabot PRs — it replaces Dependabot's commit signature with GitHub's,
-# which breaks dependabot/fetch-metadata verification and causes Dependabot
-# to refuse future rebases on that PR. The merge method preserves the
-# original commits.
-#
-# Note: the merge commit is authored by GitHub, not Dependabot, so the
-# dependabot-automerge workflow must use skip-commit-verification: true
-# in the dependabot/fetch-metadata step.
+# Note: @dependabot rebase is Dependabot rebasing its own branch, which
+# preserves Dependabot's commit signature. This is distinct from using the
+# update-branch API with rebase method (which force-pushes with GitHub's
+# identity and breaks dependabot/fetch-metadata verification).
 #
 # Required org/repo secrets (passed explicitly by caller via secrets: mapping):
 #   APP_ID         — GitHub App ID with contents:write and pull-requests:write
@@ -48,7 +52,6 @@ jobs:
   update-and-merge:
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # needed for update-branch (may touch .github/workflows/)
       pull-requests: write
     steps:
       - name: Check app secrets
@@ -69,8 +72,8 @@ jobs:
 
       - name: Update and merge Dependabot PRs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # GITHUB_TOKEN for update-branch (has workflows permission)
-          APP_TOKEN: ${{ steps.app-token.outputs.token }}  # app token reserved for approvals
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
         run: |
           # Find open Dependabot PRs
@@ -90,67 +93,40 @@ jobs:
               --jq '.behind_by')
 
             if [[ "$BEHIND" -gt 0 ]]; then
-              echo "PR #$PR_NUMBER ($HEAD_REF) is $BEHIND commit(s) behind — merging main into branch"
-              # Capture both stdout and stderr; use if-then to avoid bash -e terminating
-              # the step on non-zero exit before we can inspect the error message.
-              if UPDATE_OUTPUT=$(gh api "repos/$REPO/pulls/$PR_NUMBER/update-branch" \
-                -X PUT -f update_method=merge 2>&1); then
-                if [[ -n "$UPDATE_OUTPUT" ]]; then echo "$UPDATE_OUTPUT"; fi
-                echo "  Branch updated"
-                # Only re-approve if auto-merge is enabled. Auto-merge is set exclusively
-                # by the dependabot-automerge workflow after confirming eligibility (patch/
-                # minor updates or GitHub Actions). This guards against re-approving PRs
-                # that the policy intentionally leaves for human review (e.g. major non-
-                # Actions updates).
-                #
-                # Note: update-branch creates a merge commit authored by GitHub's
-                # infrastructure (not the app token), so require_last_push_approval is
-                # satisfied when the app re-approves — the pusher and approver are
-                # different identities.
-                AUTO_MERGE_ENABLED=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
-                  --json autoMergeRequest --jq '.autoMergeRequest != null')
-                if [[ "$AUTO_MERGE_ENABLED" == "true" ]]; then
-                  echo "  Re-approving to refresh stale approval"
-                  # Use app token for approval so it is attributed to the trusted app identity.
-                  # GITHUB_TOKEN (used above for update-branch) is the pusher, so the
-                  # approver (app) satisfies require_last_push_approval.
-                  if GH_TOKEN="$APP_TOKEN" gh pr review "$PR_NUMBER" --repo "$REPO" --approve \
-                    --body "Re-approved after branch update to keep up-to-date with main."; then
-                    echo "  Re-approved PR #$PR_NUMBER"
-                  else
-                    echo "  Warning: failed to re-approve PR #$PR_NUMBER — PR will remain blocked until manually re-approved"
-                  fi
-                else
-                  echo "  Skipping re-approval — auto-merge not enabled (PR may require human review)"
+              echo "PR #$PR_NUMBER ($HEAD_REF) is $BEHIND commit(s) behind"
+
+              # Get the date of the most recent commit on the branch so we can
+              # detect whether we already posted @dependabot rebase and are
+              # waiting for Dependabot to process it.
+              BRANCH_HEAD_DATE=$(gh api "repos/$REPO/commits/$HEAD_REF" \
+                --jq '.commit.committer.date' 2>/dev/null || echo "")
+
+              # Check for a @dependabot rebase comment posted AFTER the latest
+              # branch commit. If one exists, we already requested a rebase and
+              # Dependabot hasn't processed it yet — avoid spamming.
+              if [[ -n "$BRANCH_HEAD_DATE" ]]; then
+                PENDING=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+                  --json comments \
+                  --jq --arg d "$BRANCH_HEAD_DATE" \
+                  '[.comments[] | select(.body == "@dependabot rebase" and .createdAt > $d)] | length' \
+                  2>/dev/null || echo "0")
+                if [[ "$PENDING" -gt 0 ]]; then
+                  echo "  @dependabot rebase already requested — waiting for Dependabot to process"
+                  continue
                 fi
+              fi
+
+              # Post @dependabot rebase. Dependabot pushes to its own branch
+              # with its own identity, which triggers CI normally. The
+              # pull_request_target/synchronize event fires and the automerge
+              # workflow re-approves (satisfying require_last_push_approval since
+              # Dependabot is the pusher and the app bot is the approver).
+              echo "  Requesting @dependabot rebase so Dependabot's push triggers CI"
+              if GH_TOKEN="$APP_TOKEN" gh pr comment "$PR_NUMBER" --repo "$REPO" \
+                --body "@dependabot rebase"; then
+                echo "  Posted @dependabot rebase on PR #$PR_NUMBER"
               else
-                # update-branch failed — check if it's the workflows-permission 403
-                echo "  $UPDATE_OUTPUT"
-                if echo "$UPDATE_OUTPUT" | grep -qF "without \`workflows\` permission"; then
-                  # GitHub blocks update-branch when merging main would add .github/workflows/
-                  # changes and the token (any token) lacks the GitHub App 'workflows' permission.
-                  # Fallback: post @dependabot rebase. Dependabot has the correct permissions to
-                  # push to its own branch. After rebase, the automerge workflow fires on
-                  # pull_request_target/synchronize and re-approves.
-                  #
-                  # Idempotent: skip if a @dependabot rebase comment already exists to avoid
-                  # spamming the PR on every push-to-main trigger.
-                  ALREADY_REQUESTED=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
-                    --json comments --jq '[.comments[] | select(.body == "@dependabot rebase")] | length')
-                  if [[ "$ALREADY_REQUESTED" -gt 0 ]]; then
-                    echo "  Skipping — @dependabot rebase already requested (waiting for Dependabot to process)"
-                  else
-                    echo "  Posting @dependabot rebase as fallback"
-                    if GH_TOKEN="$APP_TOKEN" gh pr comment "$PR_NUMBER" --repo "$REPO" \
-                      --body "@dependabot rebase"; then
-                      echo "  Posted @dependabot rebase on PR #$PR_NUMBER"
-                    else
-                      echo "  Warning: failed to post @dependabot rebase — PR #$PR_NUMBER will remain stuck"
-                    fi
-                  fi
-                else
-                  echo "  Warning: failed to update PR #$PR_NUMBER"
-                fi
+                echo "  Warning: failed to post @dependabot rebase on PR #$PR_NUMBER"
               fi
               continue
             fi

--- a/.github/workflows/dependabot-rebase-reusable.yml
+++ b/.github/workflows/dependabot-rebase-reusable.yml
@@ -105,9 +105,10 @@ jobs:
               # branch commit. If one exists, we already requested a rebase and
               # Dependabot hasn't processed it yet — avoid spamming.
               if [[ -n "$BRANCH_HEAD_DATE" ]]; then
-                PENDING=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
-                  --json comments \
-                  --jq --arg d "$BRANCH_HEAD_DATE" \
+                # SC2016: $d is a jq variable (passed via --arg), not a shell variable.
+                # shellcheck disable=SC2016
+                PENDING=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json comments \
+                  2>/dev/null | jq --arg d "$BRANCH_HEAD_DATE" \
                   '[.comments[] | select(.body == "@dependabot rebase" and .createdAt > $d)] | length' \
                   2>/dev/null || echo "0")
                 if [[ "$PENDING" -gt 0 ]]; then

--- a/standards/dependabot-policy.md
+++ b/standards/dependabot-policy.md
@@ -176,21 +176,32 @@ merges indefinitely.
 This workflow fires on every push to `main` (and can be triggered manually via
 `workflow_dispatch` to flush the queue) and:
 
-1. **Updates behind PRs** — uses the GitHub API `update-branch` endpoint with
-   the **merge** method to bring Dependabot PR branches up to date with `main`.
+1. **Updates behind PRs** — posts `@dependabot rebase` on any Dependabot PR
+   that is behind `main`. Dependabot rebases its own branch, which triggers
+   CI normally. The `pull_request_target/synchronize` event fires and the
+   automerge workflow re-approves.
 2. **Merges ready PRs** — directly merges any Dependabot PR that is up-to-date,
    has auto-merge enabled, and has all CI checks passing.
 
 Using the app token for merges ensures each merge triggers a new push to `main`,
 creating a self-sustaining chain that serializes Dependabot PR merges.
 
-**Important:** always use the **merge** method (not rebase) with `update-branch`.
-The rebase method force-pushes, replacing Dependabot's commit signature, which
-breaks `dependabot/fetch-metadata` verification and causes Dependabot to refuse
-future operations ("edited by someone other than Dependabot"). The merge method
-preserves the original commits. The automerge workflow must use
-`skip-commit-verification: true` in `dependabot/fetch-metadata` since the merge
-commit is authored by GitHub, not Dependabot.
+**Why `@dependabot rebase` instead of the `update-branch` API:** GitHub's
+`GITHUB_TOKEN` is subject to a recursive-trigger guard — events caused by
+`GITHUB_TOKEN` do not create new workflow runs. When `update-branch` is called
+with `GITHUB_TOKEN`, the resulting push to the PR branch never triggers CI. The
+required checks (SonarCloud, build-and-test, etc.) have no results on the new
+commit, so the PR stays `BLOCKED` indefinitely.
+
+Dependabot's own push (via `@dependabot rebase`) bypasses this guard and CI runs
+normally. The `pull_request_target/synchronize` event then fires and the automerge
+workflow re-approves, satisfying `require_last_push_approval` (Dependabot is the
+pusher; the app bot is the approver).
+
+**Note:** `@dependabot rebase` causes Dependabot to rebase its own branch, which
+preserves Dependabot's commit signature. This is different from using the
+`update-branch` API with `update_method=rebase`, which force-pushes with GitHub's
+infrastructure identity and breaks `dependabot/fetch-metadata` verification.
 
 ### Caller Stub Format
 
@@ -201,8 +212,7 @@ The repo-level `dependabot-rebase.yml` is a thin caller stub. It must use
 jobs:
   dependabot-rebase:
     permissions:
-      contents: write   # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
-      pull-requests: write  # re-approve PRs after branch update
+      pull-requests: write # post @dependabot rebase comments and re-approve PRs
     uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@2f6d246fd7cc8740f5d7e2e4d12f087889c58365 # v1
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
@@ -211,8 +221,8 @@ jobs:
 
 > **Why not `secrets: inherit`?** GitHub reusable workflows receive no more
 > permissions than the calling job grants them. A caller with `permissions: read`
-> prevents the reusable from making any write API calls — branch updates and
-> PR approvals silently fail. Additionally, `secrets: inherit` with mismatched
+> prevents the reusable from making any write API calls — PR comments and
+> approvals silently fail. Additionally, `secrets: inherit` with mismatched
 > permission levels can cause `startup_failure` on the reusable job. Always use
 > explicit secrets and grant write permissions.
 

--- a/standards/workflows/dependabot-rebase.yml
+++ b/standards/workflows/dependabot-rebase.yml
@@ -21,7 +21,7 @@
 # Dependabot update-and-merge — thin caller for the org-level reusable.
 # To adopt: copy this file to .github/workflows/dependabot-rebase.yml in your repo.
 # Required org secrets (passed explicitly):
-#   APP_ID         — GitHub App ID with contents:write and pull-requests:write
+#   APP_ID         — GitHub App ID with pull-requests:write
 #   APP_PRIVATE_KEY — GitHub App private key
 name: Dependabot update and merge
 
@@ -40,8 +40,7 @@ permissions: {}
 jobs:
   dependabot-rebase:
     permissions:
-      contents: write # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
-      pull-requests: write # re-approve PRs after branch update
+      pull-requests: write # post @dependabot rebase comments and re-approve PRs
     uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@2f6d246fd7cc8740f5d7e2e4d12f087889c58365 # v1
     secrets:
       APP_ID: ${{ secrets.APP_ID }}


### PR DESCRIPTION
## Problem

The `dependabot-rebase-reusable.yml` workflow was using the GitHub API `update-branch` endpoint with `GITHUB_TOKEN` to bring Dependabot PR branches up-to-date with `main`. This approach is broken:

**GitHub's recursive-trigger guard** prevents events caused by `GITHUB_TOKEN` from starting new workflow runs. After `update-branch` creates a merge commit using `GITHUB_TOKEN`, none of the CI workflows (SonarCloud, build-and-test, dependency-audit, agent-shield) run on the new commit. The PR's status rollup only shows independent checks (CodeQL Advanced Security), and the PR stays `BLOCKED` indefinitely — even after re-approval.

Confirmed in google-app-scripts: 11 Dependabot PRs were updated and re-approved by the rebase workflow but remain stuck with `mergeStateStatus: BLOCKED` and no CI results on the updated commits.

## Fix

Replace `update-branch` with `@dependabot rebase` comments. Dependabot updates its own branch with its own identity, which:

1. Triggers CI normally (Dependabot's push is not subject to the GITHUB_TOKEN guard)
2. Fires `pull_request_target/synchronize`, causing the automerge workflow to re-approve
3. Satisfies `require_last_push_approval` (Dependabot is pusher, app bot is approver)
4. Preserves Dependabot's commit signature (unlike the API `rebase` method)

**Idempotency:** The workflow checks for a `@dependabot rebase` comment posted *after* the latest branch commit. If one exists, we're already waiting for Dependabot to process it — no duplicate comment is posted. Once Dependabot processes the rebase (its new commit is newer than our comment), the check clears and we'd post again if needed.

## Changes

- `dependabot-rebase-reusable.yml`: replace `update-branch` block with `@dependabot rebase` comment logic; remove `contents: write` permission (no longer needed)
- `standards/dependabot-policy.md`: update workflow description and caller stub format
- `standards/workflows/dependabot-rebase.yml`: update template to remove `contents: write`

## After merge

1. Update the `v1` tag to the new merge commit
2. Manually trigger `dependabot-rebase.yml` on google-app-scripts (or any repo with stuck Dependabot PRs) to post `@dependabot rebase` on behind PRs
3. Monitor: Dependabot will rebase → CI runs → automerge approves → PRs merge in the self-sustaining chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the mechanism for synchronizing out-of-date dependency update PRs to use automated comment-based triggering instead of direct API operations.

* **Chores**
  * Simplified required permissions for dependency update automation workflows by removing unnecessary access levels.

* **Documentation**
  * Updated workflow documentation and configuration guidance to reflect the revised dependency PR synchronization approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->