### PR TITLE
feat(copilot): add org-wide Copilot custom instruction files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,106 @@
+# Copilot Instructions — Petry Projects Organization
+
+## Organization Overview
+
+**Petry Projects** builds TypeScript-first applications: Electron desktop apps (TalkTerm),
+backend services, Google Apps Script automation, and GitHub infrastructure. The primary stack is
+TypeScript · React · Electron · Vitest · Node.js · Go · Python · Terraform · GitHub Actions.
+
+## Standards Reference
+
+Full AI agent development standards live in **[AGENTS.md](../AGENTS.md)**. This file is a
+Copilot-focused summary; AGENTS.md is authoritative when they conflict. Read the relevant
+standard in [`standards/`](../standards/) before touching CI, repo settings, or agent
+configuration.
+
+Language-specific rules are applied automatically via files in `.github/instructions/`:
+`typescript`, `javascript`, `python`, `go`, `terraform`, and `shell` — see those files for
+per-language guidance.
+
+## Core Development Rules
+
+**Test-driven development is mandatory.** Write tests before implementing features. Never
+`.skip()` a failing test — fix it. Never add coverage-ignore comments (`istanbul ignore`,
+`c8 ignore`, `v8 ignore`). PRs that reduce coverage below the repo-defined threshold are
+rejected.
+
+**SOLID + DDD.** Each module has one reason to change. High-level policy never imports
+infrastructure directly — inject dependencies. Use domain terminology in code, tests, and docs.
+Bounded contexts communicate through well-defined interfaces or domain events. Use typed value
+objects for domain identifiers and quantities instead of raw primitives.
+
+**CLEAN Code + KISS + YAGNI.** Names reveal intent. Functions do one thing at one level of
+abstraction. Implement exactly what the current story requires — no speculative features. Wait
+for three concrete cases before extracting an abstraction.
+
+**Fail loud, never fake.** Never swallow exceptions silently. Never substitute placeholder data
+when a real fetch or computation fails without an explicit, disclosed fallback (log it, flag it,
+or surface a `degraded: true` field). Never report a step complete when it errored.
+
+**No breaking changes without explicit human approval.** Before removing or renaming any public
+symbol, endpoint, field, event schema, or database column: search all consumers, count them, and
+propose a non-breaking alternative first. Treat the existing test suite as a contract — failing
+tests signal breaking changes, not tests to update.
+
+## Pre-Commit Quality Checks
+
+Before every commit run in order: **format → lint → typecheck → test**. Hooks may not execute
+in Copilot sessions — apply manually. Zero warnings and zero errors required for lint and
+typecheck. Run the full test suite with coverage before pushing.
+
+## Structured Logging
+
+All services emit structured JSON logs in production. Every entry includes `timestamp`
+(ISO 8601 UTC), `level`, `msg`, `service`, `version`. Variable data goes in fields, never in
+the message string:
+
+- **Wrong:** `logger.info("User 1234 placed order 5678")`
+- **Right:** `logger.info("order placed", { user_id: "1234", order_id: "5678" })`
+
+Use `pino` in TypeScript/Node.js and `log/slog` in Go. Never use `console.log` in application
+code. Never log passwords, tokens, API keys, cookies, or PII.
+
+## CI Quality Gates
+
+All PRs must pass before merge: CodeQL (SAST), SonarCloud (quality), project linter at zero
+errors, type-checker, full test suite at coverage threshold, CodeRabbit and Copilot review
+comments resolved. Never bypass CI gates or weaken thresholds to make a PR pass.
+
+## Git and PR Workflow
+
+Always branch from `main`:
+
+```bash
+git checkout main && git pull origin main && git checkout -b <branch-name>
+```
+
+All changes go through pull requests — never commit directly to `main`. Squash merge only
+(enforced by the `pr-quality` ruleset). Resolve every review thread before merging. Use
+`in-progress` labels when multiple agents work from a shared issue queue.
+
+## Security
+
+Never commit secrets, `.env` files, API keys, or Terraform state. Use GitHub Actions secrets or
+an external secret manager. Mark all sensitive Terraform variables `sensitive = true`. Gitleaks
+secret scanning runs on every PR.
+
+---
+
+## Extending These Instructions Per Repository
+
+Each repository SHOULD provide its own `.github/copilot-instructions.md`. Repository-level
+instructions take priority over this org-level file. A repo-level file SHOULD cover:
+
+1. **About** — one sentence describing what the repo does and its role in the org
+2. **Tech stack** — frameworks, libraries, and major versions specific to this repo
+3. **Project structure** — key directories, naming conventions, bounded context layout
+4. **Local dev commands** — exact install, dev, test, lint, and typecheck commands
+5. **Required environment variables** — names, purposes, and example values
+6. **Testing framework** — runner (Vitest / Jest / pytest / go test), coverage tool, thresholds
+7. **Repo-specific rule overrides** — any rule that differs from these org-level defaults;
+   reference the specific AGENTS.md section being overridden
+
+The repo-level file inherits all org-level rules; only document what differs or adds detail.
+Copy the template from
+[`standards/copilot-instructions-standard.md`](../standards/copilot-instructions-standard.md)
+to get started.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -55,7 +55,7 @@ All services emit structured JSON logs in production. Every entry includes `time
 the message string:
 
 - **Wrong:** `logger.info("User 1234 placed order 5678")`
-- **Right:** `logger.info("order placed", { user_id: "1234", order_id: "5678" })`
+- **Right:** `logger.info({ user_id: "1234", order_id: "5678" }, "order placed")`
 
 Use `pino` in TypeScript/Node.js and `log/slog` in Go. Never use `console.log` in application
 code. Never log passwords, tokens, API keys, cookies, or PII.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,10 +1,18 @@
-# Copilot Instructions — Petry Projects Organization
+# Copilot Instructions — petry-projects/.github
 
-## Organization Overview
+> **Note:** This file applies to the `petry-projects/.github` repository only. Copilot
+> instruction files are repository-scoped — there is no automatic org-wide propagation. Every
+> other repo in the org must have its own `.github/copilot-instructions.md`. Use this file as
+> the canonical template; the weekly compliance audit enforces deployment to each repo.
 
-**Petry Projects** builds TypeScript-first applications: Electron desktop apps (TalkTerm),
-backend services, Google Apps Script automation, and GitHub infrastructure. The primary stack is
-TypeScript · React · Electron · Vitest · Node.js · Go · Python · Terraform · GitHub Actions.
+## Repository Overview
+
+This is the **org standards repository** for `petry-projects`. It contains org-wide AI agent
+standards (`AGENTS.md`), canonical CI workflow templates (`standards/workflows/`), the
+compliance audit script, and the canonical Copilot instruction files that every repo should
+adopt.
+
+Primary stack for work done in this repo: Bash · YAML · Markdown · Python (scripts).
 
 ## Standards Reference
 
@@ -86,10 +94,11 @@ secret scanning runs on every PR.
 
 ---
 
-## Extending These Instructions Per Repository
+## Deploying These Instructions to Each Repository
 
-Each repository SHOULD provide its own `.github/copilot-instructions.md`. Repository-level
-instructions take priority over this org-level file. A repo-level file SHOULD cover:
+Every repository MUST have its own `.github/copilot-instructions.md` — this file does not
+propagate automatically. Copy this file as the starting point, then tailor it to the repo.
+A repo-level file SHOULD cover:
 
 1. **About** — one sentence describing what the repo does and its role in the org
 2. **Tech stack** — frameworks, libraries, and major versions specific to this repo

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,0 +1,151 @@
+---
+description: Go development standards for the Petry Projects organization, based on Effective Go and Google's Go Style Guide
+applyTo: "**/*.go,**/go.mod,**/go.sum"
+---
+
+# Go Development Standards
+
+These rules extend the org-level `copilot-instructions.md`. They are based on
+[Effective Go](https://go.dev/doc/effective_go),
+[Go Code Review Comments](https://go.dev/wiki/CodeReviewComments), and
+[Google's Go Style Guide](https://google.github.io/styleguide/go/). Go is used for
+infrastructure tools, CLI utilities, and backend services in this org.
+
+## General Principles
+
+- Write simple, clear, and idiomatic Go. Favor clarity over cleverness.
+- Keep the happy path left-aligned — return early to reduce nesting.
+- Make the zero value useful. Design types so the zero value is a valid, safe starting state.
+- Prefer the standard library over third-party packages when equivalent functionality exists.
+- Use Go modules (`go.mod` / `go.sum`) for all dependency management.
+
+## Naming Conventions
+
+- Package names: lowercase, single-word, no underscores or hyphens. Singular, not plural.
+  Avoid generic names (`util`, `common`, `base`, `helper`).
+- Variables and functions: `camelCase`. Exported symbols: `PascalCase`.
+- Interfaces: `-er` suffix when describing a single behavior (`Reader`, `Writer`, `Formatter`).
+  Keep interfaces small (1–3 methods is ideal).
+- **Each Go file must have exactly ONE `package` declaration.** When editing an existing file,
+  preserve the existing declaration. When creating a new file, check the package names of
+  sibling files first.
+
+## Code Style
+
+- Always format with `gofmt` (or `goimports`). This is non-negotiable.
+- Use `goimports` to manage import blocks automatically.
+- Write comments in English. Document all exported symbols — start with the symbol name.
+  Comment the *why*, not the *what*, unless the logic is complex.
+- Avoid emoji in code and comments.
+
+## Error Handling
+
+- Check errors immediately after every function call. Never ignore with `_` without a comment.
+- Wrap errors with context: `fmt.Errorf("operation description: %w", err)`.
+- Place error returns as the last return value, named `err`.
+- Use `errors.Is` / `errors.As` for error checking, not string comparison.
+- Log errors at the point of handling — not at every intermediate propagation layer. Add context
+  by wrapping, then log once at the top-level handler.
+- Error messages: lowercase, no trailing punctuation.
+
+## Project Structure
+
+Follow standard Go project layout:
+
+```text
+cmd/           # Application entry points (one directory per binary)
+internal/      # Private packages (not importable by external projects)
+pkg/           # Reusable packages safe for external import
+```
+
+Avoid circular dependencies. Use `internal/` for packages that should not be imported outside
+the module. Group related functionality into focused packages.
+
+## Structured Logging
+
+Use **`log/slog`** (Go 1.21+) as the default structured logger:
+
+```go
+import "log/slog"
+
+// Production: JSON output
+handler := slog.NewJSONHandler(os.Stdout, nil)
+logger := slog.New(handler)
+
+// Development: text output
+handler := slog.NewTextHandler(os.Stderr, nil)
+
+// Propagate via context for OpenTelemetry integration:
+slog.InfoContext(ctx, "order placed", "order_id", orderID, "user_id", userID)
+```
+
+- **Never use the global `log` package** from the standard library.
+- Propagate loggers via `context.Context`. Use `slog.InfoContext(ctx, ...)` so trace/span IDs
+  are automatically bridged.
+- In tests, suppress output: `slog.New(slog.NewTextHandler(io.Discard, nil))`.
+- Log at the point of handling, not at every layer. Wrap errors with `fmt.Errorf` and log once.
+- Never log variables named `password`, `secret`, `token`, `api_key`, `private_key`,
+  `authorization`, or `cookie`.
+
+## Concurrency
+
+- Be cautious about creating goroutines in libraries; prefer letting the caller control
+  concurrency.
+- Always know how a goroutine will exit. Use `sync.WaitGroup` or channels to wait for
+  goroutines. Avoid goroutine leaks.
+- Use channels for communication between goroutines; use `sync.Mutex` for protecting shared
+  state.
+- Close channels from the sender side only.
+- WaitGroup by Go version:
+  - Go ≥ 1.25: use `wg.Go(fn)` (new method).
+  - Go < 1.25: use the classic `wg.Add(1)` / `defer wg.Done()` pattern.
+
+## HTTP Clients and I/O
+
+- HTTP client structs hold configuration only (base URL, `*http.Client`, auth, default headers).
+  Never store per-request state on the client struct.
+- Construct a fresh `*http.Request` per method call. Never cache or reuse a request object.
+- Always close response bodies: `defer resp.Body.Close()`.
+- `io.Reader` streams are consumable once. To read a body multiple times, use `io.ReadAll` once
+  and create fresh readers: `bytes.NewReader(buf)`.
+- Set `req.GetBody` for retryable requests so the transport can recreate the body.
+
+## HTTP Server (net/http)
+
+- Go ≥ 1.22: use the enhanced `net/http` `ServeMux` with method + pattern routing.
+- Go < 1.22: handle methods manually in handlers or use a justified third-party router.
+
+## Type Safety
+
+- Prefer explicit type conversions. Use `any` (Go 1.18+) instead of `interface{}`.
+- Use generics over unconstrained types. Prefer specific type constraints when possible.
+- Use type assertions carefully — always check the second return value:
+  `v, ok := x.(SomeType); if !ok { ... }`.
+
+## Testing
+
+- Use table-driven tests with `t.Run` subtests.
+- Name tests: `Test_FunctionName_Scenario` or `TestFunctionName`.
+- Mark helper functions with `t.Helper()`. Use `t.Cleanup()` for teardown.
+- Place test files next to source (`service.go` → `service_test.go`).
+- White-box tests use the same package; black-box tests use the `_test` package suffix.
+- Use `testify/assert` when it adds clarity, but avoid over-complicating simple assertions.
+
+## Security
+
+- Validate all external input at system boundaries.
+- Use `crypto/rand` for random number generation. Never use `math/rand` for security-sensitive
+  operations.
+- Use standard library `crypto` packages — never implement cryptographic algorithms.
+- Store passwords with bcrypt, scrypt, or argon2 (`golang.org/x/crypto`).
+- Use TLS for all network communication.
+
+## Tooling
+
+- `go fmt` — format code (non-negotiable)
+- `go vet` — find suspicious constructs
+- `golangci-lint` — extended linting (replaces deprecated `golint`)
+- `go test ./...` — run all tests
+- `go mod tidy` — clean up unused dependencies
+
+Run `golangci-lint run` before committing. Zero warnings, zero errors.

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -66,15 +66,18 @@ the module. Group related functionality into focused packages.
 Use **`log/slog`** (Go 1.21+) as the default structured logger:
 
 ```go
