### PR TITLE
feat: trigger review agent when donpetry-bot is assigned as reviewer

### DIFF
--- a/.github/workflows/pr-review-mention.yml
+++ b/.github/workflows/pr-review-mention.yml
@@ -2,7 +2,8 @@
 #   .github/workflows/pr-review-mention.yml
 #
 # Purpose: Trigger the pr-review-agent whenever @petry-review-bot is mentioned
-#          in a PR comment or review comment within the petry-projects org.
+#          in a PR comment or review comment, OR when donpetry-bot is assigned
+#          as a reviewer on a PR within the petry-projects org.
 #
 # Prerequisites:
 #   Uses GH_PAT_WORKFLOWS (org secret, classic PAT with repo scope) — already
@@ -15,6 +16,8 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
+  pull_request:
+    types: [review_requested]
 
 permissions:
   pull-requests: write
@@ -22,31 +25,48 @@ permissions:
 jobs:
   handle-mention:
     runs-on: ubuntu-latest
-    # Only fire when @petry-review-bot appears in the comment body.
-    # For issue_comment events, also require that the comment is on a PR (not a plain issue).
+    # Fire when:
+    #   (a) @petry-review-bot is mentioned in a PR comment / review comment, OR
+    #   (b) donpetry-bot is added as a reviewer on a pull request.
     if: |
-      contains(github.event.comment.body, '@petry-review-bot') &&
-      (github.event_name == 'pull_request_review_comment' ||
-       github.event.issue.pull_request != null)
+      (github.event_name == 'pull_request' &&
+       github.event.requested_reviewer.login == 'donpetry-bot') ||
+      (contains(github.event.comment.body, '@petry-review-bot') &&
+       (github.event_name == 'pull_request_review_comment' ||
+        github.event.issue.pull_request != null))
 
     steps:
       - name: Check commenter trust level
         id: trust
         env:
           GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
-          AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
-          COMMENTER: ${{ github.event.comment.user.login }}
+          # For review_requested, sender is the person who assigned the reviewer.
+          # For comment events, it's the comment author.
+          ACTOR: ${{ github.event_name == 'pull_request' && github.event.sender.login || github.event.comment.user.login }}
+          AUTHOR_ASSOCIATION: ${{ github.event_name == 'pull_request' && github.event.sender.author_association || github.event.comment.author_association }}
         run: |
           # Only OWNER, MEMBER, and COLLABORATOR can trigger reviews.
           # This prevents external contributors or bots from burning review quota.
-          case "$AUTHOR_ASSOCIATION" in
+          #
+          # For review_requested events the sender association field is not
+          # populated in the payload, so fall back to querying the API.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            ASSOC=$(gh api /repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}/permission \
+              --jq '.user.permissions | if .admin then "OWNER" elif .push then "MEMBER" else "NONE" end' 2>/dev/null || echo "NONE")
+            ACTOR="${{ github.event.sender.login }}"
+          else
+            ASSOC="${{ github.event.comment.author_association }}"
+            ACTOR="${{ github.event.comment.user.login }}"
+          fi
+
+          case "$ASSOC" in
             OWNER|MEMBER|COLLABORATOR)
               echo "trusted=true" >> "$GITHUB_OUTPUT"
-              echo "Commenter @$COMMENTER has association $AUTHOR_ASSOCIATION — trusted"
+              echo "Actor @$ACTOR has association $ASSOC — trusted"
               ;;
             *)
               echo "trusted=false" >> "$GITHUB_OUTPUT"
-              echo "Commenter @$COMMENTER has association $AUTHOR_ASSOCIATION — not trusted, skipping"
+              echo "Actor @$ACTOR has association $ASSOC — not trusted, skipping"
               ;;
           esac
 
