### PR TITLE
fix(ci): enable allow_auto_merge and convert dependabot-automerge to thin-caller stub

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,22 +1,26 @@
-# Dependabot auto-merge workflow.
-# Auto-approves and merges eligible patch/minor Dependabot PRs after CI passes.
-# Standard: https://github.com/petry-projects/.github/blob/main/standards/dependabot-policy.md#auto-merge-workflow
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/dependabot-automerge.yml
+# Standard:        petry-projects/.github/standards/dependabot-policy.md
+# Reusable:        petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml
 #
-# Requires repository secrets:
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. All eligibility logic and the GitHub
+#     App token dance live in the reusable workflow above.
+#   • You MAY change: nothing in this file in normal use. Adopt verbatim.
+#   • You MUST NOT change: trigger event (must be `pull_request_target`),
+#     the `uses:` line, `secrets: inherit`, or the job-level `permissions:`
+#     block — reusable workflows can be granted no more permissions than the
+#     calling job has, so removing the stanza breaks the reusable's gh API
+#     calls.
+#   • If you need different behaviour, open a PR against the reusable in the
+#     central repo.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Dependabot auto-merge — thin caller for the org-level reusable.
+# To adopt: copy this file to .github/workflows/dependabot-automerge.yml in your repo.
+# Required org/repo secrets (inherited):
 #   APP_ID         — GitHub App ID with contents:write and pull-requests:write
 #   APP_PRIVATE_KEY — GitHub App private key
-#
-# Auto-approves and enables auto-merge for Dependabot PRs that are:
-#   - GitHub Actions updates (any version bump, including major)
-#   - Security updates for any ecosystem (patch or minor)
-#   - Indirect (transitive) dependency updates
-# Major version updates for non-Actions ecosystems are left for human review.
-# Uses --auto so the merge waits for all required CI checks to pass.
-#
-# Safety model: application ecosystems use open-pull-requests-limit: 0 in
-# dependabot.yml, so the only app-ecosystem PRs Dependabot can create are
-# security updates. This workflow adds defense-in-depth by also checking
-# the package ecosystem.
 name: Dependabot auto-merge
 
 on:
@@ -27,55 +31,9 @@ on:
 permissions: {}
 
 jobs:
-  dependabot:
-    runs-on: ubuntu-latest
+  dependabot-automerge:
     permissions:
       contents: read
       pull-requests: read
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
-    steps:
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v2
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: Determine if auto-merge eligible
-        id: eligible
-        run: |
-          UPDATE_TYPE="${{ steps.metadata.outputs.update-type }}"
-          DEP_TYPE="${{ steps.metadata.outputs.dependency-type }}"
-          ECOSYSTEM="${{ steps.metadata.outputs.package-ecosystem }}"
-
-          # GitHub Actions are SHA-pinned and don't affect app runtime,
-          # so all version bumps (including major) are eligible.
-          # App ecosystem PRs can only exist as security updates (limit: 0)
-          # and must be patch/minor/indirect — major requires human review.
-          if [[ "$ECOSYSTEM" != "github_actions" && \
-                "$UPDATE_TYPE" != "version-update:semver-patch" && \
-                "$UPDATE_TYPE" != "version-update:semver-minor" && \
-                "$DEP_TYPE" != "indirect" ]]; then
-            echo "eligible=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping: major update for $ECOSYSTEM requires human review"
-            exit 0
-          fi
-
-          echo "eligible=true" >> "$GITHUB_OUTPUT"
-          echo "Auto-merge eligible: ecosystem=$ECOSYSTEM update=$UPDATE_TYPE"
-
-      - name: Generate app token
-        if: steps.eligible.outputs.eligible == 'true'
-        id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
-      - name: Approve and enable auto-merge
-        if: steps.eligible.outputs.eligible == 'true'
-        run: |
-          gh pr review --approve "$PR_URL"
-          gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@v1
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Enabled the `allow_auto_merge` repository setting via GitHub API (`null` → `true`), resolving the weekly compliance audit finding
- Converted `.github/workflows/dependabot-automerge.yml` from an inline workflow to the standard thin-caller stub that delegates to `dependabot-automerge-reusable.yml@v1`

## Why both changes

The compliance audit (`scripts/compliance-audit.sh`) checks `allow_auto_merge` via the GitHub API and was seeing `null`. The setting has now been applied directly.

The inline `dependabot-automerge.yml` was pre-centralization code that:
- Was missing `skip-commit-verification: true` (present in the reusable since a later update)
- Was missing the "Check app secrets" step (present in the reusable)
- Duplicated eligibility logic already maintained in `dependabot-automerge-reusable.yml`

The thin-caller stub is the org standard per `standards/workflows/dependabot-automerge.yml` and delegates all logic to the reusable.

## Test plan

- [x] `allow_auto_merge` verified `true` via `gh api repos/petry-projects/.github --jq '.allow_auto_merge'`
- [x] Stub calls `dependabot-automerge-reusable.yml@v1` which has full eligibility logic, `skip-commit-verification: true`, and app secrets check
- [ ] Next weekly compliance audit should close issue #107 automatically (no longer finds `null`)
- [ ] Next Dependabot PR to this repo will exercise the reusable path

Closes #107

Generated with [Claude Code](https://claude.ai/code)