### PR TITLE
feat(concurrency): add per-repo serialized concurrency to dev-lead stubs

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -37,6 +37,16 @@ on:
 
 permissions: {}
 
+concurrency:
+  # One active run per repo; ci-relay (check_run) keeps an ephemeral per-SHA slot
+  # so it can fire immediately without blocking or being blocked by the dispatch queue.
+  group: >-
+    ${{
+      github.event_name == 'check_run' && format('dev-lead-ci-relay-{0}', github.event.check_run.head_sha) ||
+      'dev-lead'
+    }}
+  cancel-in-progress: false
+
 jobs:
   dev-lead:
     uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@main

--- a/standards/workflows/dev-lead.yml
+++ b/standards/workflows/dev-lead.yml
@@ -37,6 +37,16 @@ on:
 
 permissions: {}
 
+concurrency:
+  # One active run per repo; ci-relay (check_run) keeps an ephemeral per-SHA slot
+  # so it can fire immediately without blocking or being blocked by the dispatch queue.
+  group: >-
+    ${{
+      github.event_name == 'check_run' && format('dev-lead-ci-relay-{0}', github.event.check_run.head_sha) ||
+      'dev-lead'
+    }}
+  cancel-in-progress: false
+
 jobs:
   dev-lead:
     uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@main


### PR DESCRIPTION
## Summary

- Adds a `concurrency:` block to `.github/workflows/dev-lead.yml` (the live org-level caller) and `standards/workflows/dev-lead.yml` (the copy-verbatim template) so at most one dev-lead dispatch run executes in a repo at a time
- The `ci-relay` (`check_run`) path keeps its ephemeral per-SHA slot
- Mirrors the policy landed in petry-projects/.github-private

## Why

Without `concurrency:` in the caller stub, multiple dev-lead runs could execute simultaneously in the same repo (one per PR event). The new per-repo group serializes them while keeping the lightweight ci-relay path unblocked.

## Test plan

- [ ] CI passes on this PR
- [ ] Verify no dev-lead runs overlap in the `.github` repo after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)