### PR TITLE
perf(org-status): reduce report size to fit GitHub issue body limit

### DIFF
--- a/.github/workflows/daily-org-status.yml
+++ b/.github/workflows/daily-org-status.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Truncate report if near GitHub issue body limit
         run: |
-          MAX_BYTES=60000
+          MAX_BYTES=64000
           if [ "$(wc -c < /tmp/report.md)" -gt "$MAX_BYTES" ]; then
             truncated=$(head -c "$MAX_BYTES" /tmp/report.md)
             printf '%s\n\n_Report truncated — exceeded GitHub issue body limit._\n' "$truncated" > /tmp/report.md

--- a/scripts/org_status.sh
+++ b/scripts/org_status.sh
@@ -328,10 +328,9 @@ Per-repo breakdown table (omit repos with 0 total PRs). You MUST include the hea
 
 ### \`## Open PRs — Needs Human Review\`
 Full table for PRs with needsHumanReview == true:
-| Repo | PR # | Opened | Title | CI | Approvals |
-|---|---|---|---|---|---|
-- PR # as markdown link using url field: [#N](url)
-- Title as markdown link using url field: [title](url)
+| Repo | PR | Opened | CI | Approvals |
+|---|---|---|---|---|
+- PR cell: single markdown link combining number and title, e.g. \`[#42 — Fix the thing](url)\`
 - CI: PASS (SUCCESS) / FAIL (FAILURE or ERROR) / PENDING / N/A (null)
 If none: _none_
 
@@ -343,14 +342,17 @@ Counts only per repo (dep_bumps > 0):
 If none: _none_
 
 ### \`## Open Issues (N total)\`
-For each repo with issues, show all provided rows (up to $ISSUE_LIMIT):
-| Repo | # | Opened | Title | Labels | Linked PR |
-|---|---|---|---|---|---|
-- # as markdown link using url field: [#N](url)
-- Title as markdown link using url field: [title](url)
+Render as a per-repo subsection list (NOT a single flat table). For each repo with issues, in the order provided:
+
+\`### [owner/repo](https://github.com/owner/repo) (N issues)\`
+- If truncated:true, replace the suffix with " (showing $ISSUE_LIMIT of N issues)".
+
+Then a small table (Repo column omitted — it's in the heading):
+| Issue | Opened | Labels | Linked PR |
+|---|---|---|---|
+- Issue cell: single markdown link combining number and title, e.g. \`[#123 — Compliance: foo](url)\`
 - Opened = createdAt date only (YYYY-MM-DD)
 - Linked PR: look up "owner/repo#N" in the Issue→Linked PR Map; if found render as [#M](pr_url); if multiple, comma-separate; if none render —
-- If truncated:true, note "(showing $ISSUE_LIMIT of N)" next to the repo name
 
 ### \`## PR Merge Activity — Last 8 Days\`
 Per-repo-per-day table using the Merge Activity — Per-Repo Per-Day data (omit repos with 0 total):
@@ -365,10 +367,9 @@ Daily org-level summary table (include zero rows):
 Grand total and trend sentence. Trend: Increasing if avg(last 3 days) > avg(first 3 days), Decreasing if opposite, Flat otherwise.
 
 ### \`## Open Discussions\`
-| Repo | # | Opened | Title | Replies |
-|---|---|---|---|---|
-- # as markdown link using url field: [#N](url)
-- Title as markdown link using url field: [title](url)
+| Repo | Discussion | Opened | Replies |
+|---|---|---|---|
+- Discussion cell: single markdown link combining number and title, e.g. \`[#7 — Feature idea](url)\`
 If none: _none_
 
 ---


### PR DESCRIPTION
## Summary

The daily org status report has been hitting the 60000-byte truncate threshold and the `head -c` truncate step was dropping the **start** of the report (the `@org-leads` opener and the first three required sections — Why Unmerged, Needs Human Review, Automation). Today's #233 only kept the tail of Needs Human Review onwards.

Sized the visible portion of #233 (~60K bytes): **97.8%** of it was the Open Issues table, with 178 rows averaging 352 bytes — and **~14K bytes** of that was just repeating the `[owner/repo](url)` cell on every row. So the cuts target Open Issues hardest, and apply consistently to the other two tables that have the same redundancy.

## Changes (prompt-side only — no data-shape changes)

### 1. Group Open Issues by repo
Flat `| Repo | # | Opened | Title | Labels | Linked PR |` table → per-repo subsections:
```
### [petry-projects/.github](https://github.com/petry-projects/.github) (24 issues)
| Issue | Opened | Labels | Linked PR |
| ... |
```
Drops the Repo column (it's now in the heading) — saves ~78 bytes per row × 178 rows ≈ **13K**.

### 2. Merge `[#N](url) | [title](url)` into a single `[#N — title](url)` cell
Previously every Open Issue / Needs Human Review / Open Discussion row had two cells linking to the same URL. Combined into one cell across all three tables — saves another **~16K**.

### 3. Bump `MAX_BYTES` from 60000 → 64000
GitHub's issue body limit is 65536 chars; the previous 60000 left more slack than needed. With the rendered report ~25-30K smaller, this gives room without flirting with the cliff.

## Test plan

- [ ] Manually trigger `Daily Org Status` (`workflow_dispatch`) on this branch.
- [ ] Verify the resulting `Org Status — YYYY-MM-DD` issue:
  - Starts with `@org-leads` and contains all six sections (no missing front).
  - `## Open Issues` is rendered as `### owner/repo (N issues)` subsections, each with a 4-column inner table.
  - Issue / PR / Discussion cells render as `[#N — title](url)` (single link) rather than two adjacent links.
  - Total body is well under 65536 chars and the `_Report truncated_` footer is **not** present.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HhEmdYwezrDs5taPMyisEJ)_