### PR TITLE
chore: add dev-lead.yml to DEPLOYABLE_WORKFLOWS

### DIFF
--- a/scripts/deploy-standard-workflows.sh
+++ b/scripts/deploy-standard-workflows.sh
@@ -37,6 +37,7 @@ SKIP_REPOS=(".github" ".github-private")
 # feature-ideation.yml (requires repo-specific project_context input).
 DEPLOYABLE_WORKFLOWS=(
   pr-review-mention.yml
+  dev-lead.yml
   agent-shield.yml
   auto-rebase.yml
   claude.yml


### PR DESCRIPTION
## Summary

- Adds `dev-lead.yml` to the `DEPLOYABLE_WORKFLOWS` list in `deploy-standard-workflows.sh` so the dev-lead caller stub is auto-deployed to all org repos going forward.
- All 6 app repos were manually synced to the current version as part of this rollout (all confirmed compliant via dry-run).

## Test plan

- [ ] `bash scripts/deploy-standard-workflows.sh --dry-run` reports all repos compliant for both `dev-lead.yml` and `pr-review-mention.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled deployment of the dev-lead workflow to supported repositories, making it available alongside existing deployable workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/petry-projects/.github/pull/324?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->