### PR TITLE
fix(compliance-audit): replace echo|grep -q pipes with here-strings in detect_ecosystems

### DIFF
--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -127,10 +127,10 @@ detect_ecosystems() {
   local tree
   tree=$(gh_api "repos/$ORG/$repo/git/trees/HEAD?recursive=1" --jq '.tree[].path' 2>/dev/null || echo "")
 
-  if echo "$tree" | grep -qE '(^|/)package\.json$'; then
+  if grep -qE '(^|/)package\.json$' <<< "$tree"; then
     ECOSYSTEMS+=("npm")
   fi
-  if echo "$tree" | grep -qE '(^|/)pnpm-lock\.yaml$'; then
+  if grep -qE '(^|/)pnpm-lock\.yaml$' <<< "$tree"; then
     # Override npm with pnpm if lock file present, or add pnpm directly
     if [[ " ${ECOSYSTEMS[*]} " == *" npm "* ]]; then
       ECOSYSTEMS=("${ECOSYSTEMS[@]/npm/pnpm}")
@@ -138,25 +138,25 @@ detect_ecosystems() {
       ECOSYSTEMS+=("pnpm")
     fi
   fi
-  if echo "$tree" | grep -qE '(^|/)go\.mod$'; then
+  if grep -qE '(^|/)go\.mod$' <<< "$tree"; then
     ECOSYSTEMS+=("go")
   fi
-  if echo "$tree" | grep -qE '(^|/)Cargo\.toml$'; then
+  if grep -qE '(^|/)Cargo\.toml$' <<< "$tree"; then
     ECOSYSTEMS+=("rust")
   fi
-  if echo "$tree" | grep -qE '(^|/)(pyproject\.toml|requirements\.txt)$'; then
+  if grep -qE '(^|/)(pyproject\.toml|requirements\.txt)$' <<< "$tree"; then
     ECOSYSTEMS+=("python")
   fi
-  if echo "$tree" | grep -qE '\.tf$'; then
+  if grep -qE '\.tf$' <<< "$tree"; then
     ECOSYSTEMS+=("terraform")
   fi
-  if echo "$tree" | grep -qE '\.github/workflows/.*\.yml$'; then
+  if grep -qE '\.github/workflows/.*\.yml$' <<< "$tree"; then
     ECOSYSTEMS+=("github-actions")
   fi
   # BMAD Method: detected via either the active install dir (`_bmad/`) or
   # the planning artifacts output dir (`_bmad-output/`). Repos may have one,
   # the other, or both depending on the BMAD workflow stage.
-  if echo "$tree" | grep -qE '(^|/)_bmad(-output)?/'; then
+  if grep -qE '(^|/)_bmad(-output)?/' <<< "$tree"; then
     ECOSYSTEMS+=("bmad-method")
   fi
 }

--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -150,7 +150,7 @@ detect_ecosystems() {
   if grep -qE '\.tf$' <<< "$tree"; then
     ECOSYSTEMS+=("terraform")
   fi
-  if grep -qE '\.github/workflows/.*\.yml$' <<< "$tree"; then
+  if grep -qE '\.github/workflows/.*\.ya?ml$' <<< "$tree"; then
     ECOSYSTEMS+=("github-actions")
   fi
   # BMAD Method: detected via either the active install dir (`_bmad/`) or


### PR DESCRIPTION
## Problem

`detect_ecosystems()` in `scripts/compliance-audit.sh` uses the pattern:

```bash
echo "$tree" | grep -qE '...'
```

When `$tree` is large (repos with many files), `grep -q` exits immediately after the first match, closing the read end of the pipe. The `echo` subprocess is still writing and receives **SIGPIPE**, producing:

```
scripts/compliance-audit.sh: line 153: echo: write error: Broken pipe
scripts/compliance-audit.sh: line 159: echo: write error: Broken pipe
```

## Fix

Replace all 8 `echo "$tree" | grep -qE` calls with bash here-strings:

```bash
grep -qE '...' <<< "$tree"
```

A here-string feeds the variable directly to `grep`'s stdin with no subprocess pipe — no SIGPIPE is possible regardless of the size of `$tree`.

## Affected lines

| Line | Pattern |
|------|---------|
| 130 | `package.json` (npm) |
| 133 | `pnpm-lock.yaml` (pnpm) |
| 141 | `go.mod` (go) |
| 144 | `Cargo.toml` (rust) |
| 147 | `pyproject.toml` / `requirements.txt` (python) |
| 150 | `*.tf` (terraform) |
| 153 | `.github/workflows/*.yml` (github-actions) ← reported error |
| 159 | `_bmad(-output)?/` (bmad-method) ← reported error |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal compliance audit script with streamlined ecosystem detection logic for improved performance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/petry-projects/.github/pull/249)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->