### PR TITLE
fix(dependabot): fix automerge stall — bypass fallback on update-branch failure + schedule trigger

### DIFF
--- a/.github/workflows/dependabot-rebase-reusable.yml
+++ b/.github/workflows/dependabot-rebase-reusable.yml
@@ -113,10 +113,14 @@ jobs:
 
               # update-branch failed (e.g. App lacks 'workflows' permission when
               # main contains workflow file changes, or there is a merge conflict).
-              # Fall through to the merge attempt — the bypass actor (bypass_mode:always)
-              # can merge directly even when the branch is behind, provided the PR's
-              # own CI has already passed and the strict_required_status_checks_policy
-              # is false (which it is for this org).
+              # Fall through to the direct merge attempt. The bypass actor
+              # (bypass_mode: always) can call the merge API directly when the
+              # branch is behind, provided:
+              #   - The PR's own CI has already passed, AND
+              #   - strict_required_status_checks_policy is false for this repo.
+              # If strict up-to-date checking IS enforced (strict: true), this
+              # fallback will also fail — granting the App the 'workflows'
+              # permission so update-branch succeeds is the correct fix.
               echo "  Warning: could not update branch for PR #$PR_NUMBER — will attempt direct merge"
             else
               echo "PR #$PR_NUMBER ($HEAD_REF) is up to date — checking if merge-ready"

--- a/.github/workflows/dependabot-rebase-reusable.yml
+++ b/.github/workflows/dependabot-rebase-reusable.yml
@@ -108,13 +108,19 @@ jobs:
               if GH_TOKEN="$APP_TOKEN" gh api "repos/$REPO/pulls/$PR_NUMBER/update-branch" \
                 -X PUT 2>/dev/null; then
                 echo "  Updated branch for PR #$PR_NUMBER"
-              else
-                echo "  Warning: could not update branch for PR #$PR_NUMBER (may have conflicts)"
+                continue  # wait for CI on updated branch before merging
               fi
-              continue
-            fi
 
-            echo "PR #$PR_NUMBER ($HEAD_REF) is up to date — checking if merge-ready"
+              # update-branch failed (e.g. App lacks 'workflows' permission when
+              # main contains workflow file changes, or there is a merge conflict).
+              # Fall through to the merge attempt — the bypass actor (bypass_mode:always)
+              # can merge directly even when the branch is behind, provided the PR's
+              # own CI has already passed and the strict_required_status_checks_policy
+              # is false (which it is for this org).
+              echo "  Warning: could not update branch for PR #$PR_NUMBER — will attempt direct merge"
+            else
+              echo "PR #$PR_NUMBER ($HEAD_REF) is up to date — checking if merge-ready"
+            fi
 
             # Skip if we already merged one (strict mode means others are now behind)
             if [[ "$MERGED" == "true" ]]; then

--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -30,6 +30,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '0 */4 * * *' # every 4 hours — safety net when no pushes to main trigger the chain
   workflow_dispatch: # allow manual trigger to flush Dependabot PR queue
 
 concurrency:

--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -10,11 +10,13 @@
 #     a LOCAL ref (`./`) instead of a pinned SHA — this repo IS the source of
 #     truth, so a local ref is always current. Other repos use pinned SHAs
 #     (see standards/workflows/dependabot-rebase.yml).
-#   • You MUST NOT change: trigger event, the concurrency group name,
-#     the explicit secrets block, or the job-level `permissions:` block —
-#     reusable workflows can be granted no more permissions than the calling
-#     job has, so removing the stanza breaks
-#     the reusable's gh API calls.
+#   • You MUST NOT change: the concurrency group name, the explicit secrets
+#     block, or the job-level `permissions:` block — reusable workflows can
+#     be granted no more permissions than the calling job has, so removing
+#     the stanza breaks the reusable's gh API calls. Do not remove any
+#     trigger (`push` keeps the self-sustaining chain; `schedule` is the
+#     safety net when no PR merges have occurred recently; `workflow_dispatch`
+#     allows manual queue flushes).
 #   • If you need different behaviour, open a PR against the reusable in the
 #     central repo.
 # ─────────────────────────────────────────────────────────────────────────────

