### PR TITLE
feat: trigger Claude on CodeRabbit and Copilot review comments

### DIFF
--- a/.github/workflows/claude-code-reusable.yml
+++ b/.github/workflows/claude-code-reusable.yml
@@ -25,7 +25,8 @@ jobs:
         contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' &&
         github.event.comment.user.login != 'claude[bot]' &&
-        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+        (contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) ||
+          contains(fromJson('["coderabbitai[bot]","Copilot"]'), github.event.comment.user.login)))
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
## Summary

- Extends the `pull_request_review_comment` trigger condition in `claude-code-reusable.yml` to include `coderabbitai[bot]` and `Copilot` alongside the existing `OWNER/MEMBER/COLLABORATOR` check
- Previously, bot review comments were silently skipped — the workflow event fired but the job `if:` evaluated false for `author_association: NONE` (CodeRabbit) and `author_association: CONTRIBUTOR` (Copilot)
- Bot logins confirmed from [PR #167](https://github.com/petry-projects/.github/pull/167) API response

## Why

CodeRabbit and Copilot post actionable inline findings on PRs. Without this change, Claude never sees them and they accumulate unaddressed (as seen on PR #167).

Loop risk is low: both bots re-review only on pushes, not on comment replies, so Claude responding to a bot comment won't re-trigger those bots.

## Test plan

- [ ] CI passes (yamllint, dependency audit, SonarCloud)
- [ ] After merge, verify Claude responds when CodeRabbit or Copilot post an inline review comment on a new PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)