### PR TITLE
fix: disable Claude + CodeRabbit auto-trigger check suites to unblock auto-merge

### DIFF
--- a/scripts/apply-repo-settings.sh
+++ b/scripts/apply-repo-settings.sh
@@ -33,6 +33,7 @@ DRY_RUN="${DRY_RUN:-false}"
 
 info()  { echo "[INFO]  $*"; }
 ok()    { echo "[OK]    $*"; }
+warn()  { echo "[WARN]  $*" >&2; }
 err()   { echo "[ERROR] $*" >&2; }
 skip()  { echo "[SKIP]  $*"; }
 
@@ -246,7 +247,7 @@ apply_check_suite_prefs() {
   prefs=$(gh api "repos/$ORG/$repo/check-suites/preferences" 2>/dev/null || true)
   if [ -z "$prefs" ]; then
     warn "  Could not read check-suite preferences for $repo — skipping"
-    return 0
+    return 1
   fi
 
   local all_disabled=true
@@ -254,7 +255,8 @@ apply_check_suite_prefs() {
     local setting
     setting=$(echo "$prefs" | jq -r --argjson id "$app_id" \
       '.preferences.auto_trigger_checks // [] | map(select(.app_id == $id)) | first | .setting // "missing"')
-    if [ "$setting" != "false" ]; then
+    # "missing" means the app has never run in this repo — no orphaned suite possible, skip
+    if [ "$setting" != "false" ] && [ "$setting" != "missing" ]; then
       all_disabled=false
     fi
   done

--- a/scripts/apply-repo-settings.sh
+++ b/scripts/apply-repo-settings.sh
@@ -36,6 +36,13 @@ ok()    { echo "[OK]    $*"; }
 err()   { echo "[ERROR] $*" >&2; }
 skip()  { echo "[SKIP]  $*"; }
 
+# App IDs whose auto_trigger_checks must be disabled — these apps create
+# orphaned "queued" suites on every push that are never completed, permanently
+# blocking GitHub auto-merge.
+# 1236702 = Claude (anthropics/claude-code-action)
+# 347564  = CodeRabbit
+CHECK_SUITE_APP_IDS=(1236702 347564)
+
 # Source the shared push-protection library — provides
 # pp_apply_security_and_analysis() and the PP_REQUIRED_SA_SETTINGS list.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -227,6 +234,56 @@ apply_codeql_default_setup() {
 }
 
 # ---------------------------------------------------------------------------
+# apply_check_suite_prefs — disable auto-trigger check suites for Claude and
+# CodeRabbit. Without this, GitHub auto-creates "queued" suites on every push
+# that are never completed, permanently blocking auto-merge.
+# ---------------------------------------------------------------------------
+apply_check_suite_prefs() {
+  local repo="$1"
+  info "Configuring check-suite auto-trigger preferences for $ORG/$repo ..."
+
+  local prefs
+  prefs=$(gh api "repos/$ORG/$repo/check-suites/preferences" 2>/dev/null || true)
+  if [ -z "$prefs" ]; then
+    warn "  Could not read check-suite preferences for $repo — skipping"
+    return 0
+  fi
+
+  local all_disabled=true
+  for app_id in "${CHECK_SUITE_APP_IDS[@]}"; do
+    local setting
+    setting=$(echo "$prefs" | jq -r --argjson id "$app_id" \
+      '.preferences.auto_trigger_checks // [] | map(select(.app_id == $id)) | first | .setting // "missing"')
+    if [ "$setting" != "false" ]; then
+      all_disabled=false
+    fi
+  done
+
+  if [ "$all_disabled" = true ]; then
+    ok "$ORG/$repo check-suite prefs already correct"
+    return 0
+  fi
+
+  if [ "${DRY_RUN:-false}" = "true" ]; then
+    skip "DRY_RUN — skipping check-suite prefs PATCH for $repo"
+    return 0
+  fi
+
+  local payload
+  payload=$(printf '%s\n' "${CHECK_SUITE_APP_IDS[@]}" | \
+    jq -Rs 'split("\n") | map(select(. != "")) | map(tonumber) |
+             {"auto_trigger_checks": map({"app_id": ., "setting": false})}')
+
+  if gh api -X PATCH "repos/$ORG/$repo/check-suites/preferences" \
+       --input - <<< "$payload" > /dev/null; then
+    ok "  auto-trigger disabled for app_ids: ${CHECK_SUITE_APP_IDS[*]}"
+  else
+    warn "  PATCH failed for $repo — manual fix required"
+    return 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 if [ $# -eq 0 ]; then
@@ -263,6 +320,7 @@ if [ "$1" = "--all" ]; then
     apply_labels "$repo"
     pp_apply_security_and_analysis "$repo" || failed=$((failed + 1))
     apply_codeql_default_setup "$repo" || failed=$((failed + 1))
+    apply_check_suite_prefs "$repo" || failed=$((failed + 1))
   done
 
   if [ "$failed" -gt 0 ]; then
@@ -282,4 +340,5 @@ else
   apply_labels "$1"
   pp_apply_security_and_analysis "$1"
   apply_codeql_default_setup "$1"
+  apply_check_suite_prefs "$1"
 fi

--- a/scripts/apply-repo-settings.sh
+++ b/scripts/apply-repo-settings.sh
@@ -244,9 +244,8 @@ apply_check_suite_prefs() {
   info "Configuring check-suite auto-trigger preferences for $ORG/$repo ..."
 
   local prefs
-  prefs=$(gh api "repos/$ORG/$repo/check-suites/preferences" 2>/dev/null || true)
-  if [ -z "$prefs" ]; then
-    warn "  Could not read check-suite preferences for $repo — skipping"
+  if ! prefs=$(gh api "repos/$ORG/$repo/check-suites/preferences" 2>&1); then
+    err "  Could not read check-suite preferences for $repo. API response: $prefs"
     return 1
   fi
 
@@ -276,11 +275,12 @@ apply_check_suite_prefs() {
     jq -Rs 'split("\n") | map(select(. != "")) | map(tonumber) |
              {"auto_trigger_checks": map({"app_id": ., "setting": false})}')
 
-  if gh api -X PATCH "repos/$ORG/$repo/check-suites/preferences" \
-       --input - <<< "$payload" > /dev/null; then
+  local api_err
+  if api_err=$(gh api -X PATCH "repos/$ORG/$repo/check-suites/preferences" \
+       --input - <<< "$payload" 2>&1 >/dev/null); then
     ok "  auto-trigger disabled for app_ids: ${CHECK_SUITE_APP_IDS[*]}"
   else
-    warn "  PATCH failed for $repo — manual fix required"
+    err "  PATCH failed for $repo. API response: $api_err"
     return 1
   fi
 }

--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -866,7 +866,12 @@ check_check_suite_prefs() {
 
   local prefs
   prefs=$(gh_api "repos/$ORG/$repo/check-suites/preferences" 2>/dev/null || true)
-  [ -z "$prefs" ] && return  # non-fatal if API unavailable
+  if [ -z "$prefs" ]; then
+    add_finding "$repo" "settings" "check-suite-prefs-unreadable" "warning" \
+      "Could not read check-suite preferences — verify GH_TOKEN has repo scope and the repo is accessible. Check-suite auto-trigger compliance was not evaluated." \
+      "standards/github-settings.md"
+    return
+  fi
 
   for app_id in "${CHECK_SUITE_APP_IDS[@]}"; do
     local setting

--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -52,6 +52,11 @@ REQUIRED_LABEL_SPECS=(
   "in-progress:fbca04:An agent is actively working this issue"
 )
 
+# App IDs whose auto_trigger_checks must be disabled org-wide.
+# 1236702 = Claude (anthropics/claude-code-action)
+# 347564  = CodeRabbit
+CHECK_SUITE_APP_IDS=(1236702 347564)
+
 REQUIRED_SETTINGS_BOOL=(
   "allow_auto_merge:true:warning:Allow auto-merge must be enabled for Dependabot workflow"
   "delete_branch_on_merge:true:warning:Automatically delete head branches must be enabled"
@@ -854,6 +859,35 @@ check_agents_md() {
 }
 
 # ---------------------------------------------------------------------------
+# Check: check-suite auto-trigger disabled for Claude and CodeRabbit
+# ---------------------------------------------------------------------------
+check_check_suite_prefs() {
+  local repo="$1"
+
+  local prefs
+  prefs=$(gh_api "repos/$ORG/$repo/check-suites/preferences" 2>/dev/null || true)
+  [ -z "$prefs" ] && return  # non-fatal if API unavailable
+
+  for app_id in "${CHECK_SUITE_APP_IDS[@]}"; do
+    local setting
+    setting=$(echo "$prefs" | jq -r --argjson id "$app_id" \
+      '.preferences.auto_trigger_checks // [] | map(select(.app_id == $id)) | first | .setting // "missing"')
+
+    # "missing" means the app has never run in this repo — no orphaned suite possible
+    [ "$setting" = "missing" ] && continue
+    [ "$setting" = "false"   ] && continue
+
+    local app_label="app_id=$app_id"
+    [ "$app_id" = "1236702" ] && app_label="Claude (1236702)"
+    [ "$app_id" = "347564"  ] && app_label="CodeRabbit (347564)"
+
+    add_finding "$repo" "settings" "check-suite-auto-trigger-${app_id}" "error" \
+      "$app_label auto-trigger is enabled: GitHub creates a queued check suite on every push that is never completed, permanently blocking auto-merge. Run: \`bash scripts/apply-repo-settings.sh $repo\`" \
+      "standards/github-settings.md"
+  done
+}
+
+# ---------------------------------------------------------------------------
 # Issue management
 # ---------------------------------------------------------------------------
 ensure_audit_label() {
@@ -1299,6 +1333,7 @@ main() {
     check_centralized_check_names "$repo"
     check_claude_md "$repo"
     check_agents_md "$repo"
+    check_check_suite_prefs "$repo"
     pp_run_all_checks "$repo"
 
     log_end

--- a/standards/github-settings.md
+++ b/standards/github-settings.md
@@ -253,7 +253,11 @@ See [CI Standards](ci-standards.md) for workflow templates and patterns.
 
 ### Check-Suite Auto-Trigger Preferences
 
-GitHub automatically creates a check suite for any app that has previously created check runs in a repo, on every push. Some apps (Claude, CodeRabbit) create these suites proactively but only complete them when they have real work to do. When they have nothing to do, the suite stays in `queued` state indefinitely — **GitHub auto-merge waits for all check suites to reach a terminal state before merging**, so these orphaned suites permanently block auto-merge.
+GitHub automatically creates a check suite for any app that has previously created check runs in a repo, on every push.
+Some apps (Claude, CodeRabbit) create these suites proactively but only complete them when they have real work to do.
+When they have nothing to do, the suite stays in `queued` state indefinitely —
+**GitHub auto-merge waits for all check suites to reach a terminal state before merging**,
+so these orphaned suites permanently block auto-merge.
 
 **Required configuration** (enforced by `scripts/apply-repo-settings.sh` and detected by `scripts/compliance-audit.sh`):
 
@@ -264,7 +268,9 @@ GitHub automatically creates a check suite for any app that has previously creat
 
 Disabling auto-trigger stops GitHub from creating suites on every push. The apps still create suites explicitly when they have work to report.
 
-If an app has never created a check run in a repository, GitHub omits that app from `auto_trigger_checks` entirely. Both `scripts/apply-repo-settings.sh` and `scripts/compliance-audit.sh` treat this `missing` state as compliant — no PATCH is needed and no finding is raised until the app is first seen in the repo.
+If an app has never created a check run in a repository, GitHub omits that app from `auto_trigger_checks` entirely.
+Both `scripts/apply-repo-settings.sh` and `scripts/compliance-audit.sh` treat this `missing` state as compliant —
+no PATCH is needed and no finding is raised until the app is first seen in the repo.
 
 **Applying manually** (requires a classic PAT with `repo` scope — OAuth app tokens are rejected by this API endpoint):
 

--- a/standards/github-settings.md
+++ b/standards/github-settings.md
@@ -264,6 +264,8 @@ GitHub automatically creates a check suite for any app that has previously creat
 
 Disabling auto-trigger stops GitHub from creating suites on every push. The apps still create suites explicitly when they have work to report.
 
+If an app has never created a check run in a repository, GitHub omits that app from `auto_trigger_checks` entirely. Both `scripts/apply-repo-settings.sh` and `scripts/compliance-audit.sh` treat this `missing` state as compliant — no PATCH is needed and no finding is raised until the app is first seen in the repo.
+
 **Applying manually** (requires a classic PAT with `repo` scope — OAuth app tokens are rejected by this API endpoint):
 
 ```bash

--- a/standards/github-settings.md
+++ b/standards/github-settings.md
@@ -237,6 +237,27 @@ See [CI Standards](ci-standards.md) for workflow templates and patterns.
 | **SonarQube Cloud (SonarCloud)** | Code quality, security hotspots, coverage tracking | 2026-03-25 |
 | **CodeRabbit AI** | AI-powered code review on PRs | 2026-03-25 |
 
+### Check-Suite Auto-Trigger Preferences
+
+GitHub automatically creates a check suite for any app that has previously created check runs in a repo, on every push. Some apps (Claude, CodeRabbit) create these suites proactively but only complete them when they have real work to do. When they have nothing to do, the suite stays in `queued` state indefinitely — **GitHub auto-merge waits for all check suites to reach a terminal state before merging**, so these orphaned suites permanently block auto-merge.
+
+**Required configuration** (enforced by `scripts/apply-repo-settings.sh` and detected by `scripts/compliance-audit.sh`):
+
+| App | app_id | Setting |
+|-----|--------|---------|
+| Claude (`anthropics/claude-code-action`) | `1236702` | `auto_trigger_checks: false` |
+| CodeRabbit | `347564` | `auto_trigger_checks: false` |
+
+Disabling auto-trigger stops GitHub from creating suites on every push. The apps still create suites explicitly when they have work to report.
+
+**Applying manually** (requires a classic PAT with `repo` scope — OAuth app tokens are rejected by this API endpoint):
+
+```bash
+GH_TOKEN=<classic-pat> bash scripts/apply-repo-settings.sh <repo-name>
+# or for all org repos:
+GH_TOKEN=<classic-pat> bash scripts/apply-repo-settings.sh --all
+```
+
 ### Other Integrations
 
 | Integration | Purpose | Scope |


### PR DESCRIPTION
## Summary

- GitHub auto-creates \"queued\" check suites for Claude (app\_id `1236702`) and CodeRabbit (app\_id `347564`) on every push to any branch with an open PR. When those apps have nothing to do, the suites stay in `queued` state forever.
- GitHub auto-merge waits for **all** check suites — not just required ones — to reach a terminal state before merging. This is why PRs show `mergeStateStatus: BLOCKED` even with `reviewDecision: APPROVED` and all required checks green.
- Fix: `PATCH /repos/{owner}/{repo}/check-suites/preferences` with `auto_trigger_checks: [{app_id: N, setting: false}]` stops GitHub from auto-creating these suites. The apps still create them explicitly when they have real work to report.

## Changes

- **`scripts/apply-repo-settings.sh`** — `apply_check_suite_prefs()` applies the preference to a repo
- **`scripts/compliance-audit.sh`** — `check_check_suite_prefs()` detects drift and creates error-severity findings

## Test plan

- [ ] CI passes on this PR
- [ ] Apply to this repo manually: `bash scripts/apply-repo-settings.sh .github`
- [ ] Verify preferences: `gh api repos/petry-projects/.github/check-suites/preferences --jq '.preferences.auto_trigger_checks'` → should show `setting: false` for both app IDs
- [ ] Push a test commit to an open PR branch → Checks tab should show no new `queued` suites from Claude or CodeRabbit
- [ ] After merge: run `bash scripts/apply-repo-settings.sh --all` to apply across all org repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository settings now enforce GitHub Check Suite auto-trigger preferences for specified GitHub Apps (e.g., Claude, CodeRabbit).
  * Added organization-wide compliance audit to verify Check Suite auto-trigger settings across all repositories.

* **Documentation**
  * Added "Check-Suite Auto-Trigger Preferences" guidance with steps to review and disable auto-triggering and notes on orphaned suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->