--- a/standards/dependabot-policy.md
+++ b/standards/dependabot-policy.md
@@ -186,6 +186,25 @@ This workflow fires on every push to `main` (and can be triggered manually via
 Using the app token for merges ensures each merge triggers a new push to `main`,
 creating a self-sustaining chain that serializes Dependabot PR merges.
 
+**GitHub App permission requirement:** The `dependabot-automerge-petry` GitHub App
+must have the `workflows` permission granted. Without it, the `update-branch` API
+call fails with *"refusing to allow a GitHub App to create or update workflow"*
+whenever `main` contains workflow file changes (`.github/workflows/*.yml`) that
+would be merged into the PR branch. Grant the permission in the GitHub App settings:
+Settings → GitHub Apps → dependabot-automerge-petry → Permissions → Workflows → Read & Write.
+
+**Chain-stall safety net:** The rebase workflow also runs on a 4-hour schedule
+(`cron: '0 */4 * * *'`) in addition to `push: main` and `workflow_dispatch`.
+This prevents the serialization chain from stalling in repos where no PR merges
+to `main` occur for extended periods, without relying solely on external pushes.
+
+**Fallback merge when `update-branch` fails:** If `update-branch` fails (e.g., the
+GitHub App lacks the `workflows` permission or there are merge conflicts), the
+workflow falls through to the direct merge attempt instead of skipping the PR
+permanently. The bypass actor (`bypass_mode: always`) can call `gh api .../merge`
+directly even when the branch is behind `main`, as long as the PR's own CI has
+passed and `strict_required_status_checks_policy` is `false`.
+
 **Why `update-branch` with APP_TOKEN (not `GITHUB_TOKEN` or `@dependabot rebase`):**
 
 - **`GITHUB_TOKEN`** is subject to GitHub's recursive-trigger guard — events it
@@ -297,7 +316,14 @@ The workflow fails if any known vulnerability is found, blocking the PR from mer
    > [CODEOWNERS Standard](codeowners-standard.md). The earlier approach of
    > using `gh api .../merge` as a bypass was fragile and has been superseded.
 4. Add `workflows/dependency-audit.yml` to `.github/workflows/`.
-5. **GitHub App secrets** — `APP_ID` and `APP_PRIVATE_KEY` are managed at the
+5. **GitHub App permissions** — the `dependabot-automerge-petry` GitHub App requires
+   the `workflows` permission in addition to `contents: write` and `pull_requests: write`.
+   Without it, the rebase workflow cannot call `update-branch` when `main` contains
+   workflow file changes. Grant: GitHub App settings → Permissions → Repository →
+   Workflows → Read & Write, then accept the updated permission in each repo's
+   installed-app settings.
+
+6. **GitHub App secrets** — `APP_ID` and `APP_PRIVATE_KEY` are managed at the
    **organization level** (`gh secret set <name> --org petry-projects --visibility all`),
    not per-repo. The caller stubs pass these explicitly via:
 
@@ -321,9 +347,9 @@ The workflow fails if any known vulnerability is found, blocking the PR from mer
    both secrets are confirmed should you run `gh secret delete APP_ID --repo <repo>`
    to clean up per-repo copies — otherwise `gh pr review` calls fail with
    `Secret APP_ID is required`.
-6. Create the `security` and `dependencies` labels in the repository if they
+7. Create the `security` and `dependencies` labels in the repository if they
    don't already exist.
-7. Add `dependency-audit / Detect ecosystems` as a required status check in
+8. Add `dependency-audit / Detect ecosystems` as a required status check in
    branch protection rules. Do **not** require the per-ecosystem audit jobs
    (`npm audit`, `govulncheck`, `cargo audit`, `pip-audit`, `pnpm audit`) —
    they're conditional on lockfile presence and report `SKIPPED` when absent,

--- a/standards/dependabot-policy.md
+++ b/standards/dependabot-policy.md
@@ -202,8 +202,12 @@ to `main` occur for extended periods, without relying solely on external pushes.
 GitHub App lacks the `workflows` permission or there are merge conflicts), the
 workflow falls through to the direct merge attempt instead of skipping the PR
 permanently. The bypass actor (`bypass_mode: always`) can call `gh api .../merge`
