### PR TITLE
fix: disable check-suite auto-trigger for Claude and CodeRabbit on .github

### DIFF
--- a/standards/github-settings.md
+++ b/standards/github-settings.md
@@ -407,8 +407,8 @@ When creating a new repository in `petry-projects`:
 
 ## Current Compliance Status
 
-**Repository settings:** All 7 repos are fully compliant as of 2026-05-08
-(check-suite auto-trigger preferences re-applied for `.github` via API;
+**Repository settings:** All 7 repos are fully compliant as of 2026-05-13
+(check-suite auto-trigger preferences re-applied for `.github` via API — issue #274;
 last full remediation via `scripts/apply-repo-settings.sh --all` on 2026-04-05).
 
 **Ruleset status (as of 2026-05-04):**


### PR DESCRIPTION
## Summary

- Disabled `auto_trigger_checks` for Claude (app_id `1236702`) and CodeRabbit (app_id `347564`) on `petry-projects/.github` via the GitHub API
- Updated `standards/github-settings.md` compliance status to reflect the 2026-05-13 remediation

## Root Cause

GitHub was automatically creating a queued check suite on every push for these apps. Since the apps only complete their suites when they have real work to do, orphaned `queued` suites were blocking auto-merge indefinitely.

## What was done

The API fix was applied directly:
```
PATCH /repos/petry-projects/.github/check-suites/preferences
{"auto_trigger_checks": [{"app_id": 1236702, "setting": false}, {"app_id": 347564, "setting": false}]}
```

Result confirms both are now `false`:
- app_id `1236702` (Claude): `setting: false` ✅
- app_id `347564` (CodeRabbit): `setting: false` ✅

Closes #274

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub repository settings documentation with revised compliance status and repository automation configuration notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/petry-projects/.github/pull/275)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->