@@ -56,7 +76,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            PR_URL="${{ github.event.pull_request.html_url }}"
+          elif [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
             PR_URL="${{ github.event.pull_request.html_url }}"
           else
             # issue_comment: resolve the PR URL from the issue's pull_request link
@@ -70,13 +92,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
           PR_URL: ${{ steps.pr.outputs.pr_url }}
-          COMMENTER: ${{ github.event.comment.user.login }}
         run: |
-          gh pr comment "$PR_URL" --body "$(cat <<'EOF'
-          <!-- pr-review-agent mention-ack -->
-          @'"$COMMENTER"' I'm on it — starting a fresh review now. Results will appear in a few minutes.
-          EOF
-          )"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            ACTOR="${{ github.event.sender.login }}"
+            MSG="@$ACTOR assigned me as reviewer — starting a fresh review now. Results will appear in a few minutes."
+          else
+            ACTOR="${{ github.event.comment.user.login }}"
+            MSG="@$ACTOR I'm on it — starting a fresh review now. Results will appear in a few minutes."
+          fi
+          gh pr comment "$PR_URL" --body "<!-- pr-review-agent mention-ack -->
+          $MSG"
 
       - name: Trigger review agent
         if: steps.trust.outputs.trusted == 'true'

--- a/.github/workflows/pr-review-mention.yml
+++ b/.github/workflows/pr-review-mention.yml
@@ -26,12 +26,19 @@ jobs:
   handle-mention:
     runs-on: ubuntu-latest
     # Fire when:
-    #   (a) @petry-review-bot is mentioned in a PR comment / review comment, OR
-    #   (b) donpetry-bot is added as a reviewer on a pull request.
+    #   (a) donpetry-bot is added as a reviewer on a same-repo PR (fork PRs
+    #       don't receive org secrets so we exclude them), OR
+    #   (b) @petry-review-bot is mentioned in a PR comment / review comment.
+    #
+    # Guard each branch against missing fields: requested_reviewer is null for
+    # team review requests; comment fields don't exist on pull_request events.
     if: |
       (github.event_name == 'pull_request' &&
-       github.event.requested_reviewer.login == 'donpetry-bot') ||
-      (contains(github.event.comment.body, '@petry-review-bot') &&
+       github.event.requested_reviewer != null &&
+       github.event.requested_reviewer.login == 'donpetry-bot' &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name != 'pull_request' &&
+       contains(github.event.comment.body, '@petry-review-bot') &&
        (github.event_name == 'pull_request_review_comment' ||
         github.event.issue.pull_request != null))
 
@@ -40,35 +47,42 @@ jobs:
         id: trust
         env:
           GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
-          # For review_requested, sender is the person who assigned the reviewer.
-          # For comment events, it's the comment author.
-          ACTOR: ${{ github.event_name == 'pull_request' && github.event.sender.login || github.event.comment.user.login }}
-          AUTHOR_ASSOCIATION: ${{ github.event_name == 'pull_request' && github.event.sender.author_association || github.event.comment.author_association }}
         run: |
           # Only OWNER, MEMBER, and COLLABORATOR can trigger reviews.
           # This prevents external contributors or bots from burning review quota.
           #
-          # For review_requested events the sender association field is not
-          # populated in the payload, so fall back to querying the API.
+          # For review_requested events author_association is absent from the
+          # sender payload, so query the collaborator permission API instead.
+          # The endpoint returns a top-level .permission string:
+          #   "admin" | "write" | "read" | "none"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            ASSOC=$(gh api /repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}/permission \
-              --jq '.user.permissions | if .admin then "OWNER" elif .push then "MEMBER" else "NONE" end' 2>/dev/null || echo "NONE")
             ACTOR="${{ github.event.sender.login }}"
+            PERM=$(gh api /repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}/permission \
+              --jq '.permission' 2>/dev/null || echo "none")
+            case "$PERM" in
+              admin|write)
+                echo "trusted=true" >> "$GITHUB_OUTPUT"
+                echo "Actor @$ACTOR has permission $PERM — trusted"
+                ;;
+              *)
+                echo "trusted=false" >> "$GITHUB_OUTPUT"
+                echo "Actor @$ACTOR has permission $PERM — not trusted, skipping"
+                ;;
+            esac
           else