-directly even when the branch is behind `main`, as long as the PR's own CI has
-passed and `strict_required_status_checks_policy` is `false`.
+directly when the branch is behind `main`, provided the PR's own CI has passed
+and `strict_required_status_checks_policy` is `false` for the repo. If a repo
+enforces `strict_required_status_checks_policy: true` (branches must be up to
+date before merge), the fallback direct merge will also fail — granting the
+`dependabot-automerge-petry` App the `workflows` permission so that
+`update-branch` succeeds is the correct resolution in that case.
 
 **Why `update-branch` with APP_TOKEN (not `GITHUB_TOKEN` or `@dependabot rebase`):**
 

--- a/standards/github-settings.md
+++ b/standards/github-settings.md
@@ -163,6 +163,8 @@ The `pr-quality` ruleset MUST include the following bypass actors:
 | `dependabot-automerge-petry` | GitHub App | `always` | Approves and merges Dependabot PRs; must bypass review gate |
 | `OrganizationAdmin` | Role | `always` | Emergency admin override |
 
+> **Critical — ALL rulesets that include a `pull_request` or `required_status_checks` rule MUST include the `dependabot-automerge-petry` bypass actor.** GitHub evaluates bypass eligibility per-ruleset: a bypass actor in `pr-quality` does NOT carry over to `protect-branches` or any other ruleset on the same branch. If a repo has multiple rulesets targeting `main` (e.g., `pr-quality` + `protect-branches` + `main`), ALL of them must include `dependabot-automerge-petry` with `bypass_mode: always` — otherwise the merge API calls are rejected even though the actor has bypass in `pr-quality`.
+
 > **Critical:** `bypass_mode: pull_request` does **not** work for Dependabot PRs.
 > That mode only bypasses review requirements when the bypass actor *opens* the PR
 > via the PR flow. Since `dependabot[bot]` opens Dependabot PRs, the

