### PR TITLE
feat(standards): require language instruction file links in Org Standards section

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,16 +14,22 @@ adopt.
 
 Primary stack for work done in this repo: Bash · YAML · Markdown · Python (scripts).
 
-## Standards Reference
+## Org Standards
 
 Full AI agent development standards live in **[AGENTS.md](../AGENTS.md)**. This file is a
 Copilot-focused summary; AGENTS.md is authoritative when they conflict. Read the relevant
 standard in [`standards/`](../standards/) before touching CI, repo settings, or agent
 configuration.
 
-Language-specific rules are applied automatically via files in `.github/instructions/`:
-`typescript`, `javascript`, `python`, `go`, `terraform`, and `shell` — see those files for
-per-language guidance.
+Language-specific rules are applied automatically via files in `.github/instructions/` when you
+open a matching file type. Canonical files in this repo (deployed verbatim to each target repo):
+
+- [`typescript.instructions.md`](instructions/typescript.instructions.md) — strict config, branded types, DDD/CQRS, pino, React, Electron IPC
+- [`javascript.instructions.md`](instructions/javascript.instructions.md) — style, JSDoc type annotations, error handling
+- [`python.instructions.md`](instructions/python.instructions.md) — black/ruff, type annotations, structlog, pytest, GAS companion code
+- [`go.instructions.md`](instructions/go.instructions.md) — naming, gofmt, slog, error wrapping, concurrency, HTTP, testing, security
+- [`terraform.instructions.md`](instructions/terraform.instructions.md) — fmt, tflint, tfsec, trivy, state management, security
+- [`shell.instructions.md`](instructions/shell.instructions.md) — safety flags, ShellCheck, quoting, error handling, Makefile standards
 
 ## Core Development Rules
 

--- a/standards/copilot-instructions-standard.md
+++ b/standards/copilot-instructions-standard.md
@@ -92,6 +92,10 @@ only document what differs or adds detail.
 A repo-level `copilot-instructions.md` MUST include the following sections. Keep the file to
 approximately two pages — concise, specific, and actionable.
 
+The `## Org Standards` section MUST list every language-specific `.instructions.md` file deployed
+to `.github/instructions/` in that repo, each with a one-line scope description. This makes the
+path-specific files discoverable without requiring contributors to browse the directory.
+
 ---
 
 ```markdown
@@ -147,7 +151,19 @@ apply.]
 ## Org Standards
 
 See [petry-projects/.github — AGENTS.md](https://github.com/petry-projects/.github/blob/main/AGENTS.md)
-for full development standards.
+for org-wide development standards.
+
+**Language-specific instructions** (applied automatically by Copilot when you open matching file types):
+
+- [TypeScript / TSX](instructions/typescript.instructions.md) — [strict config, branded types, DDD/CQRS, pino, React/Electron as applicable]
+- [JavaScript](instructions/javascript.instructions.md) — [style, JSDoc, error handling]
+- [Go](instructions/go.instructions.md) — [naming, gofmt, slog, error wrapping, concurrency, testing]
+- [Shell](instructions/shell.instructions.md) — [safety flags, ShellCheck, quoting, error handling]
+- [Python](instructions/python.instructions.md) — [black/ruff, type annotations, structlog, pytest]
+- [Terraform](instructions/terraform.instructions.md) — [fmt, tflint, security scanning, state management]
+
+_List only the files actually deployed to `.github/instructions/` for this repo.
+Omit this block entirely if no language instruction files were deployed._
 ```
 
 ---
@@ -162,6 +178,7 @@ for full development standards.
 - Coverage thresholds and testing tools specific to this repo
 - Architecture patterns unique to this repo (e.g., Electron IPC conventions, GAS extraction pattern)
 - Any rule that overrides or refines the org-level defaults
+- Links to every language-specific `.instructions.md` file deployed to `.github/instructions/`, each with a one-line scope description (list only files that are actually present)
 
 **Do NOT include in repo-level instructions:**
 
@@ -169,6 +186,7 @@ for full development standards.
 - Rules already covered in language-specific `.instructions.md` files
 - Content already documented in `AGENTS.md`
 - Secrets, API keys, credentials, or example tokens with real values
+- Links to language instruction files that were not deployed to this repo's `.github/instructions/`
 
 ## Content Quality Rules
 
@@ -186,13 +204,14 @@ for full development standards.
 ## Compliance
 
 The weekly compliance audit (`scripts/compliance-audit.sh`) enforces this standard
-automatically. Two `warning`-severity checks run against every repository in the org:
+automatically. Four `warning`-severity checks run against every repository in the org:
 
 | Check ID | Trigger | Remediation |
 |----------|---------|-------------|
 | `missing-copilot-instructions` | `.github/copilot-instructions.md` is absent | Copy the template below and fill in the repo-specific sections |
 | `copilot-instructions-missing-tech-stack` | File exists but `## Tech Stack` section is absent | Add the section — list runtimes, frameworks, and major library versions |
 | `copilot-instructions-missing-local-dev-commands` | File exists but `## Local Dev Commands` section is absent | Add the section — include exact install, dev-run, test, lint, and typecheck commands |
+| `copilot-instructions-missing-language-links` | Files exist in `.github/instructions/` but are not listed in `## Org Standards` | Ensure files in `.github/instructions/` are listed in `## Org Standards` and that each listed link resolves to the correct relative path (no broken links) |
 
 Findings are reported as `warning` (not `error`) because the org-level baseline in
 `petry-projects/.github` ensures minimum Copilot guidance even without a repo-level file.


### PR DESCRIPTION
## Summary

- Adds an explicit requirement that repo-level `copilot-instructions.md` files MUST list each deployed language instruction file in `## Org Standards` with a one-line scope description
- Updates the template in `copilot-instructions-standard.md` to show the pattern with all six language files as examples
- Adds `copilot-instructions-missing-language-links` to the compliance check table (for future audit enforcement)
- Converts the prose language-file mention in the org-level `copilot-instructions.md` to the linked-list pattern, serving as the canonical example

## Motivation

CodeRabbit flagged across the rollout PRs (#203, #241, #204, #181, #199, #357) that the `## Org Standards` section didn't surface the language instruction files that were deployed alongside `copilot-instructions.md`. Contributors had no way to discover `typescript.instructions.md` etc. without browsing `.github/instructions/`. This change makes discoverability a standard requirement and closes the gap that caused those review comments.

## Files changed

- `standards/copilot-instructions-standard.md` — template updated, requirement added to intro + What to Include, compliance row added
- `.github/copilot-instructions.md` — prose → linked list; serves as the live example of the pattern

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development standards and templates to clarify code assistant configuration guidance across language-specific instruction files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/petry-projects/.github/pull/343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->