-            ASSOC="${{ github.event.comment.author_association }}"
             ACTOR="${{ github.event.comment.user.login }}"
+            ASSOC="${{ github.event.comment.author_association }}"
+            case "$ASSOC" in
+              OWNER|MEMBER|COLLABORATOR)
+                echo "trusted=true" >> "$GITHUB_OUTPUT"
+                echo "Actor @$ACTOR has association $ASSOC — trusted"
+                ;;
+              *)
+                echo "trusted=false" >> "$GITHUB_OUTPUT"
+                echo "Actor @$ACTOR has association $ASSOC — not trusted, skipping"
+                ;;
+            esac
           fi
-
-          case "$ASSOC" in
-            OWNER|MEMBER|COLLABORATOR)
-              echo "trusted=true" >> "$GITHUB_OUTPUT"
-              echo "Actor @$ACTOR has association $ASSOC — trusted"
-              ;;
-            *)
-              echo "trusted=false" >> "$GITHUB_OUTPUT"
-              echo "Actor @$ACTOR has association $ASSOC — not trusted, skipping"
-              ;;
-          esac
 
       - name: Resolve PR URL
         id: pr
@@ -95,13 +109,16 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             ACTOR="${{ github.event.sender.login }}"
-            MSG="@$ACTOR assigned me as reviewer — starting a fresh review now. Results will appear in a few minutes."
+            MSG="@${ACTOR} assigned me as reviewer — starting a fresh review now. Results will appear in a few minutes."
           else
             ACTOR="${{ github.event.comment.user.login }}"
-            MSG="@$ACTOR I'm on it — starting a fresh review now. Results will appear in a few minutes."
+            MSG="@${ACTOR} I'm on it — starting a fresh review now. Results will appear in a few minutes."
           fi
-          gh pr comment "$PR_URL" --body "<!-- pr-review-agent mention-ack -->
-          $MSG"
+          gh pr comment "$PR_URL" --body "$(cat <<EOF
+<!-- pr-review-agent mention-ack -->
+${MSG}
+EOF
+)"
 
       - name: Trigger review agent
         if: steps.trust.outputs.trusted == 'true'

--- a/.github/workflows/pr-review-mention.yml
+++ b/.github/workflows/pr-review-mention.yml
@@ -114,11 +114,7 @@ jobs:
             ACTOR="${{ github.event.comment.user.login }}"
             MSG="@${ACTOR} I'm on it — starting a fresh review now. Results will appear in a few minutes."
           fi
-          gh pr comment "$PR_URL" --body "$(cat <<EOF
-<!-- pr-review-agent mention-ack -->
-${MSG}
-EOF
-)"
+          gh pr comment "$PR_URL" --body "$(printf '<!-- pr-review-agent mention-ack -->\n%s' "${MSG}")"
 
       - name: Trigger review agent
         if: steps.trust.outputs.trusted == 'true'


### PR DESCRIPTION
## Summary

- Adds `pull_request: types: [review_requested]` trigger so the review agent fires automatically whenever `donpetry-bot` is added as a PR reviewer
- Updates the job `if` guard to handle both the existing mention path and the new reviewer-assignment path
- Trust check now queries the collaborator permission API for `review_requested` events (the payload doesn't include `author_association` for the sender)
- Acknowledgement comment is tailored per trigger — mentions the assigner by name for reviewer-assignment events
- PR URL resolution handles all three event types cleanly

## Behavior

| Trigger | Condition checked | Ack message |
|---|---|---|
| `issue_comment` / `pull_request_review_comment` | `@petry-review-bot` in body | "@actor I'm on it..." |
| `pull_request: review_requested` | `requested_reviewer.login == 'donpetry-bot'` | "@actor assigned me as reviewer..." |

## Test plan

- [ ] Assign `donpetry-bot` as reviewer on a test PR → workflow fires, ack comment appears, dispatch sent
- [ ] Mention `@petry-review-bot` in a comment → existing path still works
- [ ] Non-member assigns `donpetry-bot` → trust check blocks the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)