### PR TITLE
fix(compliance): detect HTTP errors in compliance-retrigger search

### DIFF
--- a/scripts/compliance-retrigger.sh
+++ b/scripts/compliance-retrigger.sh
@@ -137,12 +137,37 @@ retrigger_stale_issues() {
   cutoff=$(stale_cutoff)
   info "Stale cutoff: $cutoff"
 
-  # Search across the whole org
-  local issues
-  issues=$(gh api \
+  # Search across the whole org. Fetch raw response first so we can detect
+  # HTTP errors — gh api dumps the error JSON to stdout and exits non-zero,
+  # which the old `--jq '.items[]' || echo ""` pattern silently swallowed,
+  # producing a single "Skipping null#null" iteration when the token lacked
+  # search scope. See: failure mode where ORG_SCORECARD_TOKEN scope did not
+  # permit cross-org search but the script still reported success.
+  local raw rc
+  raw=$(gh api \
     "search/issues?q=org:${ORG}+label:${AUDIT_LABEL}+label:${TRIGGER_LABEL}+state:open&per_page=100" \
-    --jq '.items[] | {number: .number, repo: (.repository_url | split("/") | last), created_at: .created_at, title: .title}' \
-    2>/dev/null || echo "")
+    2>&1) && rc=0 || rc=$?
+
+  if [ "$rc" -ne 0 ]; then
+    error "search/issues API call failed (exit $rc). Response:"
+    echo "$raw" | head -5 >&2
+    error "Cannot retrigger issues; aborting. Check GH_TOKEN scope — token must be able to read issues across all repos in org ${ORG}."
+    return 1
+  fi
+
+  # Detect error-response JSON even when exit code was 0 (defensive).
+  if echo "$raw" | jq -e 'has("message") and (.items | not)' >/dev/null 2>&1; then
+    error "search/issues returned an error response:"
+    echo "$raw" | jq -r '.message' >&2
+    return 1
+  fi
+
+  local total
+  total=$(echo "$raw" | jq -r '.total_count // 0')
+  info "search/issues returned ${total} matching issues"
+
+  local issues
+  issues=$(echo "$raw" | jq -c '.items[] | {number: .number, repo: (.repository_url | split("/") | last), created_at: .created_at, title: .title}')
 
   if [ -z "$issues" ]; then
     info "No open compliance-audit issues found."


### PR DESCRIPTION
## Summary

The `compliance-retrigger.sh` script silently swallowed `gh api` failures, masking the daily retrigger as successful while no issues were actually re-triggered.

## Root cause

```bash
issues=$(gh api ... --jq '.items[]' 2>/dev/null || echo "")
```

When `gh api` returned HTTP error (e.g., search rate-limit, missing scope, transient 5xx):
- The error JSON went to **stdout** (not stderr).
- `2>/dev/null` only discarded stderr.
- `|| echo ""` didn't fire because stdout was non-empty.
- The while loop iterated once with the error JSON as the iteration value.
- `jq -r '.number'` etc. extracted `"null"` for every field.
- Log line: `[info] Skipping null#null (null) — created null, not yet stale`
- Summary: `0 retriggered, 1 skipped` — script marked successful.

This is why the org accumulated ~40 stale compliance issues over 3 days despite the daily workflow running and 'succeeding' each time.

## Fix

- Capture raw response separately from jq extraction.
- Check gh api exit code; abort with a clear error and dump the response if non-zero.
- Additionally detect error-shape JSON (\`{ "message": ..., no "items" }\`) with exit 0 - defensive.
- Log total_count so operators can see how many matches the search returned.
- Use \`jq -c\` to ensure one-line-per-object.

## Test plan

- [ ] Merge.
- [ ] Trigger workflow manually with \`gh workflow run compliance-retrigger.yml --repo petry-projects/.github\`.
- [ ] Confirm log shows \`search/issues returned N matching issues\` and re-trigger lines.
- [ ] If the CI run reveals the underlying API failure cause, follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)