### PR TITLE
chore: standardize CODEOWNERS on @petry-projects/org-leads team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,10 @@
 # CODEOWNERS
 # Each line is a pattern followed by one or more owners.
 # Owners are matched in order, last matching pattern wins.
+#
+# Standard: use the @petry-projects/org-leads team for all code owner
+# assignments instead of listing individuals or bot accounts directly.
+# This keeps CODEOWNERS files stable and centralizes membership management.
+# See: standards/codeowners-standard.md
 
-# Default owner for all files
-* @don-petry @petry-projects-pr-review-agent @dependabot-automerge-petry
+* @petry-projects/org-leads

--- a/standards/codeowners-standard.md
+++ b/standards/codeowners-standard.md
@@ -1,0 +1,40 @@
+# CODEOWNERS Standard
+
+**Status:** Active
+**Applies to:** All repos in `petry-projects` org
+
+## Rule
+
+CODEOWNERS files MUST reference the `@petry-projects/org-leads` team rather than individual users or bot accounts.
+
+```
+# Default
+* @petry-projects/org-leads
+```
+
+Path-specific rules MAY use additional teams or individuals when a narrower owner is appropriate, but the default `*` rule must always include `@petry-projects/org-leads`.
+
+## Why
+
+- **Stable CODEOWNERS files** — adding/removing an owner is a team membership change, not a multi-repo PR
+- **CODEOWNERS support for automation** — GitHub Apps cannot be listed in CODEOWNERS (platform limitation), but a machine user account in the team can satisfy `require_code_owner_review`. See [pr-review-agent issue #27](https://github.com/don-petry/pr-review-agent/issues/27)
+- **Centralized control** — team membership is managed in one place via the org admin UI
+
+## Team Composition
+
+The `@petry-projects/org-leads` team contains:
+
+- `@don-petry` — primary maintainer (team maintainer)
+- `@donpetry-bot` — automation machine user (used by pr-review-agent and similar tooling)
+
+Add additional human maintainers as needed. Bots/apps that need code owner standing should be machine user accounts added to this team, not GitHub Apps.
+
+## Branch Protection
+
+Repos that require code owner review must set `require_code_owner_review: true` on protected branches. Approvals from any member of `@petry-projects/org-leads` will satisfy the requirement.
+
+## Migration
+
+Repos still using individual owner lists should migrate via PR replacing the legacy `* @don-petry @petry-projects-pr-review-agent @dependabot-automerge-petry` line with `* @petry-projects/org-leads`.
+
+The `petry-projects-pr-review-agent` GitHub App reference is non-functional (GitHub Apps cannot be CODEOWNERS) and should be removed during migration.

--- a/standards/codeowners-standard.md
+++ b/standards/codeowners-standard.md
@@ -7,7 +7,7 @@
 
 CODEOWNERS files MUST reference the `@petry-projects/org-leads` team rather than individual users or bot accounts.
 
-```
+```text
 # Default
 * @petry-projects/org-leads
 ```
@@ -17,7 +17,9 @@ Path-specific rules MAY use additional teams or individuals when a narrower owne
 ## Why
 
 - **Stable CODEOWNERS files** — adding/removing an owner is a team membership change, not a multi-repo PR
-- **CODEOWNERS support for automation** — GitHub Apps cannot be listed in CODEOWNERS (platform limitation), but a machine user account in the team can satisfy `require_code_owner_review`. See [pr-review-agent issue #27](https://github.com/don-petry/pr-review-agent/issues/27)
+- **CODEOWNERS support for automation** — GitHub Apps cannot be listed in CODEOWNERS
+  (platform limitation), but a machine user in the team can satisfy
+  `require_code_owner_review`. See [pr-review-agent issue #27](https://github.com/don-petry/pr-review-agent/issues/27)
 - **Centralized control** — team membership is managed in one place via the org admin UI
 
 ## Team Composition


### PR DESCRIPTION
## Summary

- Replace individual user/bot listings in `.github/CODEOWNERS` with the new `@petry-projects/org-leads` team
- Add `standards/codeowners-standard.md` documenting the policy

## Why

- **Stable CODEOWNERS files** — owner changes become team membership changes, not multi-repo PRs
- **Fixes GitHub App limitation** — GitHub Apps cannot be code owners (platform limitation), but machine user `@donpetry-bot` in the team can satisfy `require_code_owner_review`. Closes [pr-review-agent#27](https://github.com/don-petry/pr-review-agent/issues/27)
- **Centralized control** — manage owners in one place

## Team

`@petry-projects/org-leads` (newly created):
- `@don-petry` (maintainer)
- `@donpetry-bot` (member — machine user for pr-review-agent)

## Test plan

- [ ] PR merges cleanly
- [ ] Org Leads team has push access to all org repos (already granted via API)
- [ ] Follow-up PRs migrate child repos (ContentTwin, TalkTerm, markets, broodly, google-app-scripts, bmad-bgreat-suite)
- [ ] Verify donpetry-bot approvals satisfy `require_code_owner_review` on TalkTerm after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)