### PR TITLE
Fix: Update scorecard summary score extraction

### DIFF
--- a/.github/workflows/org-scorecard.yml
+++ b/.github/workflows/org-scorecard.yml
@@ -59,7 +59,7 @@ jobs:
             fi
 
             # Extract aggregate score
-            AGG_SCORE=$(jq -r '.aggregate_score // "N/A"' "$RESULT_FILE")
+            AGG_SCORE=$(jq -r '.score // "N/A"' "$RESULT_FILE")
 
             # Ensure scorecard label exists
             gh label create scorecard --repo "$ORG/$REPO" --description "OpenSSF Scorecard finding" --color "d93f0b" --force 2>/dev/null || true


### PR DESCRIPTION
Updates the `jq` filter to use the `score` key instead of `aggregate_score`, which is the correct field in Scorecard v5.5.0.

Verified with a successful manual workflow run: https://github.com/petry-projects/.github/actions/runs/25994747481