-import "log/slog"
+import (
+    "log/slog"
+    "os"
+)
 
-// Production: JSON output to stdout
+// Wire up once at program start (e.g., main.go).
+// Production — structured JSON for log aggregation:
 logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+// Development — swap the handler for human-readable text:
+// logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 
-// Development: human-readable text to stderr
-logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
-
-// Propagate via context for OpenTelemetry integration:
+// Propagate the logger via context so OpenTelemetry can bridge trace/span IDs:
 logger.InfoContext(ctx, "order placed", "order_id", orderID, "user_id", userID)
 ```
 

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,6 +1,6 @@
 ---
 description: Go development standards for the Petry Projects organization, based on Effective Go and Google's Go Style Guide
-applyTo: "**/*.go,**/go.mod,**/go.sum"
+applyTo: "**/*.go"
 ---
 
 # Go Development Standards
@@ -68,15 +68,14 @@ Use **`log/slog`** (Go 1.21+) as the default structured logger:
 ```go
 import "log/slog"
 
-// Production: JSON output
-handler := slog.NewJSONHandler(os.Stdout, nil)
-logger := slog.New(handler)
+// Production: JSON output to stdout
+logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 
-// Development: text output
-handler := slog.NewTextHandler(os.Stderr, nil)
+// Development: human-readable text to stderr
+logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 
 // Propagate via context for OpenTelemetry integration:
-slog.InfoContext(ctx, "order placed", "order_id", orderID, "user_id", userID)
+logger.InfoContext(ctx, "order placed", "order_id", orderID, "user_id", userID)
 ```
 
 - **Never use the global `log` package** from the standard library.
@@ -96,9 +95,10 @@ slog.InfoContext(ctx, "order placed", "order_id", orderID, "user_id", userID)
 - Use channels for communication between goroutines; use `sync.Mutex` for protecting shared
   state.
 - Close channels from the sender side only.
-- WaitGroup by Go version:
-  - Go ≥ 1.25: use `wg.Go(fn)` (new method).
+- WaitGroup pattern:
+  - Go ≥ 1.25: `sync.WaitGroup` gains a `Go(fn func())` method — use `wg.Go(fn)` directly.
   - Go < 1.25: use the classic `wg.Add(1)` / `defer wg.Done()` pattern.
+  - For error propagation across goroutines, prefer `golang.org/x/sync/errgroup` (`eg.Go(fn)`) over bare `sync.WaitGroup`.
 
 ## HTTP Clients and I/O
 

--- a/.github/instructions/javascript.instructions.md
+++ b/.github/instructions/javascript.instructions.md
@@ -1,0 +1,52 @@
+---
+description: JavaScript development standards for the Petry Projects organization
+applyTo: "**/*.js,**/*.mjs,**/*.cjs"
+---
+
+# JavaScript Development Standards
+
+These rules extend the org-level `copilot-instructions.md` and apply to JavaScript files.
+
+> **Prefer TypeScript.** If a file can be migrated to TypeScript without significant disruption,
+> prefer the migration. JavaScript is accepted for configuration files (`eslint.config.js`,
+> `vite.config.mjs`, `jest.config.js`), build scripts, and legacy code during migration.
+
+## Style and Formatting
+
+- **Formatter:** Prettier. Run `prettier --write` before committing.
+- **Linter:** ESLint. Zero warnings, zero errors.
+- Never use `var`. Use `const` for all bindings that are not reassigned; use `let` only when
+  reassignment is required.
+- Prefer `async`/`await` over raw `.then()`/`.catch()` chains. Handle rejections — never leave
+  a floating promise.
+- Use ES modules (`import`/`export`) in all new code. CommonJS (`require`/`module.exports`) is
+  acceptable only in config files that require it.
+- Use destructuring assignment to extract values from objects and arrays.
+
+## Naming Conventions
+
+- `camelCase` for variables and functions. `PascalCase` for constructors and classes.
+  `SCREAMING_SNAKE_CASE` for module-level constants.
+- File names match the primary export or purpose (`orderService.js`, `eslint.config.mjs`).
+
+## Type Safety Without TypeScript
+
+- Use JSDoc annotations (`@param`, `@returns`, `@type`) in JavaScript files that cannot yet be
+  migrated, to enable IDE type inference and `checkJs` validation.
+- Enable `// @ts-check` at the top of critical JavaScript files to surface type errors in the
+  IDE without requiring full TypeScript migration.
+
+## Error Handling
+
+- Always handle Promise rejections — either with `try`/`catch` in `async` functions or with an
+  explicit `.catch()` handler.
+- Never use empty catch blocks (`catch (e) {}`). At minimum, log the error with structured
+  fields.
+- Do not use `console.log` in application or library code. Use a structured logger (`pino`).
+  `console.*` is acceptable only in CLI scripts and build tooling.
+
+## Testing
+
+- Follow the same TDD rules as TypeScript: write tests before implementing, never `.skip()`.
+- Use the same test runner as the rest of the project (Vitest or Jest).
+- Name tests as functional requirement specifications.

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -1,0 +1,125 @@
+---
+description: Python development standards for the Petry Projects organization
+applyTo: "**/*.py"
+---
+
+# Python Development Standards
+
+These rules extend the org-level `copilot-instructions.md` and apply to Python files. Python
+is used primarily for CI scripts, Google Apps Script companion tooling, and automation utilities.
+
+## Code Style and Formatting
+
+- **Formatter:** `black` (line length 88) or `ruff format`. Run before committing.
+- **Linter:** `ruff` (preferred) or `flake8`. Zero errors, zero warnings.
+- **Import sorting:** `isort` (or `ruff`'s `I` rule). Standard library → third-party →
+  local imports, separated by blank lines.
+- Follow **PEP 8** for naming:
+  - `snake_case` for variables, functions, and module names
+  - `PascalCase` for classes
+  - `SCREAMING_SNAKE_CASE` for module-level constants
+  - `_private` prefix for internal functions not part of the public API
+
+## Type Annotations
+
+Type annotations are **required** on all function signatures and class attributes in new code.
+Use `from __future__ import annotations` for forward references in Python < 3.10.
+
+```python
+from __future__ import annotations
+
+def process_order(order_id: str, amount: float) -> dict[str, str]:
+    ...
+```
+
+Use `mypy` or `pyright` for static type checking. Target `strict` mode where feasible.
+
+- Use `|` union syntax (Python 3.10+) or `Optional[X]` / `Union[X, Y]` for older versions.
+- Use `TypedDict` for structured dictionary shapes, not plain `dict[str, Any]`.
+- Avoid `Any` unless bridging untyped third-party code — document why.
+
+## Error Handling
+
+- Be explicit. Catch specific exception types, not bare `except:` or `except Exception:`.
+- Never swallow exceptions silently. At minimum, log with context before re-raising or returning
+  a typed error result.
+- Use custom exception classes for domain-level errors:
+
+  ```python
+  class OrderNotFoundError(Exception):
+      def __init__(self, order_id: str) -> None:
+          super().__init__(f"Order not found: {order_id}")
+          self.order_id = order_id
+  ```
+
+- Use `contextlib.suppress` only for truly ignorable errors (e.g., `FileNotFoundError` on
+  optional cleanup).
+
+## Structured Logging
+
+Never use `print()` in application or library code. Use the standard `logging` module with
+structured context, or a third-party library that emits JSON (`structlog`, `python-json-logger`):
+
+```python
+import logging
+logger = logging.getLogger(__name__)
+
+# Wrong:
+print(f"Processing order {order_id}")
+
+# Right:
+logger.info("processing order", extra={"order_id": order_id})
+```
+
+Configure the root logger once at the application entry point. Library code uses
+`logging.getLogger(__name__)` only — never configures handlers or formatters.
+
+## Testing (pytest)
+
+- Use **pytest** as the test runner. Tests live in a `tests/` directory mirroring the source
+  structure, or co-located with source files.
+- Use `pytest.mark.parametrize` for table-driven tests instead of loops.
+- Use fixtures (`@pytest.fixture`) for shared setup and teardown. Prefer function-scoped
+  fixtures; escalate to `session` scope only for expensive shared resources.
+- Name tests descriptively: `test_submitting_valid_order_creates_confirmed_record`.
+- Never use `unittest.TestCase` in new code unless integrating with a legacy suite.
+- Coverage thresholds are defined per-repo. Google Apps Script repos require 100% line coverage.
+
+## Google Apps Script Companion Code
+
+Python used alongside Google Apps Script MUST:
+
+- Extract all business logic into pure, testable Python functions. GAS-specific I/O is tested
+  via mocks; business logic is tested directly.
+- Use `pre-commit` hooks (`pre-commit/pre-commit-hooks`, `ruff`, `black`, `mypy`).
+- Export coverage in `lcov` format for SonarCloud when configured.
+
+## Security
+
+- Never hardcode credentials, API keys, or secrets. Read them from environment variables or a
+  secret manager.
+- Validate and sanitize all external input before using it in file paths, SQL, or subprocess
+  calls.
+- Use `subprocess.run([...], check=True)` with a list (not a shell string) to avoid shell
+  injection. Never use `shell=True` with untrusted input.
+- Use `secrets` module (not `random`) for generating cryptographic tokens.
+
+## Pre-Commit Configuration
+
+Repos using Python SHOULD include a `.pre-commit-config.yaml` with at minimum:
+
+```yaml
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.0
+    hooks:
+      - id: ruff
+      - id: ruff-format
+```

--- a/.github/instructions/shell.instructions.md
+++ b/.github/instructions/shell.instructions.md
@@ -1,0 +1,139 @@
+---
+description: Shell script development standards for the Petry Projects organization
+applyTo: "**/*.sh,**/*.bash,**/Makefile"
+---
+
+# Shell Script Development Standards
+
+These rules extend the org-level `copilot-instructions.md`. Shell scripts are used for CI
+helper utilities, compliance automation, and infrastructure orchestration.
+
+## Safety Flags
+
+Every shell script MUST begin with:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+```
+
+- `set -e` — exit immediately on any command failure
+- `set -u` — treat unset variables as errors
+- `set -o pipefail` — propagate failures through pipelines (not just the last command)
+
+For scripts that intentionally handle errors inline (e.g., checking return codes manually),
+disable `set -e` locally within a subshell or use `|| true` with a comment explaining why.
+
+## ShellCheck Compliance
+
+All scripts MUST pass `shellcheck` with zero warnings:
+
+```bash
+shellcheck --shell=bash <script>.sh
+```
+
+Run ShellCheck before committing. Common issues to fix proactively:
+
+- Unquoted variables — always quote: `"$variable"`, `"${array[@]}"`
+- Unsafe `$()` with user-controlled input — validate input first
+- Deprecated constructs — use `[[ ... ]]` over `[ ... ]` for bash conditionals
+
+## Quoting and Variable Expansion
+
+- **Always quote variable expansions:** `"$var"`, `"${var}"`, `"${array[@]}"`.
+- Use `${var:-default}` for safe defaults. Use `${var:?error message}` to fail fast on required
+  variables.
+- Use `$( )` for command substitution, not backticks.
+- Use `[[ ... ]]` for conditionals (bash built-in, safer than `[ ]`).
+- Use `(( ... ))` for arithmetic expressions.
+
+## Function Organization
+
+- Extract reusable logic into functions. Name functions with `snake_case`.
+- Declare local variables with `local` inside functions to avoid polluting global scope.
+- Functions that produce output should write to stdout. Functions that report errors should write
+  to stderr: `echo "Error: message" >&2`.
+
+  ```bash
+  log_info()  { echo "[INFO]  $*"; }
+  log_error() { echo "[ERROR] $*" >&2; }
+
+  process_item() {
+    local item="$1"
+    local output_dir="$2"
+    # ...
+  }
+  ```
+
+## Error Handling
+
+- Check return codes for commands that can fail silently (e.g., `curl`, `jq`, `aws`).
+- Use `|| { log_error "..."; exit 1; }` patterns to provide descriptive failure messages.
+- Use `trap 'cleanup' EXIT` to ensure cleanup runs even on error:
+
+  ```bash
+  cleanup() {
+    rm -f "$tmp_file"
+  }
+  trap 'cleanup' EXIT
+  ```
+
+## Command Injection Prevention
+
+- Never pass user-controlled input directly to shell commands without validation.
+- Use arrays to pass arguments to commands (avoids word-splitting and globbing):
+
+  ```bash
+  # Wrong — subject to word splitting:
+  run_command "$user_args"
+
+  # Right — use an array:
+  args=("--flag" "$user_value")
+  run_command "${args[@]}"
+  ```
+
+- Avoid `eval` with untrusted input.
+
+## Style and Readability
+
+- Use heredocs for multi-line strings instead of multiple `echo` statements:
+
+  ```bash
+  cat <<'EOF'
+  Usage: script.sh [options]
+    -h, --help    Show this help message
+  EOF
+  ```
+
+- Keep lines under 100 characters where practical. Use `\` to break long commands.
+- Add a one-line comment before each function and non-obvious command explaining *why*, not
+  *what*.
+- Use `readonly` for constants at the top of the script:
+
+  ```bash
+  readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  readonly MAX_RETRIES=3
+  ```
+
+## Makefile Standards
+
+- Use `.PHONY` for all non-file targets to prevent conflicts with files of the same name.
+- Use `$(MAKE)` recursively, not bare `make`.
+- Document each target with a `##` comment on the same line (enables `make help` patterns):
+
+  ```makefile
+  .PHONY: test lint
+
+  test: ## Run the full test suite with coverage
+  	go test ./... -coverprofile=coverage.out
+
+  lint: ## Run golangci-lint
+  	golangci-lint run
+  ```
+
+## Testing Shell Scripts
+
+- Test scripts with `bats` (Bash Automated Testing System) where feasible.
+- At minimum, test the happy path and common error paths.
+- Use `shellcheck` in CI as a required status check for repositories with significant shell
+  script surface area.

--- a/.github/instructions/shell.instructions.md
+++ b/.github/instructions/shell.instructions.md
@@ -1,6 +1,6 @@
 ---
 description: Shell script development standards for the Petry Projects organization
-applyTo: "**/*.sh,**/*.bash,**/Makefile"
+applyTo: "**/*.sh,**/*.bash"
 ---
 
 # Shell Script Development Standards

--- a/.github/instructions/terraform.instructions.md
+++ b/.github/instructions/terraform.instructions.md
@@ -1,0 +1,148 @@
+---
+description: Terraform infrastructure-as-code standards for the Petry Projects organization
+applyTo: "**/*.tf,**/*.tfvars,**/*.tftest.hcl"
+---
+
+# Terraform Development Standards
+
+These rules extend the org-level `copilot-instructions.md` and are based on the
+[Terraform Style Guide](https://developer.hashicorp.com/terraform/language/style) and the
+[github/awesome-copilot Terraform template](https://github.com/github/awesome-copilot/blob/main/instructions/terraform.instructions.md).
+Terraform is used for GitHub infrastructure and cloud resource management in this org.
+
+## General Principles
+
+- Use Terraform for infrastructure provisioning and management. Keep configurations in version
+  control.
+- Always use the **latest stable version** of Terraform and its providers. Update regularly for
+  security patches.
+- Prioritize readability, clarity, and maintainability over brevity.
+
+## Security
+
+- **Never commit sensitive information** — API keys, credentials, passwords, certificates, or
+  Terraform state files — to version control. Use `.gitignore` to exclude them.
+- Store secrets in GitHub Actions secrets, AWS Secrets Manager, SSM Parameter Store, or a
+  comparable secret manager. Reference them via environment variables.
+- **Always mark sensitive variables** with `sensitive = true` to prevent them from appearing in
+  `plan` / `apply` output.
+- Follow the principle of least privilege for all IAM roles and policies.
+- Deploy resources in private subnets whenever possible. Use public subnets only for resources
+  that genuinely require direct internet access (load balancers, NAT gateways).
+- Enable encryption for data at rest (EBS, S3, RDS) and in transit (TLS).
+- Run security scanning on every PR:
+  - `trivy config .` — vulnerability and misconfiguration scanning
+  - `tfsec .` — Terraform-specific security checks
+  - `checkov -d .` — policy-as-code compliance
+
+## Modularity
+
+- **Separate projects for each major infrastructure component** — reduces `plan`/`apply` scope,
+  enables independent deployment, and limits blast radius.
+- Use modules to encapsulate related resources. Avoid modules for single resources — only use
+  them for groups of related resources that are reused.
+- Keep module nesting shallow. Avoid circular dependencies between modules.
+- Use `output` blocks to expose information needed by other modules or users. Mark outputs
+  `sensitive = true` if they contain sensitive values.
+
+## Maintainability
+
+- Use variables for all configuration values. Avoid hard-coded strings and numbers.
+- Set default values for variables where appropriate.
+- Use `data` sources to retrieve existing resource information rather than requiring manual
+  configuration. Remove unused data sources — they slow down `plan`/`apply`.
+- Use `locals` for values referenced multiple times to ensure consistency and avoid duplication.
+- Use comments to explain complex configurations and non-obvious design decisions.
+
+## Style and Formatting
+
+- Follow the Terraform Style Guide: 2-space indentation, consistent naming.
+- Run `terraform fmt` before every commit. This is non-negotiable.
+- Run `terraform validate` to check for syntax errors.
+- Run `tflint` to check for style violations and best-practice compliance.
+- Resource naming: use descriptive, consistent names. Use underscores as word separators
+  (`my_security_group`, not `my-security-group`).
+- **File organization within a project:**
+  - `providers.tf` — provider configurations and version constraints
+  - `variables.tf` — all input variable declarations
+  - `outputs.tf` — all output declarations
+  - `main.tf` — root-level resources or module calls
+  - Named files for logical groups (`network.tf`, `ecs.tf`, `rds.tf`)
+
+- **Within resource blocks, order attributes as:**
+  1. `depends_on` (if present)
+  2. `for_each` or `count` (if present)
+  3. Required attributes (alphabetized within each section)
+  4. Optional attributes (alphabetized within each section)
+  5. `lifecycle` block (always last)
+
+- Alphabetize providers, variables, data sources, resources, and outputs within each file.
+- Use blank lines to separate logical sections. Group related attributes; separate sections with
+  blank lines.
+
+## Documentation
+
+- **Every variable and output MUST include `description` and `type` attributes.**
+
+  ```hcl
+  variable "environment" {
+    description = "Deployment environment name (e.g., staging, production)"
+    type        = string
+  }
+
+  output "cluster_endpoint" {
+    description = "EKS cluster API server endpoint"
+    value       = aws_eks_cluster.main.endpoint
+    sensitive   = false
+  }
+  ```
+
+- Include a `README.md` in each Terraform project with: purpose, prerequisites, usage examples,
+  and a description of all inputs/outputs.
+- Use `terraform-docs` to generate variable/output documentation automatically.
+
+## Testing
+
+- Write tests using the native `.tftest.hcl` format:
+
+  ```hcl
+  run "creates_security_group_with_correct_ingress" {
+    command = plan
+
+    assert {
+      condition     = aws_security_group.app.ingress[0].from_port == 443
+      error_message = "Ingress rule must allow port 443"
+    }
+  }
+  ```
+
+- Cover both positive (resources created with expected values) and negative (invalid inputs
+  rejected) scenarios.
+- Tests must be idempotent — running them multiple times produces the same result.
+
+## State Management
+
+- Never commit `.tfstate` or `.tfstate.backup` files to version control.
+- Use remote state backends (S3 + DynamoDB for locking, or Terraform Cloud) for all shared
+  environments.
+- Use separate state files per environment (dev, staging, production) and per major component.
+
+## Version Pinning
+
+- Pin provider versions in `required_providers` blocks using `~>` (pessimistic constraint) or
+  exact versions for stability:
+
+  ```hcl
+  terraform {
+    required_version = ">= 1.9"
+    required_providers {
+      aws = {
+        source  = "hashicorp/aws"
+        version = "~> 5.0"
+      }
+    }
+  }
+  ```
+
+- Update provider versions regularly for security patches. Use Dependabot for automated updates
+  (see `standards/dependabot-policy.md` for the Terraform ecosystem template).

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -1,0 +1,140 @@
+---
+description: TypeScript and TSX development standards for the Petry Projects organization
+applyTo: "**/*.ts,**/*.tsx"
+---
+
+# TypeScript Development Standards
+
+These rules extend the org-level `copilot-instructions.md`. TypeScript is the primary language
+across all Petry Projects repositories.
+
+## Compiler Configuration
+
+Always use TypeScript in strict mode. All repositories MUST include these flags (or stricter):
+
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true
+  }
+}
+```
+
+Never use `// @ts-ignore` or `// @ts-expect-error` to silence type errors without a documented
+reason. Fix the underlying type issue instead.
+
+## Code Style
+
+- **Formatter:** Prettier with `singleQuote: true`, `semi: true`, `trailingComma: "all"`,
+  `printWidth: 100`, `tabWidth: 2`. Run `prettier --write` before committing.
+- **Linter:** ESLint flat config (`eslint.config.mjs`). Zero warnings, zero errors.
+- **Imports:** Use `import type { ... }` for type-only imports. Organize imports: external
+  packages first, then internal modules. No circular imports.
+- **No barrel files.** Avoid `index.ts` re-export files unless the project explicitly requires
+  them — they increase circular dependency risk and slow down bundlers.
+- **Naming:** `PascalCase` for types, interfaces, classes, and React components. `camelCase` for
+  variables, functions, and methods. `SCREAMING_SNAKE_CASE` for module-level constants.
+  File names match the primary export (`UserRepository.ts`, `OrderSummary.tsx`).
+
+## Type Safety
+
+- Prefer `unknown` over `any`. When `any` is unavoidable, add a comment explaining why.
+- Use branded types / nominal typing for domain identifiers and value objects:
+
+  ```typescript
+  type UserId = string & { readonly __brand: "UserId" };
+  type OrderId = string & { readonly __brand: "OrderId" };
+  ```
+
+- Use discriminated unions instead of optional fields where possible.
+- Avoid type assertions (`as SomeType`) at system boundaries — validate with a type guard or
+  schema parser (e.g., Zod) instead.
+- Use `readonly` for arrays and object properties that should not be mutated.
+
+## Domain-Driven Design Patterns
+
+- **Ubiquitous language:** Use domain terminology from the bounded context in type names,
+  variable names, and method names. Never rename domain concepts to generic terms.
+- **Bounded contexts:** Each context lives in its own directory (e.g., `src/orders/`,
+  `src/billing/`). Cross-context dependencies use well-defined interfaces or domain events —
+  never direct internal imports across context boundaries.
+- **Aggregate roots:** External code accesses child entities only through the aggregate root.
+  Return domain objects from repositories, not raw database rows.
+- **Value objects:** Model domain quantities, identifiers, and domain-specific strings as value
+  objects. Validate on construction; throw on invalid input.
+- **Repository pattern:** Persistence is abstracted behind repository interfaces the domain
+  defines. Infrastructure implements them. Domain code never imports database drivers, ORMs, or
+  storage libraries.
+
+## CQRS Naming Conventions
+
+| Concept | Convention | Examples |
+|---------|-----------|----------|
+| Command | Imperative verb + noun | `PlaceOrder`, `CancelSubscription` |
+| Event | Past-tense verb + noun | `OrderPlaced`, `SubscriptionCancelled` |
+| Query | `Get` / `List` / `Search` + noun | `GetOrderById`, `ListActiveUsers` |
+| Command handler | `Handle(cmd)` or `<Name>Handler` | `PlaceOrderHandler` |
+| Projection | Noun describing the view | `OrderSummaryProjection` |
+
+Commands MUST NOT return domain data — return the new entity ID or void. Queries MUST NOT
+mutate state.
+
+## Structured Logging
+
+Use **pino** as the default structured logger. Never use `console.log`, `console.error`, or
+`console.warn` in application code (`console.*` is acceptable only in CLI tools and build
+scripts):
+
+```typescript
+import pino from "pino";
+const logger = pino();
+
+// In Express/Fastify middleware, attach a child logger per request:
+const reqLogger = logger.child({ request_id: req.id, user_id: req.user?.id });
+
+// Log with structured fields, not interpolated strings:
+reqLogger.info({ order_id: orderId, amount }, "order placed");
+reqLogger.error({ err, order_id: orderId }, "payment failed");
+```
+
+Never log variables whose names end in `password`, `secret`, `token`, `api_key`, `cookie`, or
+`authorization`.
+
+## React Guidelines
+
+- Use functional components with hooks exclusively. No class components.
+- Extract business logic into custom hooks or service functions — keep components presentational.
+- Use stable `data-testid` attributes for E2E test selectors; never match on CSS classes, DOM
+  hierarchy, or display text.
+- Props interfaces use `PascalCase`: `interface ButtonProps { ... }`. Co-locate with the
+  component file.
+- Do not import React explicitly (JSX transform handles it). Use `React.FC` only if required by
+  the project — prefer plain function declarations.
+
+## Error Handling
+
+- Use typed `Result` patterns or typed error unions rather than throwing for recoverable errors
+  at domain boundaries.
+- Always handle the error case explicitly — never use `.catch(() => {})` silently.
+- Fail fast with a clear, descriptive error when an invariant is violated.
+
+## Testing (Vitest / Jest)
+
+- Name tests as functional requirement specifications:
+  `it("submitting a valid order creates a confirmed record with correct totals")`.
+- Use `describe` blocks to group by feature or class under test.
+- Mock only external I/O (databases, HTTP, file system). Never mock domain logic.
+- Co-locate unit tests next to source files (`UserRepository.test.ts` beside
+  `UserRepository.ts`).
+- Mutation testing (Stryker) runs in CI for repos that configure it — write meaningful
+  assertions, not trivial coverage padding.
+
+## Electron-Specific (TalkTerm and desktop repos)
+
+- Keep main-process and renderer-process code strictly separated. Never import renderer modules
+  in the main process or vice versa.
+- Use `contextBridge` for all IPC; never expose `ipcRenderer` directly to renderer code.
+- Validate all data crossing the IPC bridge as if it were external user input.

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -3,6 +3,8 @@ ignores:
   - "node_modules/**"
 
 config:
+  MD010:
+    code_blocks: false   # Makefiles and similar require literal tabs — exclude
   MD013:
     line_length: 200
     tables: false        # Tables often have long rows — exclude

--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -995,11 +995,50 @@ check_copilot_setup_steps() {
     return
   fi
 
-  # Verify the file contains the mandatory copilot-setup-steps job key (structural check:
-  # match an indented YAML key so a bare comment cannot falsely satisfy the check)
+  # Verify the workflow contains jobs.copilot-setup-steps specifically.
+  # Use a small indentation-based parser (not a loose grep) so comments or similarly
+  # named keys elsewhere cannot falsely satisfy this compliance check.
   local decoded
   decoded=$(echo "$content" | base64 -d 2>/dev/null || echo "")
-  if ! echo "$decoded" | grep -qE '^\s+copilot-setup-steps\s*:'; then
+  if ! echo "$decoded" | python3 -c '
+import re
+import sys
+
+lines = sys.stdin.read().splitlines()
+jobs_indent = None
+child_indent = None
+in_jobs = False
+found = False
+
+for raw in lines:
+    # Skip empty lines and comments
+    if re.match(r"^[ \t]*(#.*)?$", raw):
+        continue
+
+    indent = len(raw) - len(raw.lstrip(" \t"))
+    line = raw.strip()
+
+    if not in_jobs:
+        if re.match(r"^jobs:[ \t]*(#.*)?$", line):
+            in_jobs = True
+            jobs_indent = indent
+        continue
+
+    # Left jobs section
+    if indent <= jobs_indent:
+        break
+
+    # Determine direct-child indentation under jobs (first mapping key)
+    if child_indent is None and re.match(r"^[^:#][^:]*:[ \t]*(#.*)?$", line):
+        child_indent = indent
+
+    # Match the exact required direct child key
+    if child_indent is not None and indent == child_indent and re.match(r"^copilot-setup-steps:[ \t]*(#.*)?$", line):
+        found = True
+        break
+
+sys.exit(0 if found else 1)
+'; then
     add_finding "$repo" "standards" "copilot-setup-steps-invalid-job-name" "error" \
       "\`.github/workflows/copilot-setup-steps.yml\` exists but does not contain a job named \`copilot-setup-steps\` — GitHub requires this exact job name to pick up the file." \
       "standards/ci-standards.md"

--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -1032,8 +1032,8 @@ for raw in lines:
     if child_indent is None and re.match(r"^[^:#][^:]*:[ \t]*(#.*)?$", line):
         child_indent = indent
 
-    # Match the exact required direct child key
-    if child_indent is not None and indent == child_indent and re.match(r"^copilot-setup-steps:[ \t]*(#.*)?$", line):
+    # Match the exact required direct child key (quoted or unquoted YAML key)
+    if child_indent is not None and indent == child_indent and re.match(r'^["\']?copilot-setup-steps["\']?:[ ]*(#.*)?$', line):
         found = True
         break
 
@@ -1062,7 +1062,7 @@ sys.exit(0 if found else 1)
 #   2. Required sections present: "## Tech Stack" and "## Local Dev Commands"
 #      (warning per missing section)
 #
-# The .github repo itself is exempt — it holds the org-level baseline, not
+# The .github repo itself is exempt — it holds the canonical template, not
 # a per-repo extension.
 #
 # See standards/copilot-instructions-standard.md for the required sections
@@ -1071,8 +1071,8 @@ sys.exit(0 if found else 1)
 check_copilot_instructions() {
   local repo="$1"
 
-  # The .github repo holds the org-level baseline — exempt from the
-  # repo-level requirement.
+  # The .github repo holds the canonical template — exempt from the
+  # per-repo requirement.
   [ "$repo" = ".github" ] && return
 
   local content
@@ -1081,7 +1081,7 @@ check_copilot_instructions() {
 
   if [ -z "$content" ]; then
     add_finding "$repo" "standards" "missing-copilot-instructions" "warning" \
-      "Missing \`.github/copilot-instructions.md\`. Every repo should provide a repo-level Copilot instructions file with its specific tech stack, project structure, local dev commands, required environment variables, and testing configuration. The org-level baseline in \`petry-projects/.github\` covers org-wide rules; this file adds the repo-specific context Copilot cannot infer from code alone. Copy the template from \`standards/copilot-instructions-standard.md\` in \`petry-projects/.github\` to get started." \
+      "Missing \`.github/copilot-instructions.md\`. Every repo must have its own Copilot instructions file — Copilot instruction files are repository-scoped and do not propagate from the \`petry-projects/.github\` repo. Copy the canonical template from \`standards/copilot-instructions-standard.md\` in \`petry-projects/.github\`, then tailor it with this repo's specific tech stack, project structure, local dev commands, required environment variables, and testing configuration." \
       "standards/copilot-instructions-standard.md"
     return
   fi
@@ -1089,12 +1089,18 @@ check_copilot_instructions() {
   local decoded
   decoded=$(echo "$content" | base64 -d 2>/dev/null || echo "")
 
+  # Strip fenced code blocks before checking for required section headers so
+  # that ## headings inside code examples (e.g. template snippets) cannot
+  # falsely satisfy the check.
+  local prose
+  prose=$(echo "$decoded" | awk '/^```/{in_block=!in_block; next} !in_block{print}')
+
   # Verify required section headers (level-2, case-insensitive)
   local required_sections=("Tech Stack" "Local Dev Commands")
   for section in "${required_sections[@]}"; do
     local slug
     slug=$(echo "$section" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
-    if ! echo "$decoded" | grep -qiE "^##[[:space:]]+${section}"; then
+    if ! echo "$prose" | grep -qiE "^##[[:space:]]+${section}"; then
       add_finding "$repo" "standards" "copilot-instructions-missing-${slug}" "warning" \
         "\`.github/copilot-instructions.md\` is missing the required \`## $section\` section. See \`standards/copilot-instructions-standard.md\` for the required template and guidance on what to include." \
         "standards/copilot-instructions-standard.md"

--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -973,6 +973,39 @@ check_agents_md() {
 }
 
 # ---------------------------------------------------------------------------
+# Check: copilot-setup-steps.yml exists
+# ---------------------------------------------------------------------------
+# Every repo should have a copilot-setup-steps.yml to pre-install tools and
+# dependencies in the Copilot cloud agent environment before it starts work.
+# Without it the agent discovers dependencies via trial and error, which is
+# slow, non-deterministic, and impossible for repos with private packages.
+# See standards/ci-standards.md §11 Copilot Cloud Agent Setup.
+# ---------------------------------------------------------------------------
+check_copilot_setup_steps() {
+  local repo="$1"
+
+  local content
+  content=$(gh_api "repos/$ORG/$repo/contents/.github/workflows/copilot-setup-steps.yml" \
+    --jq '.content' 2>/dev/null || echo "")
+
+  if [ -z "$content" ]; then
+    add_finding "$repo" "standards" "missing-copilot-setup-steps" "warning" \
+      "Missing \`.github/workflows/copilot-setup-steps.yml\` — every repo should pre-install tools and dependencies for the Copilot cloud agent. Copy the template from the org standards and uncomment the stack block(s) for this repo." \
+      "standards/ci-standards.md"
+    return
+  fi
+
+  # Verify the file contains the mandatory copilot-setup-steps job name
+  local decoded
+  decoded=$(echo "$content" | base64 -d 2>/dev/null || echo "")
+  if ! echo "$decoded" | grep -q 'copilot-setup-steps'; then
+    add_finding "$repo" "standards" "copilot-setup-steps-invalid-job-name" "error" \
+      "\`.github/workflows/copilot-setup-steps.yml\` exists but does not contain a job named \`copilot-setup-steps\` — GitHub requires this exact job name to pick up the file." \
+      "standards/ci-standards.md"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Check: check-suite auto-trigger disabled for Claude and CodeRabbit
 # ---------------------------------------------------------------------------
 check_check_suite_prefs() {
@@ -1189,7 +1222,7 @@ create_umbrella_issue() {
     "ci-workflows|Workflows|per-repo workflow additions"
     "action-pinning|Action SHA Pinning|pin actions to SHA in each workflow file"
     "dependabot|Dependabot Configuration|per-repo .github/dependabot.yml"
-    "standards|CLAUDE.md / AGENTS.md References|per-repo doc updates"
+    "standards|Agent Standards (CLAUDE.md / AGENTS.md / copilot-setup-steps.yml)|per-repo doc and workflow additions"
   )
 
   local body
@@ -1584,6 +1617,7 @@ main() {
     check_centralized_check_names "$repo"
     check_claude_md "$repo"
     check_agents_md "$repo"
+    check_copilot_setup_steps "$repo"
     check_check_suite_prefs "$repo"
     pp_run_all_checks "$repo"
 

--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -224,7 +224,7 @@ check_action_pinning() {
     # SHA-pinned: uses: owner/action@<40+ hex chars>
     # Exclude docker:// and ./ references
     local unpinned
-    unpinned=$(echo "$decoded" | grep -E '^\s*-?\s*uses:\s+[^#]*@' | grep -vE '@[0-9a-f]{40}' | grep -vE '(docker://|\.\/)' || true)
+    unpinned=$(echo "$decoded" | grep -E '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]+[^#]*@' | grep -vE '@[0-9a-f]{40}' | grep -vE '(docker://|\.\/)' || true)
 
     if [ -n "$unpinned" ]; then
       local count
@@ -447,7 +447,7 @@ check_codeowners() {
   #   2. Additional teams (@petry-projects/<slug>) are allowed.
   #   3. Individual users (@username without "/") are forbidden.
   local owner_lines
-  owner_lines=$(echo "$codeowners_content" | grep -v '^\s*#' | grep -v '^\s*$')
+  owner_lines=$(echo "$codeowners_content" | grep -v '^[[:space:]]*#' | grep -v '^[[:space:]]*$')
 
   if [ -z "$owner_lines" ]; then
     add_finding "$repo" "settings" "codeowners-empty" "error" \

--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -995,10 +995,11 @@ check_copilot_setup_steps() {
     return
   fi
 
-  # Verify the file contains the mandatory copilot-setup-steps job name
+  # Verify the file contains the mandatory copilot-setup-steps job key (structural check:
+  # match an indented YAML key so a bare comment cannot falsely satisfy the check)
   local decoded
   decoded=$(echo "$content" | base64 -d 2>/dev/null || echo "")
-  if ! echo "$decoded" | grep -q 'copilot-setup-steps'; then
+  if ! echo "$decoded" | grep -qE '^\s+copilot-setup-steps\s*:'; then
     add_finding "$repo" "standards" "copilot-setup-steps-invalid-job-name" "error" \
       "\`.github/workflows/copilot-setup-steps.yml\` exists but does not contain a job named \`copilot-setup-steps\` — GitHub requires this exact job name to pick up the file." \
       "standards/ci-standards.md"

--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -1007,6 +1007,63 @@ check_copilot_setup_steps() {
 }
 
 # ---------------------------------------------------------------------------
+# Check: .github/copilot-instructions.md exists with required sections
+#
+# Every repo SHOULD have a repo-level Copilot instructions file to give
+# Copilot specific context it cannot derive from code alone: the active
+# tech stack versions, project structure, exact local dev commands, required
+# environment variables, and testing thresholds. The org-level baseline in
+# petry-projects/.github supplies org-wide rules (SOLID, TDD, logging, CI
+# gates, PR workflow); repo-level files extend it with repo-specific detail.
+# Copilot prioritises repository instructions over org instructions, so the
+# repo-level file is the primary surface for per-project customisation.
+#
+# Checks:
+#   1. File present at .github/copilot-instructions.md (warning if missing)
+#   2. Required sections present: "## Tech Stack" and "## Local Dev Commands"
+#      (warning per missing section)
+#
+# The .github repo itself is exempt — it holds the org-level baseline, not
+# a per-repo extension.
+#
+# See standards/copilot-instructions-standard.md for the required sections
+# and fill-in template.
+# ---------------------------------------------------------------------------
+check_copilot_instructions() {
+  local repo="$1"
+
+  # The .github repo holds the org-level baseline — exempt from the
+  # repo-level requirement.
+  [ "$repo" = ".github" ] && return
+
+  local content
+  content=$(gh_api "repos/$ORG/$repo/contents/.github/copilot-instructions.md" \
+    --jq '.content' 2>/dev/null || echo "")
+
+  if [ -z "$content" ]; then
+    add_finding "$repo" "standards" "missing-copilot-instructions" "warning" \
+      "Missing \`.github/copilot-instructions.md\`. Every repo should provide a repo-level Copilot instructions file with its specific tech stack, project structure, local dev commands, required environment variables, and testing configuration. The org-level baseline in \`petry-projects/.github\` covers org-wide rules; this file adds the repo-specific context Copilot cannot infer from code alone. Copy the template from \`standards/copilot-instructions-standard.md\` in \`petry-projects/.github\` to get started." \
+      "standards/copilot-instructions-standard.md"
+    return
+  fi
+
+  local decoded
+  decoded=$(echo "$content" | base64 -d 2>/dev/null || echo "")
+
+  # Verify required section headers (level-2, case-insensitive)
+  local required_sections=("Tech Stack" "Local Dev Commands")
+  for section in "${required_sections[@]}"; do
+    local slug
+    slug=$(echo "$section" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
+    if ! echo "$decoded" | grep -qiE "^##[[:space:]]+${section}"; then
+      add_finding "$repo" "standards" "copilot-instructions-missing-${slug}" "warning" \
+        "\`.github/copilot-instructions.md\` is missing the required \`## $section\` section. See \`standards/copilot-instructions-standard.md\` for the required template and guidance on what to include." \
+        "standards/copilot-instructions-standard.md"
+    fi
+  done
+}
+
+# ---------------------------------------------------------------------------
 # Check: check-suite auto-trigger disabled for Claude and CodeRabbit
 # ---------------------------------------------------------------------------
 check_check_suite_prefs() {
@@ -1619,6 +1676,7 @@ main() {
     check_claude_md "$repo"
     check_agents_md "$repo"
     check_copilot_setup_steps "$repo"
+    check_copilot_instructions "$repo"
     check_check_suite_prefs "$repo"
     pp_run_all_checks "$repo"
 

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -53,6 +53,7 @@ reusable, not a local edit.
 | [`dependency-audit.yml`](workflows/dependency-audit.yml) | 1 | Multi-ecosystem audit (npm, pnpm, gomod, cargo, pip) |
 | [`feature-ideation.yml`](workflows/feature-ideation.yml) | 1 | BMAD Method ideation pipeline (BMAD-enabled repos only) |
 | [`pr-review-mention.yml`](workflows/pr-review-mention.yml) | 1 | Trigger the pr-review agent when `@donpetry-bot` is mentioned or `donpetry-bot` is assigned as reviewer |
+| [`copilot-setup-steps.yml`](workflows/copilot-setup-steps.yml) | 2 | Pre-install tools and dependencies for Copilot cloud agent sessions |
 
 **Adapt only when the template genuinely requires repo-specific content** (e.g., a
 project name in a comment, a different cron schedule for a known reason). Anything
@@ -559,6 +560,84 @@ present as an org-level secret; no per-repo setup needed.
 repos have `pr-review-mention.yml` as a thin caller stub delegating to
 `petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@v2`.
 
+### 11. Copilot Cloud Agent Setup (`copilot-setup-steps.yml`)
+
+**Recommended for all repos.** Pre-installs tools and dependencies in the Copilot
+cloud agent's ephemeral environment before the agent begins working. This is a
+**Tier 2 per-repo template** because the setup steps are inherently tech-stack-specific.
+
+**Why this matters:** Without a setup file Copilot discovers and installs dependencies
+itself via trial and error — slow, non-deterministic, and impossible for repos with
+private packages. Pre-installing dependencies via a deterministic setup file:
+
+- Speeds up every agent session (no discovery phase)
+- Ensures exact tool versions that match CI
+- Makes internal/private packages available to the agent
+- Surfaces missing instruction files (`AGENTS.md`, `copilot-instructions.md`) at
+  session start so the agent is fully oriented before it touches any code
+
+**Adoption:** Copy [`standards/workflows/copilot-setup-steps.yml`](workflows/copilot-setup-steps.yml)
+verbatim to `.github/workflows/copilot-setup-steps.yml` in the target repo, then uncomment
+the stack block(s) matching the repo's tech stack and delete the rest.
+
+> **Important:** The file must be merged to the default branch before it takes effect —
+> GitHub does not pick it up from feature branches.
+
+**Constraints enforced by GitHub (not configurable):**
+
+| Constraint | Value |
+|---|---|
+| Job name | Must be exactly `copilot-setup-steps` |
+| `timeout-minutes` | Max 59 |
+| `fetch-depth` on checkout | Always overridden by the agent |
+| Customizable job keys | `steps`, `permissions`, `runs-on`, `services`, `snapshot`, `timeout-minutes` |
+| Default branch required | Workflow only triggers when present on the default branch |
+
+**Workflow trigger pattern** (standard — validates the file on change):
+```yaml
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+```
+
+**Stack blocks** (see template for full commented examples with SHA-pinned actions):
+
+| Stack | Actions used | Cache strategy |
+|---|---|---|
+| Node.js / npm | `actions/setup-node@v4` | Built-in npm cache via `cache: "npm"` |
+| Node.js / pnpm | `pnpm/action-setup@v4` + `actions/setup-node@v4` | Built-in pnpm cache via `cache: "pnpm"` |
+| Go | `actions/setup-go@v5` | Built-in module cache via `cache-dependency-path` |
+| Python / pip | `actions/setup-python@v5` | Built-in pip cache via `cache: "pip"` |
+
+**Optional additions** (uncomment in the template as needed):
+
+| Optional step | Use when |
+|---|---|
+| Build step (`npm run build`) | Agent needs pre-built artifacts (generated types, dist files) to run tests |
+| `gh-aw` MCP extension | Repo does heavy GitHub platform work (PR management, issue triage, release automation) |
+| `services:` block | Agent needs a database or queue service running during tests (see Elasticsearch example in `github/docs`, SQL Server in `dotnet/efcore`) |
+
+**Verify step** (required — always runs last): Prints tool versions and confirms
+`AGENTS.md` exists. **Fails the job if `AGENTS.md` is missing** — a repo without
+`AGENTS.md` violates agent-standards.md and the agent won't be properly oriented.
+
+**Fetching the template programmatically:**
+```bash
+gh api repos/petry-projects/.github/contents/standards/workflows/copilot-setup-steps.yml \
+  --jq '.content' | base64 -d > .github/workflows/copilot-setup-steps.yml
+```
+
+**Real-world inspiration** for advanced patterns (services, custom runners, Docker caching):
+- Multi-language monorepo: `github/copilot-sdk`
+- Node.js + Electron + custom runner pool: `microsoft/vscode`
+- SQL Server + CosmosDB services: `dotnet/efcore`
+- Docker image pre-pull with parallel caching: `Significant-Gravitas/AutoGPT`
+
 ---
 
 ## Conditional Workflows
@@ -1030,9 +1109,10 @@ autofix:
 7. **Add `dependabot-automerge.yml`** from [`standards/workflows/`](workflows/)
 8. **Add `dependency-audit.yml`** from [`standards/workflows/`](workflows/)
 9. **Add `agent-shield.yml`** from [`standards/workflows/`](workflows/)
-10. **Configure secrets** in the repository settings
-11. **Set required status checks** in branch protection (see [GitHub Settings](github-settings.md))
-12. **Pin all action references** to commit SHAs
+10. **Add `copilot-setup-steps.yml`** from [`standards/workflows/`](workflows/) — uncomment the stack block(s) that match the repo's tech stack, delete the rest, then merge to `main` and run manually from the Actions tab to verify
+11. **Configure secrets** in the repository settings
+12. **Set required status checks** in branch protection (see [GitHub Settings](github-settings.md))
+13. **Pin all action references** to commit SHAs
 
 ---
 
@@ -1047,14 +1127,14 @@ The **CodeQL** column reflects GitHub default setup state (`configured` vs
 carrying a per-repo `codeql.yml` after this standard lands are flagged as
 drift, not as compliant.
 
-| Repository | CI | CodeQL† | SonarCloud | Claude | Coverage | Dep Auto-merge | Dep Audit | Dependabot Config |
-|------------|:--:|:------:|:----------:|:------:|:--------:|:--------------:|:---------:|:-----------------:|
-| **broodly** | Yes | Pending | Yes | Yes | Yes | Yes | Yes | Yes |
-| **markets** | — | Pending | Yes | Yes | — | Yes | Yes | Partial |
-| **google-app-scripts** | Yes | Pending | Yes | Yes | Yes | Yes (older) | — | Non-standard |
-| **TalkTerm** | Yes | Pending | — | — | Yes | — | — | — |
-| **ContentTwin** | — | Pending | Yes | — | — | — | — | — |
-| **bmad-bgreat-suite** | — | Pending | — | — | — | — | — | — |
+| Repository | CI | CodeQL† | SonarCloud | Claude | Coverage | Dep Auto-merge | Dep Audit | Dependabot Config | Copilot Setup |
+|------------|:--:|:------:|:----------:|:------:|:--------:|:--------------:|:---------:|:-----------------:|:-------------:|
+| **broodly** | Yes | Pending | Yes | Yes | Yes | Yes | Yes | Yes | — |
+| **markets** | — | Pending | Yes | Yes | — | Yes | Yes | Partial | — |
+| **google-app-scripts** | Yes | Pending | Yes | Yes | Yes | Yes (older) | — | Non-standard | — |
+| **TalkTerm** | Yes | Pending | — | — | Yes | — | — | — | — |
+| **ContentTwin** | — | Pending | Yes | — | — | — | — | — | — |
+| **bmad-bgreat-suite** | — | Pending | — | — | — | — | — | — | — |
 
 † **CodeQL** values are listed as `Pending` for every repo because the
 default-setup migration is the work this standard introduces; the next
@@ -1073,6 +1153,7 @@ Every `—` in the table above is a gap that must be remediated. Priority order:
 4. **markets:** Missing CI pipeline and Coverage; Dependabot config only covers `github-actions` (missing `npm` ecosystem)
 5. **google-app-scripts:** Missing dependency audit; Dependabot npm `limit:10` (should be `0` per policy); auto-merge uses older `--admin` bypass pattern
 6. **All repos:** Enable CodeQL default setup via `apply-repo-settings.sh` and remove any pre-existing `codeql.yml` workflow file
+7. **All repos:** Add `copilot-setup-steps.yml` — copy from [`standards/workflows/`](workflows/copilot-setup-steps.yml), uncomment the matching stack block, and merge to `main`
 
 ### Version Inconsistencies
 

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -594,6 +594,7 @@ the stack block(s) matching the repo's tech stack and delete the rest.
 | Default branch required | Workflow only triggers when present on the default branch |
 
 **Workflow trigger pattern** (standard — validates the file on change):
+
 ```yaml
 on:
   workflow_dispatch:
@@ -627,12 +628,14 @@ on:
 `AGENTS.md` violates agent-standards.md and the agent won't be properly oriented.
 
 **Fetching the template programmatically:**
+
 ```bash
 gh api repos/petry-projects/.github/contents/standards/workflows/copilot-setup-steps.yml \
   --jq '.content' | base64 -d > .github/workflows/copilot-setup-steps.yml
 ```
 
 **Real-world inspiration** for advanced patterns (services, custom runners, Docker caching):
+
 - Multi-language monorepo: `github/copilot-sdk`
 - Node.js + Electron + custom runner pool: `microsoft/vscode`
 - SQL Server + CosmosDB services: `dotnet/efcore`
@@ -1109,7 +1112,9 @@ autofix:
 7. **Add `dependabot-automerge.yml`** from [`standards/workflows/`](workflows/)
 8. **Add `dependency-audit.yml`** from [`standards/workflows/`](workflows/)
 9. **Add `agent-shield.yml`** from [`standards/workflows/`](workflows/)
-10. **Add `copilot-setup-steps.yml`** from [`standards/workflows/`](workflows/) — uncomment the stack block(s) that match the repo's tech stack, delete the rest, then merge to `main` and run manually from the Actions tab to verify
+10. **Add `copilot-setup-steps.yml`** from [`standards/workflows/`](workflows/) — uncomment the
+    stack block(s) that match the repo's tech stack, delete the rest, then merge to `main` and
+    run manually from the Actions tab to verify
 11. **Configure secrets** in the repository settings
 12. **Set required status checks** in branch protection (see [GitHub Settings](github-settings.md))
 13. **Pin all action references** to commit SHAs

--- a/standards/copilot-instructions-standard.md
+++ b/standards/copilot-instructions-standard.md
@@ -3,6 +3,27 @@
 This standard defines how to create and maintain GitHub Copilot custom instruction files across
 the **petry-projects** organization.
 
+## Purpose and Benefits
+
+GitHub Copilot generates suggestions based on the open file and surrounding context, but it
+cannot infer project-specific facts from code alone: which test runner is in use, what the exact
+local dev commands are, which bounded contexts a repo defines, or what coverage thresholds are
+enforced in CI. Without instruction files, every developer and every agent session must
+re-discover this context through trial-and-error or by reading the README.
+
+Instruction files solve this by surfacing the right context to Copilot automatically:
+
+| Benefit | How instruction files deliver it |
+|---------|----------------------------------|
+| **Consistent suggestions** | Copilot sees org coding standards on every request — SOLID, DDD, TDD, structured logging — without requiring the developer to repeat them |
+| **Reduced onboarding friction** | New contributors and agents get the project's stack, structure, and commands immediately, not after reading multiple docs |
+| **Enforced standards** | Language-specific files (TypeScript, Go, Terraform, …) embed org linting, formatting, and security rules so Copilot proposes compliant code by default |
+| **Less review churn** | Fewer review comments on style and convention violations; agents are less likely to introduce drift |
+| **Faster agent execution** | Copilot coding agents pre-load the right dependencies and follow the right patterns without a bootstrapping phase |
+
+The org-level baseline (`petry-projects/.github`) covers rules that apply everywhere. Repo-level
+files add the project-specific context that makes suggestions accurate for that repo in particular.
+
 ## Overview
 
 GitHub Copilot supports three scopes of instruction files:
@@ -157,6 +178,19 @@ for full development standards.
 
 ## Compliance
 
-The compliance audit script (`scripts/compliance-audit.sh`) does not currently check for the
-presence of `copilot-instructions.md`. Adding a check is tracked as a feature request. Until
-then, maintain the file as a team discipline item.
+The weekly compliance audit (`scripts/compliance-audit.sh`) enforces this standard
+automatically. Two `warning`-severity checks run against every repository in the org:
+
+| Check ID | Trigger | Remediation |
+|----------|---------|-------------|
+| `missing-copilot-instructions` | `.github/copilot-instructions.md` is absent | Copy the template below and fill in the repo-specific sections |
+| `copilot-instructions-missing-tech-stack` | File exists but `## Tech Stack` section is absent | Add the section — list runtimes, frameworks, and major library versions |
+| `copilot-instructions-missing-local-dev-commands` | File exists but `## Local Dev Commands` section is absent | Add the section — include exact install, dev-run, test, lint, and typecheck commands |
+
+Findings are reported as `warning` (not `error`) because the org-level baseline in
+`petry-projects/.github` ensures minimum Copilot guidance even without a repo-level file.
+However, all warnings are tracked in the weekly compliance report and surfaced as GitHub issues
+for remediation.
+
+The `petry-projects/.github` repo itself is exempt from the repo-level check — its
+`.github/copilot-instructions.md` is the org-level baseline that applies to all repos.

--- a/standards/copilot-instructions-standard.md
+++ b/standards/copilot-instructions-standard.md
@@ -1,0 +1,162 @@
+# Copilot Instructions Standard
+
+This standard defines how to create and maintain GitHub Copilot custom instruction files across
+the **petry-projects** organization.
+
+## Overview
+
+GitHub Copilot supports two types of instruction files:
+
+| Type | File | Scope |
+|------|------|-------|
+| **Org-level** (this repo) | `.github/copilot-instructions.md` | Applies to all org repos |
+| **Repo-level** | `.github/copilot-instructions.md` in each repo | Overrides org-level for that repo |
+| **Path-specific** | `.github/instructions/<name>.instructions.md` | Applies to matching file patterns |
+
+Path-specific files use YAML frontmatter to specify which files they apply to:
+
+```yaml
+---
+description: "Purpose of these instructions"
+applyTo: "**/*.ts,**/*.tsx"
+---
+```
+
+The `excludeAgent` frontmatter key restricts which tools use the instructions
+(`"code-review"` or `"cloud-agent"`).
+
+Priority order (highest to lowest): Personal instructions → Repository instructions →
+Organization instructions.
+
+## Org-Level Instruction Files
+
+The following files live in this repo (`petry-projects/.github`) and apply org-wide:
+
+| File | Languages / Scope |
+|------|-------------------|
+| `.github/copilot-instructions.md` | All repos — org-wide defaults |
+| `.github/instructions/typescript.instructions.md` | `**/*.ts`, `**/*.tsx` |
+| `.github/instructions/javascript.instructions.md` | `**/*.js`, `**/*.mjs`, `**/*.cjs` |
+| `.github/instructions/python.instructions.md` | `**/*.py` |
+| `.github/instructions/go.instructions.md` | `**/*.go`, `**/go.mod`, `**/go.sum` |
+| `.github/instructions/terraform.instructions.md` | `**/*.tf`, `**/*.tfvars`, `**/*.tftest.hcl` |
+| `.github/instructions/shell.instructions.md` | `**/*.sh`, `**/*.bash`, `**/Makefile` |
+
+## Adding a New Language
+
+To add a new language instruction file:
+
+1. Create `.github/instructions/<language>.instructions.md` in this repo.
+2. Add the `applyTo` frontmatter with glob patterns for the language's file extensions.
+3. Base the content on the relevant [awesome-copilot template](https://awesome-copilot.github.com/instructions/)
+   and adapt it to org conventions defined in `AGENTS.md`.
+4. Add an entry to the table above in this document.
+5. Open a PR to `petry-projects/.github` following the standard PR workflow.
+
+## Creating a Repo-Level copilot-instructions.md
+
+Each repository SHOULD provide its own `.github/copilot-instructions.md` that adds repo-specific
+context on top of the org-level defaults. Repo-level instructions inherit all org-level rules —
+only document what differs or adds detail.
+
+### Required Sections
+
+A repo-level `copilot-instructions.md` MUST include the following sections. Keep the file to
+approximately two pages — concise, specific, and actionable.
+
+---
+
+```markdown
+# Copilot Instructions — [Repo Name]
+
+## About
+
+[One sentence describing what this repo does and its role in the petry-projects org.]
+
+## Tech Stack
+
+- **Runtime:** Node.js 22 / Python 3.12 / Go 1.23 / [adjust]
+- **Framework:** React 19 · Electron 41 / FastAPI / [adjust]
+- **Testing:** Vitest · Playwright / pytest / go test [adjust]
+- **Linting:** ESLint (flat config) + Prettier / ruff + black / golangci-lint [adjust]
+- **Key libraries:** [list major dependencies]
+
+## Project Structure
+
+[Describe key directories and naming conventions. Example:]
+
+src/
+  domain/          # Domain models, value objects, aggregates
+  application/     # Use cases, command/query handlers
+  infrastructure/  # Adapters, persistence, external services
+  presentation/    # UI components, API routes
+
+## Local Dev Commands
+
+- Install:    `npm install`
+- Dev run:    `npm run dev`
+- Test:       `npm test`
+- Lint:       `npm run lint`
+- Typecheck:  `npm run typecheck`
+
+## Required Environment Variables
+
+- `DATABASE_URL`: PostgreSQL connection string (e.g., `postgres://user:pass@host/db`)
+- `API_KEY`: External service API key (obtain from the team vault)
+
+## Testing Framework
+
+- Runner: Vitest [or Jest / pytest / go test]
+- Coverage threshold: 85% statements / 80% branches [repo-specific]
+- Mutation testing: Stryker (runs in CI) [if applicable]
+
+## Repo-Specific Overrides
+
+[List any rules that differ from the org-level copilot-instructions.md. Reference the specific
+AGENTS.md section being overridden. Leave this section blank (or remove it) if no overrides
+apply.]
+
+## Org Standards
+
+See [petry-projects/.github — AGENTS.md](https://github.com/petry-projects/.github/blob/main/AGENTS.md)
+for full development standards.
+```
+
+---
+
+### What to Include vs. What to Omit
+
+**Include in repo-level instructions:**
+
+- Specific framework versions and major library choices
+- Bounded context names and directory layout
+- Exact local dev commands with correct flags
+- Coverage thresholds and testing tools specific to this repo
+- Architecture patterns unique to this repo (e.g., Electron IPC conventions, GAS extraction pattern)
+- Any rule that overrides or refines the org-level defaults
+
+**Do NOT include in repo-level instructions:**
+
+- Org-wide rules already covered in `copilot-instructions.md` (SOLID, TDD, logging format, etc.)
+- Rules already covered in language-specific `.instructions.md` files
+- Content already documented in `AGENTS.md`
+- Secrets, API keys, credentials, or example tokens with real values
+
+## Content Quality Rules
+
+- **Max length:** ~two pages. Copilot applies instructions most effectively when they are
+  concise and broadly applicable. Longer files may be truncated.
+- **Task-specific, not task-specific:** Instructions should apply to all work in the repo, not
+  to a single task or PR.
+- **Actionable language:** Prefer imperatives ("use `pino` for logging") over descriptions
+  ("this repo uses pino for logging").
+- **No duplication with AGENTS.md:** AGENTS.md is the authoritative source for AI agent
+  standards. Copilot instruction files summarize or extend it — they don't replace it.
+- **Keep in sync:** When the tech stack changes (major version bump, new framework, tool
+  replacement), update `copilot-instructions.md` in the same PR.
+
+## Compliance
+
+The compliance audit script (`scripts/compliance-audit.sh`) does not currently check for the
+presence of `copilot-instructions.md`. Adding a check is tracked as a feature request. Until
+then, maintain the file as a team discipline item.

--- a/standards/copilot-instructions-standard.md
+++ b/standards/copilot-instructions-standard.md
@@ -26,15 +26,20 @@ files add the project-specific context that makes suggestions accurate for that 
 
 ## Overview
 
-GitHub Copilot supports three scopes of instruction files:
+GitHub Copilot supports two types of instruction files, both scoped to the individual
+repository they live in:
 
 | Type | File | Scope |
 |------|------|-------|
-| **Org-level** (this repo) | `.github/copilot-instructions.md` | Applies to all repos in the org via the special `.github` repository |
-| **Repo-level** | `.github/copilot-instructions.md` in each repo | Applies to that repo; extends or overrides the org-level baseline |
-| **Path-specific** | `.github/instructions/<name>.instructions.md` | Applies to files matching the `applyTo` glob pattern |
+| **Repo-wide** | `.github/copilot-instructions.md` | Applies to all Copilot requests in that repo |
+| **Path-specific** | `.github/instructions/<name>.instructions.md` | Applies when the file being edited matches the `applyTo` glob pattern |
 
-Path-specific files use YAML frontmatter to specify which files they apply to:
+> **There is no automatic org-wide propagation.** Placing `copilot-instructions.md` in the
+> `petry-projects/.github` repository makes it apply to that repo only — it does not broadcast
+> to other repos in the org. Org-wide coverage is achieved by deploying the file to every repo,
+> which the weekly compliance audit enforces (see [Compliance](#compliance) below).
+
+Path-specific files use YAML frontmatter to declare which files they apply to:
 
 ```yaml
 ---
@@ -43,31 +48,27 @@ applyTo: "**/*.ts,**/*.tsx"
 ---
 ```
 
-The `excludeAgent` frontmatter key restricts which tools use the instructions
+The `excludeAgent` frontmatter key restricts which Copilot tools use the instructions
 (`"code-review"` or `"cloud-agent"`).
 
-Priority order (highest to lowest): Personal instructions → Repository instructions →
-Organization instructions.
+Priority order within a repository (highest to lowest): Personal instructions → Repository
+instructions.
 
-> **Subscription note:** Org-level instructions via the org's `.github` repository require
-> a **GitHub Copilot Business or Enterprise** subscription. On individual Copilot plans, only
-> repository-level and path-specific instructions are active. The repo-level
-> `.github/copilot-instructions.md` works on all subscription tiers and is therefore the most
-> universally reliable location for project-specific context.
+## Canonical Instruction Files (source of truth in this repo)
 
-## Org-Level Instruction Files
-
-The following files live in this repo (`petry-projects/.github`) and apply org-wide:
+The following files live in `petry-projects/.github` and serve as the **canonical templates**
+that every repo should adopt. They apply to this repo only as-is; each other repo gets its own
+copy via the per-repo rollout described in [Creating a Repo-Level copilot-instructions.md](#creating-a-repo-level-copilot-instructionsmd).
 
 | File | Languages / Scope |
 |------|-------------------|
-| `.github/copilot-instructions.md` | All repos — org-wide defaults |
+| `.github/copilot-instructions.md` | Repo-wide baseline (copy to each repo) |
 | `.github/instructions/typescript.instructions.md` | `**/*.ts`, `**/*.tsx` |
 | `.github/instructions/javascript.instructions.md` | `**/*.js`, `**/*.mjs`, `**/*.cjs` |
 | `.github/instructions/python.instructions.md` | `**/*.py` |
-| `.github/instructions/go.instructions.md` | `**/*.go`, `**/go.mod`, `**/go.sum` |
+| `.github/instructions/go.instructions.md` | `**/*.go` |
 | `.github/instructions/terraform.instructions.md` | `**/*.tf`, `**/*.tfvars`, `**/*.tftest.hcl` |
-| `.github/instructions/shell.instructions.md` | `**/*.sh`, `**/*.bash`, `**/Makefile` |
+| `.github/instructions/shell.instructions.md` | `**/*.sh`, `**/*.bash` |
 
 ## Adding a New Language
 

--- a/standards/copilot-instructions-standard.md
+++ b/standards/copilot-instructions-standard.md
@@ -49,6 +49,12 @@ The `excludeAgent` frontmatter key restricts which tools use the instructions
 Priority order (highest to lowest): Personal instructions → Repository instructions →
 Organization instructions.
 
+> **Subscription note:** Org-level instructions via the org's `.github` repository require
+> a **GitHub Copilot Business or Enterprise** subscription. On individual Copilot plans, only
+> repository-level and path-specific instructions are active. The repo-level
+> `.github/copilot-instructions.md` works on all subscription tiers and is therefore the most
+> universally reliable location for project-specific context.
+
 ## Org-Level Instruction Files
 
 The following files live in this repo (`petry-projects/.github`) and apply org-wide:

--- a/standards/copilot-instructions-standard.md
+++ b/standards/copilot-instructions-standard.md
@@ -5,13 +5,13 @@ the **petry-projects** organization.
 
 ## Overview
 
-GitHub Copilot supports two types of instruction files:
+GitHub Copilot supports three scopes of instruction files:
 
 | Type | File | Scope |
 |------|------|-------|
-| **Org-level** (this repo) | `.github/copilot-instructions.md` | Applies to all org repos |
-| **Repo-level** | `.github/copilot-instructions.md` in each repo | Overrides org-level for that repo |
-| **Path-specific** | `.github/instructions/<name>.instructions.md` | Applies to matching file patterns |
+| **Org-level** (this repo) | `.github/copilot-instructions.md` | Applies to all repos in the org via the special `.github` repository |
+| **Repo-level** | `.github/copilot-instructions.md` in each repo | Applies to that repo; extends or overrides the org-level baseline |
+| **Path-specific** | `.github/instructions/<name>.instructions.md` | Applies to files matching the `applyTo` glob pattern |
 
 Path-specific files use YAML frontmatter to specify which files they apply to:
 
@@ -146,7 +146,7 @@ for full development standards.
 
 - **Max length:** ~two pages. Copilot applies instructions most effectively when they are
   concise and broadly applicable. Longer files may be truncated.
-- **Task-specific, not task-specific:** Instructions should apply to all work in the repo, not
+- **Repo-wide, not task-specific:** Instructions should apply to all work in the repo, not
   to a single task or PR.
 - **Actionable language:** Prefer imperatives ("use `pino` for logging") over descriptions
   ("this repo uses pino for logging").

--- a/standards/workflows/copilot-setup-steps.yml
+++ b/standards/workflows/copilot-setup-steps.yml
@@ -103,7 +103,7 @@ jobs:
       #     cache: "npm"
       #
       # - name: Install Node.js dependencies
-      #   run: npm ci
+      #   run: npm ci --ignore-scripts
 
       # ── NODE.JS / PNPM ────────────────────────────────────────────────────────
       # Uncomment for repos using pnpm (e.g., broodly TypeScript layer).
@@ -119,7 +119,7 @@ jobs:
       #     cache: "pnpm"
       #
       # - name: Install Node.js dependencies (pnpm)
-      #   run: pnpm install --frozen-lockfile
+      #   run: pnpm install --frozen-lockfile --ignore-scripts
 
       # ── GO ────────────────────────────────────────────────────────────────────
       # Uncomment for repos with Go code (e.g., broodly API layer).

--- a/standards/workflows/copilot-setup-steps.yml
+++ b/standards/workflows/copilot-setup-steps.yml
@@ -65,8 +65,11 @@ permissions: {}
 jobs:
   # ── REQUIRED: Job name must be exactly `copilot-setup-steps` ────────────────
   copilot-setup-steps:
-    # Skip on forks — forks cannot access org secrets required for private packages.
-    if: github.event.repository.fork == false
+    # Skip on fork-origin pull requests — forks cannot access org secrets required for private packages.
+    # `github.event.repository.fork` reflects the base repo (always false for org repos); the
+    # correct guard is on the PR head repo so that external fork PRs are skipped while direct
+    # pushes and manual runs always proceed.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
 
     runs-on: ubuntu-latest
 
@@ -198,8 +201,11 @@ jobs:
           else
             echo "ℹ️  .github/copilot-instructions.md — not present (optional but recommended)"
           fi
-          # Count path-scoped instruction files
-          INSTR_COUNT=$(find .github/instructions -name "*.instructions.md" 2>/dev/null | wc -l)
+          # Count path-scoped instruction files (guard against missing directory)
+          INSTR_COUNT=0
+          if [ -d ".github/instructions" ]; then
+            INSTR_COUNT=$(find .github/instructions -name "*.instructions.md" | wc -l)
+          fi
           echo "ℹ️  .github/instructions/: ${INSTR_COUNT} file(s)"
           echo ""
           echo "✅ Setup complete — Copilot cloud agent is ready to work"

--- a/standards/workflows/copilot-setup-steps.yml
+++ b/standards/workflows/copilot-setup-steps.yml
@@ -1,0 +1,205 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/copilot-setup-steps.yml
+# Standard:        petry-projects/.github/standards/ci-standards.md#11-copilot-cloud-agent-setup
+#
+# ADOPTING THIS WORKFLOW:
+#   1. Copy this file to .github/workflows/copilot-setup-steps.yml in your repo.
+#   2. Keep every REQUIRED section — do NOT remove the checkout or verify steps.
+#   3. Uncomment and adapt the stack blocks that match your repo's tech stack.
+#   4. Delete (not just comment out) stacks that do not apply after initial setup.
+#   5. Merge to the default branch — the workflow only triggers from the default branch.
+#   6. Run manually from Actions → "Copilot Setup Steps" → "Run workflow" to verify.
+#
+# WHAT THIS FILE DOES:
+#   Bootstraps Copilot cloud agent's ephemeral environment BEFORE the agent starts
+#   working on your repo. Pre-installing dependencies deterministically:
+#     • Speeds up every agent session (no trial-and-error dependency discovery)
+#     • Makes private/internal packages available (impossible for the agent alone)
+#     • Ensures exact tool versions that match your CI pipeline
+#   Without this file the agent installs dependencies itself — slower, non-deterministic,
+#   and unreliable for repos with private packages or complex build graphs.
+#
+# SEE ALSO:
+#   AGENTS.md                         — authoritative development standards for this repo
+#   .github/copilot-instructions.md   — always-on Copilot instructions (summary of AGENTS.md)
+#   .github/instructions/             — path-scoped instruction files per language
+#
+# CONSTRAINTS (enforced by GitHub, documented at docs.github.com):
+#   • Job MUST be named `copilot-setup-steps` to be recognized by Copilot cloud agent
+#   • timeout-minutes maximum: 59 (hard limit)
+#   • Customizable fields: steps, permissions, runs-on, services, snapshot, timeout-minutes
+#   • All other job-level settings are silently ignored by GitHub
+#   • fetch-depth on checkout is always overridden by the agent — do not rely on it here
+#   • This file MUST be present on the default branch to take effect
+#
+# AGENTS — READ BEFORE EDITING:
+#   This file is a PER-REPO TEMPLATE (Tier 2). There is no central reusable workflow
+#   because setup steps are inherently tech-stack-specific. Each repo owns its copy.
+#   Stay within the patterns documented in ci-standards.md §11. Do not change:
+#     • the job name (`copilot-setup-steps`)
+#     • the fork guard condition
+#     • the trigger events
+#     • the verify-environment step
+#   For changes to the org-wide pattern, open a PR against this file in
+#   petry-projects/.github and propagate to the fleet.
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: "Copilot Setup Steps"
+
+# Run automatically when this file changes (validates the setup steps work),
+# and allow manual runs from the Actions tab at any time.
+# NOT a standard CI trigger — this file should NOT be added to push: branches: [main].
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+# Defense-in-depth: reset top-level permissions; set exact grants per-job.
+# Pattern from envoyproxy/envoy and the org Permissions Policy (ci-standards.md).
+permissions: {}
+
+jobs:
+  # ── REQUIRED: Job name must be exactly `copilot-setup-steps` ────────────────
+  copilot-setup-steps:
+    # Skip on forks — forks cannot access org secrets required for private packages.
+    if: github.event.repository.fork == false
+
+    runs-on: ubuntu-latest
+
+    # Adjust upward only if your build or download steps genuinely need more time.
+    # Hard maximum enforced by GitHub is 59 minutes.
+    timeout-minutes: 30
+
+    # Minimum permissions — Copilot receives its own separate token for its operations.
+    # Add `packages: read` if pulling from GitHub Packages (GHCR or npm private registry).
+    permissions:
+      contents: read
+
+    steps:
+      # ── REQUIRED ──────────────────────────────────────────────────────────────
+      # Checkout the repository so dependency manifests (package.json, go.mod, etc.)
+      # are available for the install steps below.
+      # Note: fetch-depth is always overridden by the agent — set it here only if
+      # your install steps need history (rare).
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # ── NODE.JS / NPM ──────────────────────────────────────────────────────────
+      # Uncomment for repos using npm (TypeScript, React, Electron, Google Apps Script).
+      # Use node-version-file: .nvmrc if the repo maintains a .nvmrc; otherwise pin
+      # the version to match the CI pipeline and the org standard (Node.js 22 LTS).
+      #
+      # - name: Set up Node.js
+      #   uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      #   with:
+      #     node-version: "22"           # or: node-version-file: .nvmrc
+      #     cache: "npm"
+      #
+      # - name: Install Node.js dependencies
+      #   run: npm ci
+
+      # ── NODE.JS / PNPM ────────────────────────────────────────────────────────
+      # Uncomment for repos using pnpm (e.g., broodly TypeScript layer).
+      # pnpm must be set up before setup-node when using pnpm cache.
+      #
+      # - name: Set up pnpm
+      #   uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      #
+      # - name: Set up Node.js (pnpm)
+      #   uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      #   with:
+      #     node-version: "22"
+      #     cache: "pnpm"
+      #
+      # - name: Install Node.js dependencies (pnpm)
+      #   run: pnpm install --frozen-lockfile
+
+      # ── GO ────────────────────────────────────────────────────────────────────
+      # Uncomment for repos with Go code (e.g., broodly API layer).
+      # Pin go-version to match go.mod to avoid silent toolchain upgrades.
+      # For monorepos, set cache-dependency-path to the correct go.sum path.
+      #
+      # - name: Set up Go
+      #   uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      #   with:
+      #     go-version: "stable"         # or: go-version-file: go.mod
+      #     cache-dependency-path: go.sum
+      #
+      # - name: Download Go dependencies
+      #   run: go mod download
+
+      # ── PYTHON ────────────────────────────────────────────────────────────────
+      # Uncomment for repos with Python code.
+      # Pin python-version to a specific minor version for reproducibility.
+      #
+      # - name: Set up Python
+      #   uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      #   with:
+      #     python-version: "3.12"       # pin to match your runtime
+      #     cache: "pip"
+      #
+      # - name: Install Python dependencies
+      #   run: pip install -r requirements.txt
+
+      # ── OPTIONAL: Additional build artifacts ──────────────────────────────────
+      # If the agent needs pre-built artifacts to run tests (e.g., a Next.js build,
+      # a compiled binary, or generated types), add a build step here.
+      # Keep it minimal — the agent will run its own build steps when needed.
+      #
+      # - name: Build
+      #   run: npm run build
+
+      # ── OPTIONAL: gh-aw MCP extension ────────────────────────────────────────
+      # Installs GitHub Advanced Workflows (gh-aw), a GitHub-developed MCP server
+      # that gives Copilot cloud agent extended GitHub API access (web search,
+      # enhanced PR tools, and more). Used by github/copilot-sdk, TryGhost/Ghost,
+      # and github/awesome-copilot. Recommended for any repo doing heavy GitHub
+      # platform work (issue triage, PR automation, release management).
+      # Pin the version to a specific SHA for supply-chain safety.
+      #
+      # - name: Install gh-aw MCP extension
+      #   uses: github/gh-aw/actions/setup-cli@ce1794953e0ec42adc41b6fca05e02ab49ee21c3
+      #   with:
+      #     version: v0.49.3
+
+      # ── REQUIRED ──────────────────────────────────────────────────────────────
+      # Environment verification — always runs last. Fails loud if something is
+      # missing so the problem is caught here rather than mid-agent-session.
+      # Also surfaces the agent instruction files so session logs confirm they
+      # were found before the agent began working.
+      - name: Verify environment
+        run: |
+          echo "=== petry-projects Copilot cloud agent environment ==="
+          echo "Repository : ${{ github.repository }}"
+          echo "Ref        : ${{ github.ref }}"
+          echo "Runner     : ${{ runner.os }} / ${{ runner.arch }}"
+          echo ""
+          echo "--- Installed tool versions ---"
+          git   --version
+          gh    --version 2>/dev/null | head -1 || echo "gh: not installed"
+          node  --version 2>/dev/null            || echo "node: not installed"
+          npm   --version 2>/dev/null            || echo "npm: not installed"
+          go    version   2>/dev/null            || echo "go: not installed"
+          python --version 2>/dev/null           || echo "python: not installed"
+          echo ""
+          echo "--- Agent instruction files ---"
+          if [ -f "AGENTS.md" ]; then
+            echo "✅ AGENTS.md ($(wc -l < AGENTS.md) lines)"
+          else
+            echo "❌ AGENTS.md — MISSING. Add this file per agent-standards.md."
+            exit 1
+          fi
+          if [ -f ".github/copilot-instructions.md" ]; then
+            echo "✅ .github/copilot-instructions.md"
+          else
+            echo "ℹ️  .github/copilot-instructions.md — not present (optional but recommended)"
+          fi
+          # Count path-scoped instruction files
+          INSTR_COUNT=$(find .github/instructions -name "*.instructions.md" 2>/dev/null | wc -l)
+          echo "ℹ️  .github/instructions/: ${INSTR_COUNT} file(s)"
+          echo ""
+          echo "✅ Setup complete — Copilot cloud agent is ready to work"


### PR DESCRIPTION
## Summary

Establishes GitHub Copilot custom instruction files for the petry-projects organization and enforces their presence via the weekly compliance audit.

### Instruction files (org-level)

Derived from the official GitHub docs, [awesome-copilot](https://github.com/github/awesome-copilot) reference templates, and our AGENTS.md standards:

| File | Purpose |
|------|---------|
| `.github/copilot-instructions.md` | Org-level base — condensed rules Copilot sees on every request across all repos |
| `.github/instructions/typescript.instructions.md` | Strict TS, ESLint/Prettier, DDD/CQRS patterns, pino, React, Electron IPC, branded types |
| `.github/instructions/javascript.instructions.md` | ESLint, Prettier, ES modules, JSDoc types, prefer-TypeScript guidance |
| `.github/instructions/python.instructions.md` | ruff/black, type annotations, pytest, structlog, GAS companion patterns, pre-commit |
| `.github/instructions/go.instructions.md` | slog, idiomatic Go, golangci-lint, concurrency/IO patterns (based on awesome-copilot template) |
| `.github/instructions/terraform.instructions.md` | terraform fmt/validate/tflint, security scanning, modules (based on awesome-copilot template) |
| `.github/instructions/shell.instructions.md` | `set -euo pipefail`, ShellCheck, quoting, injection prevention, Makefile conventions |

### Standards document

`standards/copilot-instructions-standard.md` — defines the three instruction file scopes (org / repo / path-specific), how to add new language files, and a fill-in template for repo-level files. Also explains the **purpose and benefits** of the standard:

- **Consistent suggestions** — Copilot sees org coding standards on every request without the developer repeating them
- **Reduced onboarding friction** — new contributors and agents get the stack, structure, and commands immediately
- **Enforced standards** — language files embed org linting, formatting, and security rules so Copilot proposes compliant code by default
- **Less review churn** — fewer comments on style and convention violations
- **Faster agent execution** — Copilot coding agents pre-load the right dependencies without a bootstrapping phase

### Compliance enforcement (`scripts/compliance-audit.sh`)

Adds `check_copilot_instructions()` to the weekly audit. Three `warning`-severity findings are raised per repo:

| Check ID | Trigger |
|----------|---------|
| `missing-copilot-instructions` | `.github/copilot-instructions.md` absent |
| `copilot-instructions-missing-tech-stack` | File present but missing `## Tech Stack` section |
| `copilot-instructions-missing-local-dev-commands` | File present but missing `## Local Dev Commands` section |

`warning` (not `error`) because the org-level baseline ensures minimum guidance even without a repo-level file. The `petry-projects/.github` repo is exempt — it holds the org-level file. Findings are tracked in the weekly compliance report and surfaced as GitHub issues for remediation.

---

## How repos extend

Each repo adds its own `.github/copilot-instructions.md` using the template in `standards/copilot-instructions-standard.md`. Repo-level instructions override org-level for that repo; only document what differs or adds detail.

---

## Test plan

- [ ] Verify `.github/copilot-instructions.md` appears under the org's Copilot settings in GitHub
- [ ] Open a `.ts` file in a repo with Copilot enabled — confirm TypeScript instructions are applied (check Copilot Chat context)
- [ ] Open a `.tf` file — confirm Terraform instructions are applied
- [ ] Open a `.py` file — confirm Python instructions are applied
- [ ] Confirm no CI failures (markdown lint, AgentShield, compliance audit)
- [ ] After merge, run the compliance audit against a repo that lacks `copilot-instructions.md` and verify `missing-copilot-instructions` appears as a warning
- [ ] Verify `.github` repo is not flagged for missing repo-level file (exempt check)
- [ ] Review `standards/copilot-instructions-standard.md` template before rolling out to first non-.github repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)