--- a/standards/github-settings.md
+++ b/standards/github-settings.md
@@ -156,10 +156,10 @@ gh api repos/petry-projects/<repo>/rulesets/<ruleset-id> \
 **Compliance check:** verify all rulesets on all repos have the bypass actor:
 
 ```bash
-for repo in $(gh repo list petry-projects --json name --jq '.[].name' --limit 50); do
+for repo in $(gh repo list petry-projects --json name --jq '.[].name' --limit 1000); do
   for rs_id in $(gh api "repos/petry-projects/$repo/rulesets" --jq '.[].id' 2>/dev/null); do
     rs=$(gh api "repos/petry-projects/$repo/rulesets/$rs_id" 2>/dev/null)
-    missing=$(echo "$rs" | jq '[.bypass_actors[]? | select(.actor_id == 3167543)] | length == 0 and ([.rules[]? | select(.type == "pull_request" or .type == "required_status_checks")] | length > 0)')
+    missing=$(echo "$rs" | jq '[.bypass_actors[]? | select(.actor_id == 3167543)] | length == 0')
     [[ "$missing" == "true" ]] && echo "MISSING: $repo / $(echo "$rs" | jq -r '.name')"
   done
 done

--- a/standards/github-settings.md
+++ b/standards/github-settings.md
@@ -121,6 +121,50 @@ Rulesets are the primary enforcement mechanism for branch policies. All
 repositories MUST use rulesets on the default branch. Classic branch protection
 rules are deprecated — migrate existing classic rules to rulesets.
 
+### Bypass Actors — Required on Every Ruleset Targeting `main`
+
+**The `dependabot-automerge-petry` GitHub App MUST be a bypass actor on every
+ruleset that targets the default branch**, not only on `pr-quality`. GitHub
+evaluates bypass eligibility independently per ruleset — having bypass in
+`pr-quality` does NOT grant bypass in `protect-branches`, `main`, or any other
+ruleset applied to the same branch. Every such ruleset must include:
+
+| Actor | Type | `bypass_mode` | Reason |
+|-------|------|--------------|--------|
+| `dependabot-automerge-petry` | GitHub App | `always` | Merges Dependabot PRs via API; rejected without bypass in every active ruleset |
+| `OrganizationAdmin` | Role | `always` | Emergency admin override |
+
+**Why `bypass_mode: always`:** `pull_request` bypass mode only works when the
+bypass actor *opens* the PR. Dependabot opens its own PRs, so the
+`dependabot-automerge-petry` app cannot use that mode — its merge API calls are
+rejected. `always` mode is safe here because the rebase workflow explicitly
+verifies CI pass and `MERGEABLE` state before calling the merge API.
+
+**API snippet to add the bypass actor to an existing ruleset:**
+
+```bash
+# Get current ruleset (capture bypass_actors and rules arrays)
+gh api repos/petry-projects/<repo>/rulesets/<ruleset-id>
+
+# PUT the full ruleset back, adding actor_id 3167543 to bypass_actors
+gh api repos/petry-projects/<repo>/rulesets/<ruleset-id> \
+  -X PUT --input ruleset.json
+# where ruleset.json adds {"actor_id": 3167543, "actor_type": "Integration", "bypass_mode": "always"}
+# to the existing bypass_actors array alongside all existing rules and conditions.
+```
+
+**Compliance check:** verify all rulesets on all repos have the bypass actor:
+
+```bash
+for repo in $(gh repo list petry-projects --json name --jq '.[].name' --limit 50); do
+  for rs_id in $(gh api "repos/petry-projects/$repo/rulesets" --jq '.[].id' 2>/dev/null); do
+    rs=$(gh api "repos/petry-projects/$repo/rulesets/$rs_id" 2>/dev/null)
+    missing=$(echo "$rs" | jq '[.bypass_actors[]? | select(.actor_id == 3167543)] | length == 0 and ([.rules[]? | select(.type == "pull_request" or .type == "required_status_checks")] | length > 0)')
+    [[ "$missing" == "true" ]] && echo "MISSING: $repo / $(echo "$rs" | jq -r '.name')"
+  done
+done
+```
+
 ### `pr-quality` — Standard Ruleset (All Repositories)
 
 | Setting | Value |
@@ -156,23 +200,8 @@ for more details.
 
 #### Bypass Actors
 
-The `pr-quality` ruleset MUST include the following bypass actors:
-
-| Actor | Type | `bypass_mode` | Reason |
-|-------|------|--------------|--------|
-| `dependabot-automerge-petry` | GitHub App | `always` | Approves and merges Dependabot PRs; must bypass review gate |
-| `OrganizationAdmin` | Role | `always` | Emergency admin override |
-
-> **Critical — ALL rulesets that include a `pull_request` or `required_status_checks` rule MUST include the `dependabot-automerge-petry` bypass actor.** GitHub evaluates bypass eligibility per-ruleset: a bypass actor in `pr-quality` does NOT carry over to `protect-branches` or any other ruleset on the same branch. If a repo has multiple rulesets targeting `main` (e.g., `pr-quality` + `protect-branches` + `main`), ALL of them must include `dependabot-automerge-petry` with `bypass_mode: always` — otherwise the merge API calls are rejected even though the actor has bypass in `pr-quality`.
-
-> **Critical:** `bypass_mode: pull_request` does **not** work for Dependabot PRs.
-> That mode only bypasses review requirements when the bypass actor *opens* the PR
-> via the PR flow. Since `dependabot[bot]` opens Dependabot PRs, the
-> `dependabot-automerge-petry` app cannot use `pull_request` bypass for them —
-> its merge API calls are rejected with `Required status check` errors.
-> Use `bypass_mode: always` so the app can call `gh api .../merge` directly
-> after manually verifying CI. The rebase workflow verifies CI before merging,
-> so `always` does not bypass safety checks.
+See [Bypass Actors — Required on Every Ruleset Targeting `main`](#bypass-actors--required-on-every-ruleset-targeting-main) above.
+The same `dependabot-automerge-petry` + `OrganizationAdmin` bypass actors MUST appear in `pr-quality` and in every other ruleset that targets `main`.
 
 #### CODEOWNERS Approval Timing
 

--- a/standards/workflows/dependabot-rebase.yml
+++ b/standards/workflows/dependabot-rebase.yml
@@ -11,8 +11,9 @@
 #   • You MUST NOT change: the concurrency group name, the explicit secrets
 #     block, or the job-level `permissions:` block — reusable workflows can be
 #     granted no more permissions than the calling job has, so removing the
-#     stanza breaks the reusable's gh API calls. Do not remove either trigger
-#     (`push` keeps the self-sustaining chain; `workflow_dispatch` allows
+#     stanza breaks the reusable's gh API calls. Do not remove any trigger
+#     (`push` keeps the self-sustaining chain; `schedule` is the safety net
+#     when no PR merges have occurred recently; `workflow_dispatch` allows
 #     manual queue flushes).
 #   • If you need different behaviour, open a PR against the reusable in the
 #     central repo.
@@ -29,6 +30,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '0 */4 * * *' # every 4 hours — safety net when no pushes to main trigger the chain
   workflow_dispatch: # allow manual trigger to flush Dependabot PR queue
 
 concurrency:


### PR DESCRIPTION
## Summary

Two bugs were preventing Dependabot PRs from automerging:

### Bug 1: `update-branch` failure permanently blocked the merge step

The `dependabot-automerge-petry` GitHub App lacks the `workflows` permission. When `main` contains changes to `.github/workflows/*.yml` files, the `update-branch` API call fails with 403. The old code always called `continue` after the update-branch attempt — whether it succeeded or failed — skipping the merge step permanently.

**Fix:** Move `continue` inside the success branch. When update-branch fails, fall through to the direct merge attempt. The bypass actor (`bypass_mode: always`) can call the merge API directly even when the branch is behind, as long as CI passed on the PR head and `strict_required_status_checks_policy` is `false`.

**Affected right now:** PR #178 (`actions/checkout-6.0.2`) stuck for 4+ days — 5 commits behind because `e5ef191` changed a workflow file, causing `update-branch` to fail on every rebase run.

### Bug 2: Serialization chain stalled without pushes to main

The rebase workflow only fired on `push: main`. In repos without recent merges (TalkTerm: 3 days with no push to main), updated PR branches would sit with CI passing but no trigger to run the merge step.

**Fix:** Added `schedule: cron: '0 */4 * * *'` as a safety net. Every 4 hours the workflow checks for merge-ready PRs and drains the queue.

## Action required from repo owner

**Grant `workflows` permission to the `dependabot-automerge-petry` GitHub App:**

> Settings → GitHub Apps → dependabot-automerge-petry → Permissions → Repository → Workflows → Read & Write

Then accept the updated permission in each installed repo. Without this, `update-branch` will continue to fall back to direct merge (which works via bypass), but keeping branches up-to-date before merging is cleaner.

## Follow-up

- `v1` tag updated to `02ce89b` — TalkTerm picks up the fix automatically
- PRs to update other repos (`broodly`, `markets`, `google-app-scripts`, `ContentTwin`) pinning the old SHA will follow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Dependabot rebase flow with better handling of failed branch updates and a fallback direct-merge attempt
  * Added a 4-hour scheduled safety check to surface stalled dependency updates

* **Documentation**
  * Expanded guidance on required permissions and secrets for dependabot automation and updated ruleset bypass actor requirements
<!-- end of auto-generated comment: release notes by coderabbit.ai -->