### PR TITLE
refactor(org-status): replace Claude with programmatic report generation

### DIFF
--- a/.github/workflows/daily-org-status.yml
+++ b/.github/workflows/daily-org-status.yml
@@ -19,20 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: '20'
-
-      - name: Install Claude Code CLI
-        # postinstall (node install.cjs) downloads the claude binary — required for the CLI to function
-        run: npm install -g @anthropic-ai/claude-code@2.1.132  # NOSONAR: postinstall is the Anthropic binary fetcher, not an arbitrary script
-
       - name: Generate org status report
         env:
           GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
-          chmod +x scripts/org_status.sh
+          chmod +x scripts/org_status.sh scripts/org_report.sh
           bash scripts/org_status.sh > /tmp/report.md
           [ -s /tmp/report.md ] || { echo "Report is empty — aborting"; exit 1; }
 

--- a/scripts/org_report.sh
+++ b/scripts/org_report.sh
@@ -201,7 +201,7 @@ section_needs_review() {
     local repo number title url opened ci approvals
     repo=$(printf '%s' "$pr" | jq -r '.repo')
     number=$(printf '%s' "$pr" | jq -r '.number')
-    title=$(printf '%s' "$pr" | jq -r '.title | gsub("|"; "\\|")')
+    title=$(printf '%s' "$pr" | jq -r '.title | gsub("[|]"; "\\|")')
     url=$(printf '%s' "$pr" | jq -r '.url')
     opened=$(printf '%s' "$pr" | jq -r '.opened')
     ci=$(printf '%s' "$pr" | jq -r '.ci // ""')
@@ -263,7 +263,7 @@ section_open_issues() {
     while IFS= read -r issue; do
       local number title url opened labels linked_pr
       number=$(printf '%s' "$issue" | jq -r '.number')
-      title=$(printf '%s' "$issue" | jq -r '.title | gsub("|"; "\\|")')
+      title=$(printf '%s' "$issue" | jq -r '.title | gsub("[|]"; "\\|")')
       url=$(printf '%s' "$issue" | jq -r '.url')
       opened=$(printf '%s' "$issue" | jq -r '.createdAt | split("T")[0]')
       labels=$(printf '%s' "$issue" | jq -r '[.labels[].name] | join(", ")')
@@ -295,7 +295,7 @@ section_open_discussions() {
     while IFS= read -r disc; do
       local number title url opened replies
       number=$(printf '%s' "$disc" | jq -r '.number')
-      title=$(printf '%s' "$disc" | jq -r '.title | gsub("|"; "\\|")')
+      title=$(printf '%s' "$disc" | jq -r '.title | gsub("[|]"; "\\|")')
       url=$(printf '%s' "$disc" | jq -r '.url')
       opened=$(printf '%s' "$disc" | jq -r '.createdAt | split("T")[0]')
       replies=$(printf '%s' "$disc" | jq -r '.comments.totalCount')

--- a/scripts/org_report.sh
+++ b/scripts/org_report.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# org_report.sh — programmatic markdown report builder for daily org status.
+# Sourced by org_status.sh after data collection completes.
+#
+# Required env vars (all set by org_status.sh):
+#   ALL_PRS, PR_BY_REPO, NEEDS_REVIEW_PRS, ISSUE_PR_MAP,
+#   MERGE_DAILY, MERGE_BY_REPO_DAY, ISSUES_BY_REPO_TRIMMED,
+#   DISCUSSIONS, TODAY, NEEDS_REBASE_COUNT, ISSUE_LIMIT
+
+# fmt_month_day <YYYY-MM-DD> → "Mon-DD"
+fmt_month_day() {
+  date -u -d "$1" +"%b-%d" 2>/dev/null || date -u -jf "%Y-%m-%d" "$1" +"%b-%d"
+}
+
+# ci_label <ci_value> → "PASS" | "FAIL" | "PENDING" | "N/A"
+ci_label() {
+  case "$1" in
+    SUCCESS)           printf 'PASS'    ;;
+    FAILURE|ERROR)     printf 'FAIL'    ;;
+    PENDING|EXPECTED)  printf 'PENDING' ;;
+    *)                 printf 'N/A'     ;;
+  esac
+}
+
+# ── Section: Org Summary ──────────────────────────────────────────────────────
+section_org_summary() {
+  local total_prs total_issues total_merges open_discussions
+  total_prs=$(printf '%s' "$ALL_PRS" | jq 'length')
+  total_issues=$(printf '%s' "$ISSUES_BY_REPO_TRIMMED" | jq '[.[].count] | add // 0')
+  total_merges=$(printf '%s' "$MERGE_DAILY" | jq '[.[].org] | add // 0')
+  open_discussions=$(printf '%s' "$DISCUSSIONS" | jq '[.[].discussions | length] | add // 0')
+
+  printf '## Org Summary — %s\n\n' "$TODAY"
+  printf '| Metric | Value |\n|---|---|\n'
+  printf '| Total open PRs | %s |\n'           "$total_prs"
+  printf '| PRs needing rebase | %s |\n'        "$NEEDS_REBASE_COUNT"
+  printf '| Total open issues | %s |\n'         "$total_issues"
+  printf '| PR merges (last 8 days) | %s |\n'   "$total_merges"
+  printf '| Open discussions | %s |\n\n'        "$open_discussions"
+
+  # Mermaid pie chart — PR categories
+  printf '```mermaid\npie title Open PRs by Status\n'
+  printf '%s' "$PR_BY_REPO" | jq -r '
+    {
+      "Draft":              ([.[].draft]             | add // 0),
+      "CI Failing":         ([.[].ci_failing]        | add // 0),
+      "CI Pending":         ([.[].ci_pending]        | add // 0),
+      "Changes Requested":  ([.[].changes_requested] | add // 0),
+      "Approved":           ([.[].approved]          | add // 0),
+      "Awaiting Review":    ([.[].awaiting_review]   | add // 0),
+      "No CI / No Policy":  ([.[].no_ci_policy]      | add // 0)
+    } | to_entries | map(select(.value > 0)) | sort_by(-.value)[] |
+    "    \"" + .key + "\" : " + (.value | tostring)'
+  printf '```\n\n'
+}
+
+# ── Section: Open PRs — Why They're Unmerged ─────────────────────────────────
+section_open_prs() {
+  local total_prs
+  total_prs=$(printf '%s' "$ALL_PRS" | jq 'length')
+  printf "## Open PRs — Why They're Unmerged (%s total)\n\n" "$total_prs"
+
+  # Org-wide category bar chart
+  local chart_data labels values
+  chart_data=$(printf '%s' "$PR_BY_REPO" | jq -c '
+    {
+      "Draft":              ([.[].draft]             | add // 0),
+      "CI Failing":         ([.[].ci_failing]        | add // 0),
+      "CI Pending":         ([.[].ci_pending]        | add // 0),
+      "Changes Requested":  ([.[].changes_requested] | add // 0),
+      "Approved":           ([.[].approved]          | add // 0),
+      "Awaiting Review":    ([.[].awaiting_review]   | add // 0),
+      "No CI / No Policy":  ([.[].no_ci_policy]      | add // 0)
+    } | to_entries | map(select(.value > 0)) | sort_by(-.value)')
+  labels=$(printf '%s' "$chart_data" | jq -r 'map("\"" + .key + "\"") | join(", ")')
+  values=$(printf '%s' "$chart_data" | jq -r 'map(.value | tostring) | join(", ")')
+
+  printf '```mermaid\nxychart-beta\n'
+  printf '    title "Open PRs by Blocker Category"\n'
+  printf '    x-axis [%s]\n' "$labels"
+  printf '    y-axis "Count"\n'
+  printf '    bar [%s]\n' "$values"
+  printf '```\n\n'
+
+  # Per-repo grouped bar chart — 4 key categories, repos sorted by total desc
+  local repos_sorted short_names nc_vals ar_vals cf_vals ap_vals
+  repos_sorted=$(printf '%s' "$PR_BY_REPO" | jq -c 'map(select(.total > 0)) | sort_by(-.total)')
+  short_names=$(printf '%s' "$repos_sorted" | jq -r 'map("\"" + (.repo | split("/")[1]) + "\"") | join(", ")')
+  nc_vals=$(printf '%s' "$repos_sorted" | jq -r 'map(.no_ci_policy  | tostring) | join(", ")')
+  ar_vals=$(printf '%s' "$repos_sorted" | jq -r 'map(.awaiting_review | tostring) | join(", ")')
+  cf_vals=$(printf '%s' "$repos_sorted" | jq -r 'map(.ci_failing    | tostring) | join(", ")')
+  ap_vals=$(printf '%s' "$repos_sorted" | jq -r 'map(.approved      | tostring) | join(", ")')
+
+  printf '```mermaid\nxychart-beta\n'
+  printf '    title "Open PRs per Repo by Category"\n'
+  printf '    x-axis [%s]\n' "$short_names"
+  printf '    y-axis "PRs"\n'
+  printf '    bar [%s]\n' "$nc_vals"
+  printf '    bar [%s]\n' "$ar_vals"
+  printf '    bar [%s]\n' "$cf_vals"
+  printf '    bar [%s]\n' "$ap_vals"
+  printf '```\n\n'
+}
+
+# ── Section: PR Merge Activity ────────────────────────────────────────────────
+section_merge_activity() {
+  printf '## PR Merge Activity — Last 8 Days\n\n'
+
+  # Daily bar chart — build label/value arrays via bash loop (needs fmt_month_day)
+  local date_labels="" daily_counts=""
+  while IFS=$'\t' read -r d c; do
+    local lbl
+    lbl=$(fmt_month_day "$d")
+    date_labels="${date_labels}\"${lbl}\","
+    daily_counts="${daily_counts}${c},"
+  done < <(printf '%s' "$MERGE_DAILY" | jq -r '.[] | [.date, (.org | tostring)] | @tsv')
+  date_labels="${date_labels%,}"
+  daily_counts="${daily_counts%,}"
+
+  printf '```mermaid\nxychart-beta\n'
+  printf '    title "petry-projects Merges — Last 8 Days"\n'
+  printf '    x-axis [%s]\n' "$date_labels"
+  printf '    y-axis "Merges"\n'
+  printf '    bar [%s]\n' "$daily_counts"
+  printf '```\n\n'
+
+  # Per-repo per-day table
+  local -a dates_arr
+  mapfile -t dates_arr < <(printf '%s' "$MERGE_DAILY" | jq -r '.[].date')
+
+  # Build header
+  local header_dates="" sep_dates=""
+  for d in "${dates_arr[@]}"; do
+    local hdr
+    hdr=$(fmt_month_day "$d")
+    header_dates="${header_dates} ${hdr} |"
+    sep_dates="${sep_dates}---|"
+  done
+  printf '| Repo |%s Total |\n' "$header_dates"
+  printf '|---|%s---|\n' "$sep_dates"
+
+  # Accumulate column totals
+  local -a date_totals
+  for _ in "${dates_arr[@]}"; do date_totals+=(0); done
+  local grand_total=0
+
+  while IFS= read -r row; do
+    local repo row_total
+    repo=$(printf '%s' "$row" | jq -r '.repo')
+    row_total=$(printf '%s' "$row" | jq -r '.total')
+    [[ "$row_total" =~ ^[0-9]+$ ]] && [ "$row_total" -eq 0 ] && continue
+
+    printf '| [%s](https://github.com/%s) |' "$repo" "$repo"
+    local i=0
+    for d in "${dates_arr[@]}"; do
+      local cnt
+      cnt=$(printf '%s' "$row" | jq -r --arg d "$d" '.by_date[$d] // 0')
+      printf ' %s |' "$cnt"
+      date_totals[$i]=$(( ${date_totals[$i]} + cnt ))
+      i=$(( i + 1 ))
+    done
+    grand_total=$(( grand_total + row_total ))
+    printf ' **%s** |\n' "$row_total"
+  done < <(printf '%s' "$MERGE_BY_REPO_DAY" | jq -c '.[]')
+
+  # Grand total row
+  printf '| **TOTAL** |'
+  for cnt in "${date_totals[@]}"; do
+    printf ' %s |' "$cnt"
+  done
+  printf ' **%s** |\n\n' "$grand_total"
+
+  # Trend sentence
+  local -a counts_arr
+  mapfile -t counts_arr < <(printf '%s' "$MERGE_DAILY" | jq -r '.[].org')
+  local n=${#counts_arr[@]}
+  if [ "$n" -ge 6 ]; then
+    local first3=0 last3=0
+    first3=$(( ${counts_arr[0]} + ${counts_arr[1]} + ${counts_arr[2]} ))
+    last3=$(( ${counts_arr[n-3]} + ${counts_arr[n-2]} + ${counts_arr[n-1]} ))
+    local trend="Flat"
+    [ "$last3" -gt "$first3" ] && trend="Increasing"
+    [ "$last3" -lt "$first3" ] && trend="Decreasing"
+    printf 'Grand total: **%s** merges over 8 days. Trend: **%s**.\n\n' "$grand_total" "$trend"
+  fi
+}
+
+# ── Section: PRs Needing Human Review ────────────────────────────────────────
+section_needs_review() {
+  printf '## Open PRs — Needs Human Review\n\n'
+
+  local count
+  count=$(printf '%s' "$NEEDS_REVIEW_PRS" | jq 'length')
+  if [ "$count" -eq 0 ]; then
+    printf '_none_\n\n'
+    return
+  fi
+
+  printf '| Repo | PR | Opened | CI | Approvals |\n|---|---|---|---|---|\n'
+  while IFS= read -r pr; do
+    local repo number title url opened ci approvals
+    repo=$(printf '%s' "$pr" | jq -r '.repo')
+    number=$(printf '%s' "$pr" | jq -r '.number')
+    title=$(printf '%s' "$pr" | jq -r '.title | gsub("|"; "\\|")')
+    url=$(printf '%s' "$pr" | jq -r '.url')
+    opened=$(printf '%s' "$pr" | jq -r '.opened')
+    ci=$(printf '%s' "$pr" | jq -r '.ci // ""')
+    approvals=$(printf '%s' "$pr" | jq -r '.approvals')
+    printf '| %s | [#%s — %s](%s) | %s | %s | %s |\n' \
+      "$repo" "$number" "$title" "$url" "$opened" "$(ci_label "$ci")" "$approvals"
+  done < <(printf '%s' "$NEEDS_REVIEW_PRS" | jq -c 'sort_by(.opened) | .[]')
+  printf '\n'
+}
+
+# ── Section: Dependency Bumps ─────────────────────────────────────────────────
+section_dep_bumps() {
+  printf '## Open PRs — Automation (Dependency Bumps)\n\n'
+
+  local rows
+  rows=$(printf '%s' "$PR_BY_REPO" | jq -r 'map(select(.dep_bumps > 0)) | sort_by(-.dep_bumps)[] |
+    [.repo, (.dep_bumps | tostring)] | @tsv')
+
+  if [ -z "$rows" ]; then
+    printf '_none_\n\n'
+    return
+  fi
+
+  printf '| Repo | # Dep PRs |\n|---|---|\n'
+  while IFS=$'\t' read -r repo cnt; do
+    printf '| [%s](https://github.com/%s) | %s |\n' "$repo" "$repo" "$cnt"
+  done <<< "$rows"
+  printf '\n'
+}
+
+# ── Section: Open Issues ──────────────────────────────────────────────────────
+section_open_issues() {
+  local total_issues
+  total_issues=$(printf '%s' "$ISSUES_BY_REPO_TRIMMED" | jq '[.[].count] | add // 0')
+  printf '## Open Issues (%s total)\n\n' "$total_issues"
+
+  local count
+  count=$(printf '%s' "$ISSUES_BY_REPO_TRIMMED" | jq 'length')
+  if [ "$count" -eq 0 ]; then
+    printf '_none_\n\n'
+    return
+  fi
+
+  while IFS= read -r repo_block; do
+    local repo issue_count truncated
+    repo=$(printf '%s' "$repo_block" | jq -r '.repo')
+    issue_count=$(printf '%s' "$repo_block" | jq -r '.count')
+    truncated=$(printf '%s' "$repo_block" | jq -r '.truncated')
+
+    if [ "$truncated" = "true" ]; then
+      printf '### [%s](https://github.com/%s) (showing %s of %s issues)\n\n' \
+        "$repo" "$repo" "$ISSUE_LIMIT" "$issue_count"
+    else
+      printf '### [%s](https://github.com/%s) (%s issues)\n\n' \
+        "$repo" "$repo" "$issue_count"
+    fi
+
+    printf '| Issue | Opened | Labels | Linked PR |\n|---|---|---|---|\n'
+    while IFS= read -r issue; do
+      local number title url opened labels linked_pr
+      number=$(printf '%s' "$issue" | jq -r '.number')
+      title=$(printf '%s' "$issue" | jq -r '.title | gsub("|"; "\\|")')
+      url=$(printf '%s' "$issue" | jq -r '.url')
+      opened=$(printf '%s' "$issue" | jq -r '.createdAt | split("T")[0]')
+      labels=$(printf '%s' "$issue" | jq -r '[.labels[].name] | join(", ")')
+      linked_pr=$(printf '%s' "$ISSUE_PR_MAP" | jq -r \
+        --arg key "${repo}#${number}" \
+        'if has($key) then [.[$key][] | "[#" + (.number|tostring) + "](" + .url + ")"] | join(", ") else "—" end')
+      printf '| [#%s — %s](%s) | %s | %s | %s |\n' \
+        "$number" "$title" "$url" "$opened" "${labels:- }" "$linked_pr"
+    done < <(printf '%s' "$repo_block" | jq -c '.issues[]')
+    printf '\n'
+  done < <(printf '%s' "$ISSUES_BY_REPO_TRIMMED" | jq -c '.[]')
+}
+
+# ── Section: Open Discussions ─────────────────────────────────────────────────
+section_open_discussions() {
+  printf '## Open Discussions\n\n'
+
+  local total
+  total=$(printf '%s' "$DISCUSSIONS" | jq '[.[].discussions | length] | add // 0')
+  if [ "$total" -eq 0 ]; then
+    printf '_none_\n\n'
+    return
+  fi
+
+  printf '| Repo | Discussion | Opened | Replies |\n|---|---|---|---|\n'
+  while IFS= read -r repo_block; do
+    local repo
+    repo=$(printf '%s' "$repo_block" | jq -r '.repo')
+    while IFS= read -r disc; do
+      local number title url opened replies
+      number=$(printf '%s' "$disc" | jq -r '.number')
+      title=$(printf '%s' "$disc" | jq -r '.title | gsub("|"; "\\|")')
+      url=$(printf '%s' "$disc" | jq -r '.url')
+      opened=$(printf '%s' "$disc" | jq -r '.createdAt | split("T")[0]')
+      replies=$(printf '%s' "$disc" | jq -r '.comments.totalCount')
+      printf '| %s | [#%s — %s](%s) | %s | %s |\n' \
+        "$repo" "$number" "$title" "$url" "$opened" "$replies"
+    done < <(printf '%s' "$repo_block" | jq -c '.discussions[]')
+  done < <(printf '%s' "$DISCUSSIONS" | jq -c '.[]')
+  printf '\n'
+}
+
+# ── Entry Point ───────────────────────────────────────────────────────────────
+# generate_org_report — writes the complete daily org status report to stdout
+generate_org_report() {
+  printf '@org-leads\n\n'
+  section_org_summary
+  section_open_prs
+  section_merge_activity
+  section_needs_review
+  section_dep_bumps
+  section_open_issues
+  section_open_discussions
+}

--- a/scripts/org_status.sh
+++ b/scripts/org_status.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
-# Daily org status data collector — runs in GitHub Actions, outputs a markdown report to stdout.
+# Daily org status — collects GitHub org data and generates a markdown report to stdout.
+# Report generation is handled by org_report.sh (programmatic, no external AI dependency).
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/org_report.sh
+source "${SCRIPT_DIR}/org_report.sh"
 
 TODAY=$(date -u +%Y-%m-%d)
 if [[ "$(uname)" == "Darwin" ]]; then
@@ -250,9 +255,7 @@ DISCUSSIONS=$(gh api graphql -f query='
 ]') || DISCUSSIONS='[]'
 echo "::endgroup::" >&2
 
-# ── Build Prompt ──────────────────────────────────────────────────────────────
-# Limit issues per repo to keep prompt size manageable and ensure Claude has
-# enough output budget to generate all sections (especially the PR tables first).
+# ── Generate Report ───────────────────────────────────────────────────────────
 ISSUE_LIMIT=25
 ISSUES_BY_REPO_TRIMMED=$(echo "$ISSUES_BY_REPO" | jq --argjson limit "$ISSUE_LIMIT" '
   map({
@@ -262,188 +265,6 @@ ISSUES_BY_REPO_TRIMMED=$(echo "$ISSUES_BY_REPO" | jq --argjson limit "$ISSUE_LIM
     issues:    .issues[:$limit]
   })')
 
-cat > "$DATA_DIR/prompt.txt" << PROMPT
-Generate a daily GitHub org status report for petry-projects on $TODAY.
 
-Use ONLY the data below. Output ONLY the markdown report — no preamble, no commentary.
-
-CRITICAL: You MUST output ALL sections listed in REPORT FORMAT, in order. Do NOT skip or abbreviate any section.
-
----
-
-## DATA
-
-### PR Counts by Repo (pre-classified)
-$(echo "$PR_BY_REPO" | jq -c '.')
-
-### PRs Needing Human Review (full detail, includes url field)
-$(echo "$NEEDS_REVIEW_PRS" | jq -c '.')
-
-### Issue → Linked PR Map (key: "owner/repo#issue_number", value: [{number, url}])
-$(echo "$ISSUE_PR_MAP" | jq -c '.')
-
-### Merge Activity — Daily Counts (last 8 days, $SINCE to $TODAY)
-$(echo "$MERGE_DAILY" | jq -c '.')
-
-### Merge Activity — Per-Repo Per-Day (repo, total, by_date map keyed by YYYY-MM-DD)
-$(echo "$MERGE_BY_REPO_DAY" | jq -c '.')
-
-### Open Issues by Repo (each issue has url field; truncated:true means more exist beyond the $ISSUE_LIMIT shown)
-$(echo "$ISSUES_BY_REPO_TRIMMED" | jq -c '.')
-
-### Open Discussions (each discussion has url field)
-$(echo "$DISCUSSIONS" | jq -c '.')
-
----
-
-## REPORT FORMAT
-
-Begin the report with this exact line (replace nothing):
-@org-leads
-
-Then produce ALL of these sections in EXACTLY this order. Output each \`##\` section header before its content — do NOT skip any header, table header row, or section.
-
----
-
-### \`## Org Summary — $TODAY\`
-
-A single compact table with one row per metric:
-| Metric | Value |
-|---|---|
-| Total open PRs | _sum all repos_ |
-| PRs needing rebase | _sum needs_rebase across all repos_ |
-| Total open issues | _sum all repos_ |
-| PR merges (last 8 days) | _sum .org across all dates in Merge Activity — Daily Counts_ |
-| Open discussions | _count all discussions_ |
-
-Then immediately after the table, a mermaid pie chart of open PRs by category (use the org-wide totals):
-\`\`\`mermaid
-pie title Open PRs by Status
-    "Awaiting Review" : <N>
-    ...
-\`\`\`
-Replace each <N> with the actual org-wide count. Omit zero-count categories. Sort slices from largest to smallest count.
-
----
-
-### \`## Open PRs — Why They're Unmerged (N total)\`
-(Replace N with the actual total count.)
-
-First, an xychart-beta bar chart of org-wide PR counts by blocker category. Omit zero-count categories. Sort x-axis from highest to lowest count:
-\`\`\`mermaid
-xychart-beta
-    title "Open PRs by Blocker Category"
-    x-axis [<category labels sorted highest to lowest count>]
-    y-axis "Count"
-    bar [<counts in matching sorted order>]
-\`\`\`
-
-Then, a grouped bar chart for per-repo breakdown using multiple bar series (one per key category). Omit repos with 0 total PRs. Sort repos by total PRs descending. Use short repo names (e.g. "broodly"). Include only the 4 most actionable categories as separate bar series: No CI/Policy, Awaiting Review, CI Failing, Approved. Note: xychart-beta does not support stacked bars — multiple bar lines render as grouped/overlapping series:
-\`\`\`mermaid
-xychart-beta
-    title "Open PRs per Repo by Category"
-    x-axis [<short repo names sorted by total desc>]
-    y-axis "PRs"
-    bar [<No CI/Policy counts per repo>]
-    bar [<Awaiting Review counts per repo>]
-    bar [<CI Failing counts per repo>]
-    bar [<Approved counts per repo>]
-\`\`\`
-
----
-
-### \`## PR Merge Activity — Last 8 Days\`
-A mermaid bar chart of daily org merge counts (use Merge Activity — Daily Counts):
-\`\`\`mermaid
-xychart-beta
-    title "petry-projects Merges — Last 8 Days"
-    x-axis [<comma-separated Mon-DD date labels>]
-    y-axis "Merges"
-    bar [<comma-separated daily org counts>]
-\`\`\`
-
-Per-repo-per-day table using Merge Activity — Per-Repo Per-Day data (omit repos with 0 total):
-| Repo | Mon-DD | … | Total |
-- One column per date in chronological order (all 8 dates)
-- Date headers: short format Mon-DD (e.g. Apr-26)
-- Repo as link: [owner/repo](https://github.com/owner/repo)
-- Last column is Total (bold the number)
-- Add a **TOTAL** row summing each date column and grand total
-Grand total and trend sentence (immediately after the per-repo table). Trend: Increasing if avg(last 3 days) > avg(first 3 days), Decreasing if opposite, Flat otherwise.
-
----
-
-### \`## Open PRs — Needs Human Review\`
-Full table for PRs with needsHumanReview == true, sorted by Opened ascending (oldest first):
-| Repo | PR | Opened | CI | Approvals |
-|---|---|---|---|---|
-- PR cell: single markdown link combining number and title, e.g. \`[#42 — Fix the thing](url)\`
-- CI: PASS (SUCCESS) / FAIL (FAILURE or ERROR) / PENDING / N/A (null)
-If none: _none_
-
----
-
-### \`## Open PRs — Automation (Dependency Bumps)\`
-Counts only per repo (dep_bumps > 0):
-| Repo | # Dep PRs |
-|---|---|
-- Repo as link: [owner/repo](https://github.com/owner/repo)
-If none: _none_
-
----
-
-### \`## Open Issues (N total)\`
-Render as a per-repo subsection list (NOT a single flat table). For each repo with issues, in the order provided:
-
-\`### [owner/repo](https://github.com/owner/repo) (N issues)\`
-- If truncated:true, replace the suffix with " (showing $ISSUE_LIMIT of N issues)".
-
-Then a table (Repo column omitted — it's in the heading):
-| Issue | Opened | Labels | Linked PR |
-|---|---|---|---|
-- Issue cell: single markdown link combining number and title, e.g. \`[#123 — Compliance: foo](url)\`
-- Opened = createdAt date only (YYYY-MM-DD)
-- Linked PR: look up "owner/repo#N" in the Issue→Linked PR Map; if found render as [#M](pr_url); if multiple, comma-separate; if none render —
-
----
-
-### \`## Open Discussions\`
-| Repo | Discussion | Opened | Replies |
-|---|---|---|---|
-- Discussion cell: single markdown link combining number and title, e.g. \`[#7 — Feature idea](url)\`
-If none: _none_
-
----
-
-OUTPUT CONTRACT
-- Dates: YYYY-MM-DD
-- Section headers include total counts: \`## Open Issues (47 total)\`
-- Empty sections show _none_, never omit them
-- Every item with a url must be rendered as a markdown hyperlink
-- Output sections in EXACTLY the order listed above — do not reorder them
-PROMPT
-
-# ── Generate Report ───────────────────────────────────────────────────────────
-# --disallowedTools: block all action tools so Claude cannot act on untrusted PR/issue content
-# --output-format json: capture the full final result as JSON and extract the text with jq.
-#   In text mode, output preceding disallowed tool call attempts is silently dropped; json
-#   mode always includes the complete response in .result regardless of tool call filtering.
-# Write to a temp file to avoid large bash variable assignments.
-# Pipe prompt via stdin rather than a shell argument to avoid ARG_MAX (~1MB) with large orgs
-REPORT_JSON="$DATA_DIR/report.json"
-echo "Generating report with Claude..." >&2
-claude -p \
-  --output-format json \
-  --disallowedTools "Bash,Read,Write,Edit,Grep,Glob,WebFetch,WebSearch,Task,TodoWrite,NotebookEdit" \
-  < "$DATA_DIR/prompt.txt" > "$REPORT_JSON"
-echo "JSON lines: $(wc -l < "$REPORT_JSON")" >&2
-echo "JSON first 600 chars:" >&2
-head -c 600 "$REPORT_JSON" >&2
-echo "" >&2
-if ! jq -e '(.result // "") | type == "string" and length > 0' "$REPORT_JSON" > /dev/null 2>&1; then
-  echo "ERROR: claude returned missing or empty .result field — raw output:" >&2
-  cat "$REPORT_JSON" >&2
-  exit 1
-fi
-jq '{stop_reason,num_turns,total_cost_usd,result_len:((.result//"")|length),result_start:((.result//"")|.[0:120])}' "$REPORT_JSON" >&2 || true
-jq -r '.result' "$REPORT_JSON"
+echo "Generating report..." >&2
+generate_org_report


### PR DESCRIPTION
## What

Replaces the Claude Code CLI dependency in the daily org status workflow with a pure bash/jq report generator, following the same pattern as `scripts/fleet_report.sh` in `.github-private`.

## Why

The daily org status run was failing because `CLAUDE_CODE_OAUTH_TOKEN` expired. Rather than rotate the token, this refactor removes the dependency entirely — the report data is already fully structured, so AI synthesis adds latency and fragility without adding value.

## Changes

- **`scripts/org_report.sh`** (new): pure bash/jq functions, one per report section. Mirrors the `fleet_report.sh` pattern: each function writes directly to stdout, no temp files, no external processes.
- **`scripts/org_status.sh`**: sources `org_report.sh` and calls `generate_org_report` in place of the prompt-building + `claude -p` invocation.
- **`daily-org-status.yml`**: removes `setup-node`, `Install Claude Code CLI` steps, and the `CLAUDE_CODE_OAUTH_TOKEN` env var. Workflow is ~30s faster and has no external token dependencies.

## Report format preserved

`@org-leads` header → Org Summary table + mermaid pie → Open PRs charts → Merge Activity bar + table → Needs Human Review → Dep Bumps → Open Issues (per-repo subsections) → Discussions