### PR TITLE
feat(compliance): migrate dev-lead trigger label claude→dev-lead + re-trigger persistent findings

### DIFF
--- a/.github/workflows/compliance-audit-and-improvement.yml
+++ b/.github/workflows/compliance-audit-and-improvement.yml
@@ -52,6 +52,7 @@ jobs:
       repos_with_findings: ${{ steps.audit.outputs.repos_with_findings }}
       issues_added: ${{ steps.audit.outputs.issues_added }}
       issues_existing: ${{ steps.audit.outputs.issues_existing }}
+      issues_retriggered: ${{ steps.audit.outputs.issues_retriggered }}
       issues_removed: ${{ steps.audit.outputs.issues_removed }}
     steps:
       - name: Checkout .github repo
@@ -83,12 +84,14 @@ jobs:
           if [ -f "$COUNTS_FILE" ]; then
             ISSUES_ADDED=$(jq '.added' "$COUNTS_FILE")
             ISSUES_EXISTING=$(jq '.existing' "$COUNTS_FILE")
+            ISSUES_RETRIGGERED=$(jq '.retriggered // 0' "$COUNTS_FILE")
             ISSUES_REMOVED=$(jq '.removed' "$COUNTS_FILE")
           else
-            ISSUES_ADDED=0; ISSUES_EXISTING=0; ISSUES_REMOVED=0
+            ISSUES_ADDED=0; ISSUES_EXISTING=0; ISSUES_RETRIGGERED=0; ISSUES_REMOVED=0
           fi
           echo "issues_added=$ISSUES_ADDED" >> "$GITHUB_OUTPUT"
           echo "issues_existing=$ISSUES_EXISTING" >> "$GITHUB_OUTPUT"
+          echo "issues_retriggered=$ISSUES_RETRIGGERED" >> "$GITHUB_OUTPUT"
           echo "issues_removed=$ISSUES_REMOVED" >> "$GITHUB_OUTPUT"
 
       - name: Write step summary
@@ -332,6 +335,7 @@ jobs:
             - Repos with findings: ${{ needs.audit.outputs.repos_with_findings }}
             - Issues added (new): ${{ needs.audit.outputs.issues_added }}
             - Issues existing (updated): ${{ needs.audit.outputs.issues_existing }}
+            - Issues re-triggered (dev-lead re-engaged on persistent findings): ${{ needs.audit.outputs.issues_retriggered }}
             - Issues removed (resolved): ${{ needs.audit.outputs.issues_removed }}
 
             ### Health Survey (runtime telemetry)
@@ -556,6 +560,7 @@ jobs:
             |--------|-------|
             | Added (new) | ${{ needs.audit.outputs.issues_added }} |
             | Existing (updated) | ${{ needs.audit.outputs.issues_existing }} |
+            | Re-triggered (dev-lead re-engaged) | ${{ needs.audit.outputs.issues_retriggered }} |
             | Removed (resolved) | ${{ needs.audit.outputs.issues_removed }} |
 
             Group by compliance issue type — one subsection per distinct check/finding type,

--- a/.github/workflows/compliance-audit-and-improvement.yml
+++ b/.github/workflows/compliance-audit-and-improvement.yml
@@ -4,7 +4,7 @@
 # Job 3: Claude analyzes both datasets in six phases:
 #   Phase 1-3: Load data, categorize findings, research root causes.
 #   Phase 4: Evaluate against industry best practices & emerging capabilities.
-#   Phase 5: Create actionable issues per repo (claude label for agent pickup).
+#   Phase 5: Create actionable issues per repo (dev-lead label for agent pickup).
 #   Phase 6: Summary report.
 # Standard: https://github.com/${{ github.repository_owner }}/.github/tree/main/standards
 name: Org Standards Compliance Audit
@@ -276,7 +276,7 @@ jobs:
 
   # -----------------------------------------------------------------------
   # Job 3: Combined analysis — Claude reviews both datasets
-  # Creates actionable issues in the appropriate repo with the claude label.
+  # Creates actionable issues in the appropriate repo with the dev-lead label.
   # -----------------------------------------------------------------------
   analyze:
     name: Analyze & Create Issues (Claude)
@@ -449,7 +449,7 @@ jobs:
             exclusively **proposed new or improved standards** for the org. For each top
             opportunity (max 2-3), create a standards proposal issue in `${{ github.repository_owner }}/.github`:
             - Title: `Standards: <concise description of the proposed standard>`
-            - Labels: `claude,enhancement`
+            - Labels: `dev-lead,enhancement`
             - Body must include:
               - **Proposed Standard** — the specific policy, workflow, or configuration to adopt
               - **Rationale** — why this matters, linked to the feasibility/impact/urgency assessment
@@ -465,10 +465,10 @@ jobs:
             - Issues affecting multiple repos or org-wide concerns go in `${{ github.repository_owner }}/.github`
             - Standards improvement proposals go in `${{ github.repository_owner }}/.github`
 
-            **IMPORTANT: Every issue MUST have the `claude` label** so it gets picked up for implementation.
-            Ensure the `claude` label exists in the target repo before creating the issue:
+            **IMPORTANT: Every issue MUST have the `dev-lead` label** so it gets picked up for implementation.
+            Ensure the `dev-lead` label exists in the target repo before creating the issue:
             ```bash
-            gh label create claude --repo ${{ github.repository_owner }}/<repo> --color "8B5CF6" --description "For Claude agent pickup" 2>/dev/null || true
+            gh label create dev-lead --repo ${{ github.repository_owner }}/<repo> --color "8B5CF6" --description "For dev-lead agent pickup" 2>/dev/null || true
             ```
 
             Additional labels by type: `bug`, `security`, `ci`, `automation`, `enhancement`, `documentation`
@@ -481,7 +481,7 @@ jobs:
             ```bash
             gh issue create --repo ${{ github.repository_owner }}/<target-repo> \
               --title "<severity prefix>: <concise title>" \
-              --label "claude,<other-labels>" \
+              --label "dev-lead,<other-labels>" \
               --body "<structured body>"
             ```
 
@@ -517,9 +517,9 @@ jobs:
               per-repo issues; your job is to identify systemic patterns and create higher-level
               issues for them.
             - If a similar issue exists, add a comment with latest findings instead
-            - When commenting on existing issues, also ensure the `claude` label is present:
+            - When commenting on existing issues, also ensure the `dev-lead` label is present:
               ```bash
-              gh issue edit <number> --repo ${{ github.repository_owner }}/<repo> --add-label claude
+              gh issue edit <number> --repo ${{ github.repository_owner }}/<repo> --add-label dev-lead
               ```
 
             **Before writing the Phase 6 summary**, gather linked PR data for all issues you
@@ -602,9 +602,9 @@ jobs:
             ## Rules
 
             - **Do not fix code or push changes.** Analysis and issue creation only.
-            - **Do not close or modify existing issues** beyond adding the `claude` label.
+            - **Do not close or modify existing issues** beyond adding the `dev-lead` label.
             - **Do not create PRs.** Only create issues with actionable recommendations.
-            - **Every issue gets the `claude` label.** No exceptions.
+            - **Every issue gets the `dev-lead` label.** No exceptions.
             - **Repo-specific issues go in that repo.** Org-wide issues go in `.github`.
             - **Be specific.** Include run IDs, URLs, and exact error messages.
             - **Deduplicate aggressively.** One well-written issue beats five vague ones.

--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -1237,7 +1237,6 @@ This finding is still open.
     # this issue (open dev-lead PR or `in-progress` label), in which case we
     # must not interrupt it and simply ensure the label is present.
     if dl_dev_lead_active "$ORG" "$repo" "$existing"; then
-      gh issue edit "$existing" --repo "$ORG/$repo" --add-label "claude" 2>/dev/null || true
       info "Existing issue #$existing in $repo — dev-lead already active, not re-triggering"
     elif dl_cycle_trigger_label "$ORG" "$repo" "$existing" "claude" "$DRY_RUN"; then
       info "Re-triggered dev-lead on persistent issue #$existing in $repo for: $check"

--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -1161,9 +1161,9 @@ ensure_audit_label() {
     --description "$AUDIT_LABEL_DESC" \
     --color "$AUDIT_LABEL_COLOR" \
     --force 2>/dev/null || true
-  gh label create "claude" \
+  gh label create "dev-lead" \
     --repo "$ORG/$repo" \
-    --description "For Claude agent pickup" \
+    --description "For dev-lead agent pickup" \
     --color "8B5CF6" \
     --force 2>/dev/null || true
 }
@@ -1230,21 +1230,21 @@ This finding is still open.
     # Re-engage dev-lead on findings that PERSIST across audits.
     #
     # dev-lead listens on issues:labeled and fires only once per label
-    # application. The `claude` label is already present on a pre-existing
+    # application. The `dev-lead` label is already present on a pre-existing
     # issue, so a plain --add-label is a no-op that emits no event and dev-lead
     # is never re-triggered. To give it a fresh chance to produce a fix PR we
     # cycle the label (remove + re-add) — UNLESS dev-lead is already working
     # this issue (open dev-lead PR or `in-progress` label), in which case we
-    # must not interrupt it and simply ensure the label is present.
+    # leave it alone (the label is already present, so no action is needed).
     if dl_dev_lead_active "$ORG" "$repo" "$existing"; then
       info "Existing issue #$existing in $repo — dev-lead already active, not re-triggering"
-    elif dl_cycle_trigger_label "$ORG" "$repo" "$existing" "claude" "$DRY_RUN"; then
+    elif dl_cycle_trigger_label "$ORG" "$repo" "$existing" "dev-lead" "$DRY_RUN"; then
       info "Re-triggered dev-lead on persistent issue #$existing in $repo for: $check"
       ISSUES_RETRIGGERED=$((ISSUES_RETRIGGERED + 1))
     else
       # Cycle failed mid-way — ensure the label is at least present so the issue
       # is not left without its trigger label.
-      gh issue edit "$existing" --repo "$ORG/$repo" --add-label "claude" 2>/dev/null || true
+      gh issue edit "$existing" --repo "$ORG/$repo" --add-label "dev-lead" 2>/dev/null || true
       warn "Failed to re-trigger dev-lead on issue #$existing in $repo for: $check"
     fi
     # Record existing issue for umbrella
@@ -1319,11 +1319,11 @@ ${remediation_steps}
 *This issue was automatically created by the [weekly compliance audit](https://github.com/${ORG}/.github/blob/main/.github/workflows/compliance-audit.yml).*"
 
   local issue_url
-  # Individual finding issues get both compliance-audit and claude labels so agents can pick them up.
+  # Individual finding issues get both compliance-audit and dev-lead labels so agents can pick them up.
   issue_url=$(gh issue create --repo "$ORG/$repo" \
     --title "$search_title" \
     --label "$AUDIT_LABEL" \
-    --label "claude" \
+    --label "dev-lead" \
     --body "$body" 2>/dev/null || echo "")
 
   if [ -n "$issue_url" ]; then
@@ -1463,7 +1463,7 @@ Findings are grouped by remediation category. Address each category together to 
   umbrella_url=$(gh issue create --repo "$ORG/.github" \
     --title "$title" \
     --label "$AUDIT_LABEL" \
-    --label "claude" \
+    --label "dev-lead" \
     --body "$body" 2>/dev/null || echo "")
 
   if [ -n "$umbrella_url" ]; then
@@ -1821,7 +1821,7 @@ main() {
     done
 
     # Create one umbrella issue per audit run grouping all findings by remediation category.
-    # Both individual issues and the umbrella get the `claude` label for agent pickup.
+    # Both individual issues and the umbrella get the `dev-lead` label for agent pickup.
     create_umbrella_issue
 
     # Append per-check issue links and related open PRs to the step summary

--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -40,6 +40,7 @@ ISSUE_COUNTS_FILE="$REPORT_DIR/issue-counts.json"
 ISSUES_ADDED=0
 ISSUES_EXISTING=0
 ISSUES_REMOVED=0
+ISSUES_RETRIGGERED=0
 
 REQUIRED_WORKFLOWS=(ci.yml sonarcloud.yml dev-lead.yml dependabot-automerge.yml dependency-audit.yml agent-shield.yml pr-review-mention.yml)
 # Note: codeql.yml is intentionally NOT in REQUIRED_WORKFLOWS. CodeQL is now
@@ -129,6 +130,11 @@ gh_api() {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/push-protection.sh
 . "$SCRIPT_DIR/lib/push-protection.sh"
+
+# Shared dev-lead retrigger helpers — dl_dev_lead_active() and
+# dl_cycle_trigger_label(). Used to re-engage dev-lead on persistent findings.
+# shellcheck source=lib/dev-lead-retrigger.sh
+. "$SCRIPT_DIR/lib/dev-lead-retrigger.sh"
 
 # ---------------------------------------------------------------------------
 # Ecosystem detection
@@ -1214,13 +1220,33 @@ This finding is still open.
 **Detail:** $detail
 
 **Standard:** [$standard_ref](https://github.com/$ORG/.github/blob/main/$standard_ref)" 2>/dev/null || update_ok=false
-    # Ensure claude label is present on pre-existing issues regardless
-    gh issue edit "$existing" --repo "$ORG/$repo" --add-label "claude" 2>/dev/null || true
     if [ "$update_ok" = "true" ]; then
       info "Updated existing issue #$existing in $repo for: $check"
       ISSUES_EXISTING=$((ISSUES_EXISTING + 1))
     else
       warn "Failed to update existing issue #$existing in $repo for: $check"
+    fi
+
+    # Re-engage dev-lead on findings that PERSIST across audits.
+    #
+    # dev-lead listens on issues:labeled and fires only once per label
+    # application. The `claude` label is already present on a pre-existing
+    # issue, so a plain --add-label is a no-op that emits no event and dev-lead
+    # is never re-triggered. To give it a fresh chance to produce a fix PR we
+    # cycle the label (remove + re-add) — UNLESS dev-lead is already working
+    # this issue (open dev-lead PR or `in-progress` label), in which case we
+    # must not interrupt it and simply ensure the label is present.
+    if dl_dev_lead_active "$ORG" "$repo" "$existing"; then
+      gh issue edit "$existing" --repo "$ORG/$repo" --add-label "claude" 2>/dev/null || true
+      info "Existing issue #$existing in $repo — dev-lead already active, not re-triggering"
+    elif dl_cycle_trigger_label "$ORG" "$repo" "$existing" "claude" "$DRY_RUN"; then
+      info "Re-triggered dev-lead on persistent issue #$existing in $repo for: $check"
+      ISSUES_RETRIGGERED=$((ISSUES_RETRIGGERED + 1))
+    else
+      # Cycle failed mid-way — ensure the label is at least present so the issue
+      # is not left without its trigger label.
+      gh issue edit "$existing" --repo "$ORG/$repo" --add-label "claude" 2>/dev/null || true
+      warn "Failed to re-trigger dev-lead on issue #$existing in $repo for: $check"
     fi
     # Record existing issue for umbrella
     jq --null-input \
@@ -1808,8 +1834,8 @@ main() {
 
   # Write issue-management counts and append to summary (conditional on issue management running)
   if [ "$CREATE_ISSUES" = "true" ] && [ "$DRY_RUN" != "true" ]; then
-    printf '{"added":%d,"existing":%d,"removed":%d}\n' \
-      "$ISSUES_ADDED" "$ISSUES_EXISTING" "$ISSUES_REMOVED" > "$ISSUE_COUNTS_FILE"
+    printf '{"added":%d,"existing":%d,"removed":%d,"retriggered":%d}\n' \
+      "$ISSUES_ADDED" "$ISSUES_EXISTING" "$ISSUES_REMOVED" "$ISSUES_RETRIGGERED" > "$ISSUE_COUNTS_FILE"
     cat >> "$SUMMARY_FILE" <<HEREDOC
 
 ## Issue Management
@@ -1818,10 +1844,11 @@ main() {
 |--------|-------|
 | Added (new) | $ISSUES_ADDED |
 | Existing (updated) | $ISSUES_EXISTING |
+| Re-triggered (dev-lead re-engaged) | $ISSUES_RETRIGGERED |
 | Removed (resolved) | $ISSUES_REMOVED |
 HEREDOC
   else
-    printf '{"added":0,"existing":0,"removed":0}\n' > "$ISSUE_COUNTS_FILE"
+    printf '{"added":0,"existing":0,"removed":0,"retriggered":0}\n' > "$ISSUE_COUNTS_FILE"
     cat >> "$SUMMARY_FILE" <<HEREDOC
 
 ## Issue Management

--- a/scripts/compliance-retrigger.sh
+++ b/scripts/compliance-retrigger.sh
@@ -181,8 +181,11 @@ retrigger_stale_issues() {
     fi
 
     info "Re-triggering $repo#$number: $title (created $created_at)"
-    dl_cycle_trigger_label "$ORG" "$repo" "$number" "$TRIGGER_LABEL" "$DRY_RUN"
-    ISSUES_RETRIGGERED=$((ISSUES_RETRIGGERED + 1))
+    if dl_cycle_trigger_label "$ORG" "$repo" "$number" "$TRIGGER_LABEL" "$DRY_RUN"; then
+      ISSUES_RETRIGGERED=$((ISSUES_RETRIGGERED + 1))
+    else
+      warn "Failed to re-trigger dev-lead on issue #$number in $repo"
+    fi
     # Brief pause to avoid flooding the API
     sleep 1
   done <<< "$issues"

--- a/scripts/compliance-retrigger.sh
+++ b/scripts/compliance-retrigger.sh
@@ -33,6 +33,10 @@ STALE_DAYS="${STALE_DAYS:-2}"
 DRY_RUN="${DRY_RUN:-false}"
 AUDIT_LABEL="${AUDIT_LABEL:-compliance-audit}"
 TRIGGER_LABEL="${TRIGGER_LABEL:-dev-lead}"
+# Legacy label to also sweep during the transition window before the one-time
+# migration script has run. Issues that still carry only the old label are
+# found here and given the new label so dev-lead picks them up.
+LEGACY_TRIGGER_LABEL="${LEGACY_TRIGGER_LABEL:-claude}"
 
 # Shared dev-lead retrigger helpers (dl_dev_lead_active, dl_cycle_trigger_label).
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -197,6 +201,56 @@ retrigger_stale_issues() {
     fi
     # dl_cycle_trigger_label already sleeps 1s internally; no additional pause needed.
   done <<< "$issues"
+
+  # Sweep pre-migration issues that still carry only the legacy trigger label.
+  # When this change is deployed before the one-time migration has run, open
+  # compliance issues with the legacy label would otherwise be invisible to the
+  # main search above and never retriggered. Adding TRIGGER_LABEL to each such
+  # issue both recovers the lost event and acts as a lazy per-issue migration.
+  if [ -n "${LEGACY_TRIGGER_LABEL:-}" ] && [ "$LEGACY_TRIGGER_LABEL" != "$TRIGGER_LABEL" ]; then
+    info "Sweeping pre-migration '$LEGACY_TRIGGER_LABEL'-labeled issues..."
+    local legacy_raw legacy_rc
+    # Exclude issues that already carry TRIGGER_LABEL — they were handled above.
+    legacy_raw=$(gh api \
+      "search/issues?q=org:${ORG}+label:${AUDIT_LABEL}+label:${LEGACY_TRIGGER_LABEL}+-label:${TRIGGER_LABEL}+state:open&per_page=100" \
+      2>&1) && legacy_rc=0 || legacy_rc=$?
+    if [ "$legacy_rc" -ne 0 ]; then
+      warn "Legacy label sweep search failed (exit $legacy_rc) — pre-migration issues not swept this run"
+    else
+      local legacy_total legacy_issues
+      legacy_total=$(echo "$legacy_raw" | jq -r '.total_count // 0')
+      info "Legacy sweep found ${legacy_total} matching issues"
+      legacy_issues=$(echo "$legacy_raw" | jq -c '.items[] | {number: .number, repo: (.repository_url | split("/") | last), created_at: .created_at, title: .title}')
+      while IFS= read -r issue_json; do
+        [ -z "$issue_json" ] && continue
+        number=$(echo "$issue_json" | jq -r '.number')
+        repo=$(echo "$issue_json" | jq -r '.repo')
+        created_at=$(echo "$issue_json" | jq -r '.created_at')
+        title=$(echo "$issue_json" | jq -r '.title')
+        if [[ "$created_at" > "$cutoff" ]]; then
+          ISSUES_SKIPPED=$((ISSUES_SKIPPED + 1))
+          continue
+        fi
+        if dl_dev_lead_active "$ORG" "$repo" "$number"; then
+          info "Skipping legacy $repo#$number — dev-lead already active"
+          ISSUES_SKIPPED=$((ISSUES_SKIPPED + 1))
+          continue
+        fi
+        info "Adding '$TRIGGER_LABEL' to pre-migration issue $repo#$number: $title"
+        if [ "$DRY_RUN" = "true" ]; then
+          info "[dry-run] would add '$TRIGGER_LABEL' to $repo#$number"
+          ISSUES_RETRIGGERED=$((ISSUES_RETRIGGERED + 1))
+        elif gh api -X POST "repos/$ORG/$repo/issues/$number/labels" \
+          --field "labels[]=$TRIGGER_LABEL" >/dev/null 2>&1; then
+          info "  added '$TRIGGER_LABEL' to $repo#$number"
+          ISSUES_RETRIGGERED=$((ISSUES_RETRIGGERED + 1))
+        else
+          warn "Failed to add '$TRIGGER_LABEL' to $repo#$number — issue may not be retriggered"
+          ISSUES_SKIPPED=$((ISSUES_SKIPPED + 1))
+        fi
+      done <<< "$legacy_issues"
+    fi
+  fi
 
   info "Re-trigger complete: ${ISSUES_RETRIGGERED} retriggered, ${ISSUES_SKIPPED} skipped"
 }

--- a/scripts/compliance-retrigger.sh
+++ b/scripts/compliance-retrigger.sh
@@ -184,10 +184,18 @@ retrigger_stale_issues() {
     if dl_cycle_trigger_label "$ORG" "$repo" "$number" "$TRIGGER_LABEL" "$DRY_RUN"; then
       ISSUES_RETRIGGERED=$((ISSUES_RETRIGGERED + 1))
     else
-      warn "Failed to re-trigger dev-lead on issue #$number in $repo"
+      warn "Failed to re-trigger dev-lead on issue #$number in $repo — attempting to restore label"
+      # The label may have been deleted but the re-add failed. Restore it so the
+      # issue remains visible to the next sweep's search query.
+      if [ "$DRY_RUN" != "true" ]; then
+        gh api -X POST "repos/$ORG/$repo/issues/$number/labels" \
+          --field "labels[]=$TRIGGER_LABEL" >/dev/null 2>&1 \
+          && info "Restored $TRIGGER_LABEL on $repo#$number" \
+          || warn "Could not restore $TRIGGER_LABEL on $repo#$number — issue may drop out of next sweep"
+      fi
+      ISSUES_SKIPPED=$((ISSUES_SKIPPED + 1))
     fi
-    # Brief pause to avoid flooding the API
-    sleep 1
+    # dl_cycle_trigger_label already sleeps 1s internally; no additional pause needed.
   done <<< "$issues"
 
   info "Re-trigger complete: ${ISSUES_RETRIGGERED} retriggered, ${ISSUES_SKIPPED} skipped"

--- a/scripts/compliance-retrigger.sh
+++ b/scripts/compliance-retrigger.sh
@@ -158,8 +158,7 @@ retrigger_stale_issues() {
   issues=$(echo "$raw" | jq -c '.items[] | {number: .number, repo: (.repository_url | split("/") | last), created_at: .created_at, title: .title}')
 
   if [ -z "$issues" ]; then
-    info "No open compliance-audit issues found."
-    return 0
+    info "No open compliance-audit issues found with '$TRIGGER_LABEL' label."
   fi
 
   while IFS= read -r issue_json; do
@@ -238,15 +237,23 @@ retrigger_stale_issues() {
         fi
         info "Adding '$TRIGGER_LABEL' to pre-migration issue $repo#$number: $title"
         if [ "$DRY_RUN" = "true" ]; then
-          info "[dry-run] would add '$TRIGGER_LABEL' to $repo#$number"
-          ISSUES_RETRIGGERED=$((ISSUES_RETRIGGERED + 1))
-        elif gh api -X POST "repos/$ORG/$repo/issues/$number/labels" \
-          --field "labels[]=$TRIGGER_LABEL" >/dev/null 2>&1; then
-          info "  added '$TRIGGER_LABEL' to $repo#$number"
+          info "[dry-run] would ensure '$TRIGGER_LABEL' label exists in $repo and add it to #$number"
           ISSUES_RETRIGGERED=$((ISSUES_RETRIGGERED + 1))
         else
-          warn "Failed to add '$TRIGGER_LABEL' to $repo#$number — issue may not be retriggered"
-          ISSUES_SKIPPED=$((ISSUES_SKIPPED + 1))
+          # Repos in the pre-migration state may only have the legacy label
+          # object. Ensure the new label exists before trying to apply it so
+          # the add-label API call does not fail silently and leave the issue
+          # invisible to the main dev-lead sweep.
+          gh label create "$TRIGGER_LABEL" --repo "$ORG/$repo" \
+            --color "8B5CF6" --description "For dev-lead agent pickup" --force 2>/dev/null || true
+          if gh api -X POST "repos/$ORG/$repo/issues/$number/labels" \
+            --field "labels[]=$TRIGGER_LABEL" >/dev/null 2>&1; then
+            info "  added '$TRIGGER_LABEL' to $repo#$number"
+            ISSUES_RETRIGGERED=$((ISSUES_RETRIGGERED + 1))
+          else
+            warn "Failed to add '$TRIGGER_LABEL' to $repo#$number — issue may not be retriggered"
+            ISSUES_SKIPPED=$((ISSUES_SKIPPED + 1))
+          fi
         fi
       done <<< "$legacy_issues"
     fi

--- a/scripts/compliance-retrigger.sh
+++ b/scripts/compliance-retrigger.sh
@@ -34,6 +34,11 @@ DRY_RUN="${DRY_RUN:-false}"
 AUDIT_LABEL="${AUDIT_LABEL:-compliance-audit}"
 TRIGGER_LABEL="${TRIGGER_LABEL:-claude}"
 
+# Shared dev-lead retrigger helpers (dl_dev_lead_active, dl_cycle_trigger_label).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/dev-lead-retrigger.sh
+. "$SCRIPT_DIR/lib/dev-lead-retrigger.sh"
+
 ISSUES_RETRIGGERED=0
 ISSUES_SKIPPED=0
 WORKFLOWS_DISABLED=0
@@ -47,37 +52,16 @@ info()  { echo "[info]  $*"; }
 warn()  { echo "[warn]  $*" >&2; }
 error() { echo "[error] $*" >&2; }
 
-gh_api() { gh api "$@"; }
+# has_open_pr / cycle_label live in lib/dev-lead-retrigger.sh as
+# dl_dev_lead_active() and dl_cycle_trigger_label(), shared with the weekly
+# compliance audit so both stay in sync with dev-lead's branch-naming
+# convention. Sourced via SCRIPT_DIR resolved at the top of the file.
 
 # stale_cutoff — ISO timestamp N days ago
 stale_cutoff() {
   date -u -d "${STALE_DAYS} days ago" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
     || python3 -c "from datetime import datetime,timedelta,timezone; \
                    print((datetime.now(timezone.utc)-timedelta(days=${STALE_DAYS})).strftime('%Y-%m-%dT%H:%M:%SZ'))"
-}
-
-# has_open_pr <repo> <issue_number>
-# Returns 0 (true) if there is an open PR with head ref dev-lead/issue-<number>*
-has_open_pr() {
-  local repo="$1" issue="$2"
-  local count
-  count=$(gh_api "repos/$ORG/$repo/pulls?state=open" \
-    --jq "[.[] | select(.head.ref | startswith(\"dev-lead/issue-${issue}\"))] | length" \
-    2>/dev/null || echo "0")
-  [ "${count:-0}" -gt 0 ]
-}
-
-# cycle_label <repo> <issue>
-# Removes and re-adds TRIGGER_LABEL so issues:labeled fires again.
-cycle_label() {
-  local repo="$1" issue="$2"
-  if [ "$DRY_RUN" = "true" ]; then
-    info "[dry-run] would cycle '$TRIGGER_LABEL' on $repo#$issue"
-    return 0
-  fi
-  gh api -X DELETE "repos/$ORG/$repo/issues/$issue/labels/$TRIGGER_LABEL" 2>/dev/null || true
-  gh api -X POST "repos/$ORG/$repo/issues/$issue/labels" \
-    --field "labels[]=$TRIGGER_LABEL" >/dev/null
 }
 
 # ---------------------------------------------------------------------------
@@ -189,15 +173,15 @@ retrigger_stale_issues() {
       continue
     fi
 
-    # Check if a dev-lead PR already exists for this issue
-    if has_open_pr "$repo" "$number"; then
-      info "Skipping $repo#$number — open dev-lead PR already exists"
+    # Skip if dev-lead is already working this issue (open PR or in-progress).
+    if dl_dev_lead_active "$ORG" "$repo" "$number"; then
+      info "Skipping $repo#$number — dev-lead already active (open PR or in-progress)"
       ISSUES_SKIPPED=$((ISSUES_SKIPPED + 1))
       continue
     fi
 
     info "Re-triggering $repo#$number: $title (created $created_at)"
-    cycle_label "$repo" "$number"
+    dl_cycle_trigger_label "$ORG" "$repo" "$number" "$TRIGGER_LABEL" "$DRY_RUN"
     ISSUES_RETRIGGERED=$((ISSUES_RETRIGGERED + 1))
     # Brief pause to avoid flooding the API
     sleep 1

--- a/scripts/compliance-retrigger.sh
+++ b/scripts/compliance-retrigger.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 #      Disabled workflows silently swallow issue-labeled events — findings
 #      will never be fixed even if labels are applied correctly.
 #   2. Finds all open compliance-audit issues that are ≥ STALE_DAYS old and
-#      have no associated open PR on a dev-lead branch.  Cycles the "claude"
+#      have no associated open PR on a dev-lead branch.  Cycles the "dev-lead"
 #      label (remove + re-add) to re-fire the issues:labeled event and give
 #      dev-lead a fresh chance to create a fix PR.
 #
@@ -26,13 +26,13 @@ set -euo pipefail
 #   STALE_DAYS    — issues older than this are considered stale (default: 2)
 #   DRY_RUN       — set to "true" to log actions without executing them
 #   AUDIT_LABEL   — label used to tag compliance findings (default: compliance-audit)
-#   TRIGGER_LABEL — label used to trigger dev-lead (default: claude)
+#   TRIGGER_LABEL — label used to trigger dev-lead (default: dev-lead)
 
 ORG="${ORG:-petry-projects}"
 STALE_DAYS="${STALE_DAYS:-2}"
 DRY_RUN="${DRY_RUN:-false}"
 AUDIT_LABEL="${AUDIT_LABEL:-compliance-audit}"
-TRIGGER_LABEL="${TRIGGER_LABEL:-claude}"
+TRIGGER_LABEL="${TRIGGER_LABEL:-dev-lead}"
 
 # Shared dev-lead retrigger helpers (dl_dev_lead_active, dl_cycle_trigger_label).
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/compliance-retrigger.sh
+++ b/scripts/compliance-retrigger.sh
@@ -208,18 +208,19 @@ retrigger_stale_issues() {
   # issue both recovers the lost event and acts as a lazy per-issue migration.
   if [ -n "${LEGACY_TRIGGER_LABEL:-}" ] && [ "$LEGACY_TRIGGER_LABEL" != "$TRIGGER_LABEL" ]; then
     info "Sweeping pre-migration '$LEGACY_TRIGGER_LABEL'-labeled issues..."
-    local legacy_raw legacy_rc
+    local legacy_issues legacy_rc
     # Exclude issues that already carry TRIGGER_LABEL — they were handled above.
-    legacy_raw=$(gh api \
+    # --paginate walks all result pages so issues beyond the first 100 are included.
+    legacy_issues=$(gh api --paginate \
       "search/issues?q=org:${ORG}+label:${AUDIT_LABEL}+label:${LEGACY_TRIGGER_LABEL}+-label:${TRIGGER_LABEL}+state:open&per_page=100" \
+      --jq '.items[] | {number: .number, repo: (.repository_url | split("/") | last), created_at: .created_at, title: .title}' \
       2>&1) && legacy_rc=0 || legacy_rc=$?
     if [ "$legacy_rc" -ne 0 ]; then
       warn "Legacy label sweep search failed (exit $legacy_rc) — pre-migration issues not swept this run"
     else
-      local legacy_total legacy_issues
-      legacy_total=$(echo "$legacy_raw" | jq -r '.total_count // 0')
+      local legacy_total
+      legacy_total=$(echo "$legacy_issues" | jq -s 'length')
       info "Legacy sweep found ${legacy_total} matching issues"
-      legacy_issues=$(echo "$legacy_raw" | jq -c '.items[] | {number: .number, repo: (.repository_url | split("/") | last), created_at: .created_at, title: .title}')
       while IFS= read -r issue_json; do
         [ -z "$issue_json" ] && continue
         number=$(echo "$issue_json" | jq -r '.number')

--- a/scripts/lib/dev-lead-retrigger.sh
+++ b/scripts/lib/dev-lead-retrigger.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# dev-lead-retrigger.sh — shared helpers for re-engaging the dev-lead agent on a
+# compliance issue by cycling its trigger label.
+#
+# Sourced by:
+#   scripts/compliance-audit.sh      — weekly audit; re-triggers findings that
+#                                      persist across runs (issue still open).
+#   scripts/compliance-retrigger.sh  — daily sweep; re-triggers stale issues.
+#
+# Why a shared lib?
+#   Both entry points need the same two primitives, and both depend on how
+#   dev-lead names its branches (dev-lead/issue-<number>-<timestamp>, see
+#   scripts/dev-lead-fix-issue.sh in the agent repo). Keeping that convention in
+#   one place stops the two callers from drifting apart.
+#
+# These functions are pure helpers: they take all inputs as arguments and call
+# `gh api` directly, so they do not depend on the sourcing script's own wrappers
+# or globals.
+
+# dl_dev_lead_active <org> <repo> <issue>
+# Returns 0 (true) if dev-lead is ALREADY working this issue — either an open PR
+# exists on a dev-lead/issue-<number>-* branch, or the issue carries the
+# `in-progress` label. In that case the caller must NOT cycle the trigger label,
+# to avoid interrupting or duplicating active work.
+dl_dev_lead_active() {
+  local org="$1" repo="$2" issue="$3"
+
+  # Match the dev-lead branch exactly: "dev-lead/issue-<n>-<timestamp>".
+  # Require the trailing "-" so issue 1 does not match branch "issue-12-...".
+  local pr_count
+  pr_count=$(gh api "repos/$org/$repo/pulls?state=open" \
+    --jq "[.[] | select(.head.ref | startswith(\"dev-lead/issue-${issue}-\"))] | length" \
+    2>/dev/null || echo "0")
+  [ "${pr_count:-0}" -gt 0 ] && return 0
+
+  # An agent currently mid-run marks the issue `in-progress` before it pushes a
+  # PR — respect that window too.
+  local in_progress
+  in_progress=$(gh api "repos/$org/$repo/issues/$issue" \
+    --jq '[.labels[].name] | index("in-progress") // empty' \
+    2>/dev/null || echo "")
+  [ -n "$in_progress" ] && return 0
+
+  return 1
+}
+
+# dl_cycle_trigger_label <org> <repo> <issue> <label> [dry_run]
+# Remove then re-add <label> so GitHub emits a fresh issues:labeled event,
+# re-engaging dev-lead. dev-lead fires once per label application, so a
+# persistent finding whose label is already present needs the label cycled to be
+# picked up again. Returns non-zero if the re-add fails (the caller can fall
+# back to ensuring the label is at least present).
+dl_cycle_trigger_label() {
+  local org="$1" repo="$2" issue="$3" label="$4" dry_run="${5:-false}"
+
+  if [ "$dry_run" = "true" ]; then
+    echo "[dry-run] would cycle '$label' on $org/$repo#$issue" >&2
+    return 0
+  fi
+
+  gh api -X DELETE "repos/$org/$repo/issues/$issue/labels/$label" >/dev/null 2>&1 || true
+  # Let GitHub register the removal before re-adding so the add is not coalesced
+  # with the delete (which would emit no labeled event).
+  sleep 1
+  gh api -X POST "repos/$org/$repo/issues/$issue/labels" \
+    --field "labels[]=$label" >/dev/null 2>&1 || return 1
+}

--- a/scripts/lib/dev-lead-retrigger.sh
+++ b/scripts/lib/dev-lead-retrigger.sh
@@ -28,11 +28,18 @@ dl_dev_lead_active() {
   # Match the dev-lead branch exactly: "dev-lead/issue-<n>-<timestamp>".
   # Require the trailing "-" so issue 1 does not match branch "issue-12-...".
   # Use --paginate so repos with >100 open PRs are fully scanned.
-  local pr_count
-  pr_count=$(gh api "repos/$org/$repo/pulls?state=open&per_page=100" \
+  # Fail closed: if the API call itself fails (transient error, rate limit, token
+  # scope issue), treat the issue as active so we do not cycle the label and
+  # accidentally create duplicate work.
+  local pr_raw pr_count
+  if ! pr_raw=$(gh api "repos/$org/$repo/pulls?state=open&per_page=100" \
     --paginate \
     --jq "[.[] | select(.head.ref | type == \"string\" and startswith(\"dev-lead/issue-${issue}-\"))] | length" \
-    2>/dev/null | awk '{s+=$1} END {print s+0}')
+    2>/dev/null); then
+    echo "[warn]  PR lookup for $org/$repo#$issue failed — treating as active to avoid duplicate work" >&2
+    return 0
+  fi
+  pr_count=$(echo "$pr_raw" | awk '{s+=$1} END {print s+0}')
   [ "${pr_count:-0}" -gt 0 ] && return 0
 
   # An agent currently mid-run marks the issue `in-progress` before it pushes a
@@ -92,7 +99,14 @@ dl_cycle_trigger_label() {
   encoded_label=$(printf '%s' "$label" \
     | python3 -c "import sys, urllib.parse; print(urllib.parse.quote(sys.stdin.read().strip(), safe=''))" 2>/dev/null \
     || printf '%s' "$label" | sed 's/ /%20/g')
-  gh api -X DELETE "repos/$org/$repo/issues/$issue/labels/$encoded_label" >/dev/null 2>&1 || true
+  # Treat a failed DELETE as a hard failure: if the label is still present when we
+  # POST it back, GitHub will not emit a new labeled event, so the retrigger is a
+  # no-op even though it appears to succeed. Return non-zero so the caller can
+  # attempt a restore and warn appropriately.
+  if ! gh api -X DELETE "repos/$org/$repo/issues/$issue/labels/$encoded_label" >/dev/null 2>&1; then
+    echo "[warn]  Failed to remove '$label' from $org/$repo#$issue — skipping re-add to avoid emitting no event" >&2
+    return 1
+  fi
   # Let GitHub register the removal before re-adding so the add is not coalesced
   # with the delete (which would emit no labeled event).
   sleep 1

--- a/scripts/lib/dev-lead-retrigger.sh
+++ b/scripts/lib/dev-lead-retrigger.sh
@@ -29,7 +29,7 @@ dl_dev_lead_active() {
   # Require the trailing "-" so issue 1 does not match branch "issue-12-...".
   local pr_count
   pr_count=$(gh api "repos/$org/$repo/pulls?state=open" \
-    --jq "[.[] | select(.head.ref | startswith(\"dev-lead/issue-${issue}-\"))] | length" \
+    --jq "[.[] | select(.head.ref | type == \"string\" and startswith(\"dev-lead/issue-${issue}-\"))] | length" \
     2>/dev/null || echo "0")
   [ "${pr_count:-0}" -gt 0 ] && return 0
 
@@ -37,7 +37,7 @@ dl_dev_lead_active() {
   # PR — respect that window too.
   local in_progress
   in_progress=$(gh api "repos/$org/$repo/issues/$issue" \
-    --jq '[.labels[].name] | index("in-progress") // empty' \
+    --jq '.labels[].name | select(. == "in-progress")' \
     2>/dev/null || echo "")
   [ -n "$in_progress" ] && return 0
 

--- a/scripts/lib/dev-lead-retrigger.sh
+++ b/scripts/lib/dev-lead-retrigger.sh
@@ -27,19 +27,47 @@ dl_dev_lead_active() {
 
   # Match the dev-lead branch exactly: "dev-lead/issue-<n>-<timestamp>".
   # Require the trailing "-" so issue 1 does not match branch "issue-12-...".
+  # Use --paginate so repos with >100 open PRs are fully scanned.
   local pr_count
-  pr_count=$(gh api "repos/$org/$repo/pulls?state=open" \
+  pr_count=$(gh api "repos/$org/$repo/pulls?state=open&per_page=100" \
+    --paginate \
     --jq "[.[] | select(.head.ref | type == \"string\" and startswith(\"dev-lead/issue-${issue}-\"))] | length" \
-    2>/dev/null || echo "0")
+    2>/dev/null | awk '{s+=$1} END {print s+0}')
   [ "${pr_count:-0}" -gt 0 ] && return 0
 
   # An agent currently mid-run marks the issue `in-progress` before it pushes a
-  # PR — respect that window too.
+  # PR — respect that window, but cap it at IN_PROGRESS_MAX_HOURS so a crashed or
+  # cancelled run cannot block retrigger indefinitely.
   local in_progress
   in_progress=$(gh api "repos/$org/$repo/issues/$issue" \
     --jq '.labels[].name | select(. == "in-progress")' \
     2>/dev/null || echo "")
-  [ -n "$in_progress" ] && return 0
+
+  if [ -n "$in_progress" ]; then
+    local in_progress_max_hours="${IN_PROGRESS_MAX_HOURS:-4}"
+    local labeled_at
+    labeled_at=$(gh api "repos/$org/$repo/issues/$issue/events?per_page=100" \
+      --paginate \
+      --jq '.[] | select(.event == "labeled" and .label.name == "in-progress") | .created_at' \
+      2>/dev/null | tail -1 || echo "")
+
+    if [ -z "$labeled_at" ] || [ "$labeled_at" = "null" ]; then
+      # Cannot determine when the label was applied; trust it conservatively.
+      return 0
+    fi
+
+    local now_epoch labeled_epoch elapsed_hours
+    now_epoch=$(date -u +%s)
+    labeled_epoch=$(date -u -d "$labeled_at" +%s 2>/dev/null \
+      || python3 -c "import sys, calendar, datetime; \
+                     ts = sys.stdin.read().strip(); \
+                     print(calendar.timegm(datetime.datetime.strptime(ts, '%Y-%m-%dT%H:%M:%SZ').timetuple()))" \
+      <<< "$labeled_at")
+    elapsed_hours=$(( (now_epoch - labeled_epoch) / 3600 ))
+
+    [ "$elapsed_hours" -le "$in_progress_max_hours" ] && return 0
+    # in-progress label is stale (agent likely crashed); fall through to return 1.
+  fi
 
   return 1
 }
@@ -58,7 +86,13 @@ dl_cycle_trigger_label() {
     return 0
   fi
 
-  gh api -X DELETE "repos/$org/$repo/issues/$issue/labels/$label" >/dev/null 2>&1 || true
+  # URL-encode the label for the REST path segment to handle names that contain
+  # spaces or other reserved characters.
+  local encoded_label
+  encoded_label=$(printf '%s' "$label" \
+    | python3 -c "import sys, urllib.parse; print(urllib.parse.quote(sys.stdin.read().strip(), safe=''))" 2>/dev/null \
+    || printf '%s' "$label" | sed 's/ /%20/g')
+  gh api -X DELETE "repos/$org/$repo/issues/$issue/labels/$encoded_label" >/dev/null 2>&1 || true
   # Let GitHub register the removal before re-adding so the add is not coalesced
   # with the delete (which would emit no labeled event).
   sleep 1

--- a/scripts/lib/dev-lead-retrigger.sh
+++ b/scripts/lib/dev-lead-retrigger.sh
@@ -46,9 +46,12 @@ dl_dev_lead_active() {
   # PR — respect that window, but cap it at IN_PROGRESS_MAX_HOURS so a crashed or
   # cancelled run cannot block retrigger indefinitely.
   local in_progress
-  in_progress=$(gh api "repos/$org/$repo/issues/$issue" \
+  if ! in_progress=$(gh api "repos/$org/$repo/issues/$issue" \
     --jq '.labels[].name | select(. == "in-progress")' \
-    2>/dev/null || echo "")
+    2>/dev/null); then
+    echo "[warn]  Issue lookup for $org/$repo#$issue failed — treating as active to avoid duplicate work" >&2
+    return 0
+  fi
 
   if [ -n "$in_progress" ]; then
     local in_progress_max_hours="${IN_PROGRESS_MAX_HOURS:-4}"

--- a/scripts/lib/dev-lead-retrigger.sh
+++ b/scripts/lib/dev-lead-retrigger.sh
@@ -76,7 +76,20 @@ dl_dev_lead_active() {
     elapsed_hours=$(( (now_epoch - labeled_epoch) / 3600 ))
 
     [ "$elapsed_hours" -le "$in_progress_max_hours" ] && return 0
-    # in-progress label is stale (agent likely crashed); fall through to return 1.
+    # in-progress label is stale (agent likely crashed). Remove it before
+    # returning inactive: AGENTS.md's claim protocol requires any agent to skip
+    # an issue that still carries in-progress, so leaving the label in place
+    # means the next dev-lead run will immediately skip the issue even after the
+    # trigger label is cycled, leaving the crash unrecovered.
+    if [ "${DRY_RUN:-false}" = "true" ]; then
+      echo "[dry-run] would remove stale 'in-progress' from $org/$repo#$issue" >&2
+    else
+      gh api -X DELETE "repos/$org/$repo/issues/$issue/labels/in-progress" \
+        >/dev/null 2>&1 \
+        && echo "[info]  Removed stale 'in-progress' from $org/$repo#$issue" >&2 \
+        || echo "[warn]  Could not remove stale 'in-progress' from $org/$repo#$issue — dev-lead may skip it" >&2
+    fi
+    # fall through to return 1 (inactive)
   fi
 
   return 1

--- a/scripts/migrate-claude-label.sh
+++ b/scripts/migrate-claude-label.sh
@@ -82,8 +82,22 @@ migrate_repo() {
 
   # 2. Re-label every OPEN issue currently carrying the old label.
   local issues repo_failed=0
-  issues=$(gh issue list --repo "$ORG/$repo" --label "$OLD_LABEL" --state open \
-    --limit 1000 --json number -q '.[].number' 2>/dev/null || echo "")
+  # URL-encode the label for the REST query parameter.
+  local encoded_old_label
+  encoded_old_label=$(printf '%s' "$OLD_LABEL" \
+    | python3 -c "import sys,urllib.parse; print(urllib.parse.quote(sys.stdin.read().strip(),safe=''))" 2>/dev/null \
+    || printf '%s' "$OLD_LABEL" | sed 's/ /%20/g')
+  # Use gh api --paginate for truly unlimited results; gh issue list --limit
+  # caps at a fixed number and does not paginate beyond it. Treat a failed
+  # listing as a repo_failed condition so we never delete the old label if we
+  # could not confirm every open issue was migrated.
+  if ! issues=$(gh api \
+    "repos/$ORG/$repo/issues?state=open&labels=${encoded_old_label}&per_page=100" \
+    --paginate --jq '.[] | select(.pull_request == null) | .number' 2>/dev/null); then
+    warn "  failed to list open '$OLD_LABEL' issues in $repo — skipping deletion to avoid data loss"
+    repo_failed=1
+    issues=""
+  fi
   while IFS= read -r num; do
     [ -z "$num" ] && continue
     if issue_has_label "$repo" "$num" "$NEW_LABEL"; then
@@ -93,15 +107,16 @@ migrate_repo() {
     fi
     if [ "$DRY_RUN" = "true" ]; then
       info "[dry-run] would add '$NEW_LABEL' to $repo#$num"
+      LABELS_ADDED=$((LABELS_ADDED + 1))
     else
       if gh issue edit "$num" --repo "$ORG/$repo" --add-label "$NEW_LABEL" >/dev/null 2>&1; then
         info "  added '$NEW_LABEL' to $repo#$num"
+        LABELS_ADDED=$((LABELS_ADDED + 1))
       else
         warn "  failed to add '$NEW_LABEL' to $repo#$num"
         repo_failed=1
       fi
     fi
-    LABELS_ADDED=$((LABELS_ADDED + 1))
   done <<< "$issues"
 
   # 3. Delete the old label object (strips it from all issues/PRs).

--- a/scripts/migrate-claude-label.sh
+++ b/scripts/migrate-claude-label.sh
@@ -116,6 +116,10 @@ migrate_repo() {
     if dl_dev_lead_active "$ORG" "$repo" "$num"; then
       info "  #$num has active dev-lead work — deferring migration"
       ISSUES_SKIPPED=$((ISSUES_SKIPPED + 1))
+      # Mark the repo as unsafe to delete the old label: this issue still
+      # carries only the old label and deleting it would leave the issue with
+      # no trigger label while dev-lead's active run or PR is in flight.
+      repo_failed=1
       continue
     fi
     if [ "$DRY_RUN" = "true" ]; then

--- a/scripts/migrate-claude-label.sh
+++ b/scripts/migrate-claude-label.sh
@@ -81,9 +81,9 @@ migrate_repo() {
   fi
 
   # 2. Re-label every OPEN issue currently carrying the old label.
-  local issues
+  local issues repo_failed=0
   issues=$(gh issue list --repo "$ORG/$repo" --label "$OLD_LABEL" --state open \
-    --json number -q '.[].number' 2>/dev/null || echo "")
+    --limit 1000 --json number -q '.[].number' 2>/dev/null || echo "")
   while IFS= read -r num; do
     [ -z "$num" ] && continue
     if issue_has_label "$repo" "$num" "$NEW_LABEL"; then
@@ -94,15 +94,18 @@ migrate_repo() {
     if [ "$DRY_RUN" = "true" ]; then
       info "[dry-run] would add '$NEW_LABEL' to $repo#$num"
     else
-      gh issue edit "$num" --repo "$ORG/$repo" --add-label "$NEW_LABEL" >/dev/null 2>&1 \
-        && info "  added '$NEW_LABEL' to $repo#$num" \
-        || warn "  failed to add '$NEW_LABEL' to $repo#$num"
+      if gh issue edit "$num" --repo "$ORG/$repo" --add-label "$NEW_LABEL" >/dev/null 2>&1; then
+        info "  added '$NEW_LABEL' to $repo#$num"
+      else
+        warn "  failed to add '$NEW_LABEL' to $repo#$num"
+        repo_failed=1
+      fi
     fi
     LABELS_ADDED=$((LABELS_ADDED + 1))
   done <<< "$issues"
 
   # 3. Delete the old label object (strips it from all issues/PRs).
-  if [ "$DELETE_OLD_LABEL" = "true" ]; then
+  if [ "$DELETE_OLD_LABEL" = "true" ] && [ "$repo_failed" -eq 0 ]; then
     if [ "$DRY_RUN" = "true" ]; then
       info "[dry-run] would DELETE label '$OLD_LABEL' from $repo"
     else
@@ -111,6 +114,8 @@ migrate_repo() {
         || warn "  failed to delete '$OLD_LABEL' label from $repo"
     fi
     LABELS_DELETED=$((LABELS_DELETED + 1))
+  elif [ "$repo_failed" -ne 0 ]; then
+    warn "  keeping '$OLD_LABEL' on $repo — one or more re-labels failed"
   fi
 }
 
@@ -121,7 +126,7 @@ main() {
   if [ -n "$TARGET_REPO" ]; then
     repos="${TARGET_REPO#"$ORG/"}"
   else
-    repos=$(gh repo list "$ORG" --no-archived --limit 200 --json name -q '.[].name')
+    repos=$(gh repo list "$ORG" --no-archived --limit 1000 --json name -q '.[].name')
   fi
 
   for repo in $repos; do

--- a/scripts/migrate-claude-label.sh
+++ b/scripts/migrate-claude-label.sh
@@ -136,12 +136,12 @@ migrate_repo() {
   if [ "$DELETE_OLD_LABEL" = "true" ] && [ "$repo_failed" -eq 0 ]; then
     if [ "$DRY_RUN" = "true" ]; then
       info "[dry-run] would DELETE label '$OLD_LABEL' from $repo"
+      LABELS_DELETED=$((LABELS_DELETED + 1))
     else
       gh api -X DELETE "repos/$ORG/$repo/labels/$OLD_LABEL" >/dev/null 2>&1 \
-        && info "  deleted '$OLD_LABEL' label from $repo" \
+        && { info "  deleted '$OLD_LABEL' label from $repo"; LABELS_DELETED=$((LABELS_DELETED + 1)); } \
         || warn "  failed to delete '$OLD_LABEL' label from $repo"
     fi
-    LABELS_DELETED=$((LABELS_DELETED + 1))
   elif [ "$repo_failed" -ne 0 ]; then
     warn "  keeping '$OLD_LABEL' on $repo — one or more re-labels failed"
   fi

--- a/scripts/migrate-claude-label.sh
+++ b/scripts/migrate-claude-label.sh
@@ -50,6 +50,11 @@ LABELS_DELETED=0
 info()  { echo "[info]  $*"; }
 warn()  { echo "[warn]  $*" >&2; }
 
+# Shared dev-lead retrigger helpers (dl_dev_lead_active).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/dev-lead-retrigger.sh
+. "$SCRIPT_DIR/lib/dev-lead-retrigger.sh"
+
 # repo_has_label <repo> <label> — 0 if the label object exists in the repo.
 repo_has_label() {
   gh api "repos/$ORG/$1/labels/$2" --jq '.name' >/dev/null 2>&1
@@ -102,6 +107,14 @@ migrate_repo() {
     [ -z "$num" ] && continue
     if issue_has_label "$repo" "$num" "$NEW_LABEL"; then
       info "  #$num already has '$NEW_LABEL' — skipping"
+      ISSUES_SKIPPED=$((ISSUES_SKIPPED + 1))
+      continue
+    fi
+    # Skip issues where dev-lead is already actively working (open PR or
+    # in-progress label) to avoid emitting a duplicate issues:labeled event
+    # that would start a second run in parallel with the active one.
+    if dl_dev_lead_active "$ORG" "$repo" "$num"; then
+      info "  #$num has active dev-lead work — deferring migration"
       ISSUES_SKIPPED=$((ISSUES_SKIPPED + 1))
       continue
     fi

--- a/scripts/migrate-claude-label.sh
+++ b/scripts/migrate-claude-label.sh
@@ -140,7 +140,6 @@ migrate_repo() {
   if [ "$DELETE_OLD_LABEL" = "true" ] && [ "$repo_failed" -eq 0 ]; then
     if [ "$DRY_RUN" = "true" ]; then
       info "[dry-run] would DELETE label '$OLD_LABEL' from $repo"
-      LABELS_DELETED=$((LABELS_DELETED + 1))
     else
       gh api -X DELETE "repos/$ORG/$repo/labels/$OLD_LABEL" >/dev/null 2>&1 \
         && { info "  deleted '$OLD_LABEL' label from $repo"; LABELS_DELETED=$((LABELS_DELETED + 1)); } \

--- a/scripts/migrate-claude-label.sh
+++ b/scripts/migrate-claude-label.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# migrate-claude-label.sh — One-time org-wide migration of the legacy `claude`
+# issue-trigger label to the canonical `dev-lead` label.
+#
+# Background:
+#   The dev-lead agent historically accepted BOTH `dev-lead` and `claude` labels
+#   (claude being backward-compat from the retired claude.yml workflow). We are
+#   removing the `claude` label entirely. dev-lead now triggers on `dev-lead`
+#   only, and the compliance audit creates/cycles the `dev-lead` label.
+#
+# What this does, per non-archived org repo that has a `claude` label:
+#   1. Ensure the `dev-lead` label exists (created idempotently).
+#   2. For every OPEN issue still labelled `claude`, add the `dev-lead` label so
+#      the issue stays actionable. (Adding the label re-fires issues:labeled, so
+#      dev-lead will pick the issue up — this is intended: a `claude`-labelled
+#      open issue was already pending pickup.)
+#   3. If DELETE_OLD_LABEL=true, delete the `claude` label object from the repo,
+#      which strips it from every issue/PR (open and closed).
+#
+# Idempotent: re-running skips issues that already carry `dev-lead` (no duplicate
+# trigger) and is a no-op once the `claude` label has been deleted.
+#
+# Environment:
+#   GH_TOKEN          — token with issues:write + repo admin (label delete) across
+#                       the org (e.g. ORG_SCORECARD_TOKEN). Required.
+#   ORG               — GitHub org (default: petry-projects)
+#   OLD_LABEL         — legacy label to retire (default: claude)
+#   NEW_LABEL         — canonical replacement label (default: dev-lead)
+#   NEW_LABEL_COLOR   — hex color for the new label (default: 8B5CF6)
+#   NEW_LABEL_DESC    — description for the new label (default: For dev-lead agent pickup)
+#   DELETE_OLD_LABEL  — "true" to delete the old label object (default: true)
+#   DRY_RUN           — "true" to log without mutating (default: true — safe)
+#   TARGET_REPO       — limit to one repo (name or owner/name); blank = all repos
+
+ORG="${ORG:-petry-projects}"
+OLD_LABEL="${OLD_LABEL:-claude}"
+NEW_LABEL="${NEW_LABEL:-dev-lead}"
+NEW_LABEL_COLOR="${NEW_LABEL_COLOR:-8B5CF6}"
+NEW_LABEL_DESC="${NEW_LABEL_DESC:-For dev-lead agent pickup}"
+DELETE_OLD_LABEL="${DELETE_OLD_LABEL:-true}"
+DRY_RUN="${DRY_RUN:-true}"
+TARGET_REPO="${TARGET_REPO:-}"
+
+REPOS_PROCESSED=0
+LABELS_ADDED=0
+ISSUES_SKIPPED=0
+LABELS_DELETED=0
+
+info()  { echo "[info]  $*"; }
+warn()  { echo "[warn]  $*" >&2; }
+
+# repo_has_label <repo> <label> — 0 if the label object exists in the repo.
+repo_has_label() {
+  gh api "repos/$ORG/$1/labels/$2" --jq '.name' >/dev/null 2>&1
+}
+
+# issue_has_label <repo> <issue> <label> — 0 if the issue already carries label.
+issue_has_label() {
+  local present
+  present=$(gh api "repos/$ORG/$1/issues/$2" \
+    --jq "[.labels[].name] | index(\"$3\") // empty" 2>/dev/null || echo "")
+  [ -n "$present" ]
+}
+
+migrate_repo() {
+  local repo="$1"
+
+  if ! repo_has_label "$repo" "$OLD_LABEL"; then
+    return 0  # nothing to migrate in this repo
+  fi
+  REPOS_PROCESSED=$((REPOS_PROCESSED + 1))
+  info "Repo $repo has '$OLD_LABEL' label — migrating"
+
+  # 1. Ensure the new label exists.
+  if [ "$DRY_RUN" = "true" ]; then
+    info "[dry-run] would ensure label '$NEW_LABEL' exists in $repo"
+  else
+    gh label create "$NEW_LABEL" --repo "$ORG/$repo" \
+      --color "$NEW_LABEL_COLOR" --description "$NEW_LABEL_DESC" --force 2>/dev/null || true
+  fi
+
+  # 2. Re-label every OPEN issue currently carrying the old label.
+  local issues
+  issues=$(gh issue list --repo "$ORG/$repo" --label "$OLD_LABEL" --state open \
+    --json number -q '.[].number' 2>/dev/null || echo "")
+  while IFS= read -r num; do
+    [ -z "$num" ] && continue
+    if issue_has_label "$repo" "$num" "$NEW_LABEL"; then
+      info "  #$num already has '$NEW_LABEL' — skipping"
+      ISSUES_SKIPPED=$((ISSUES_SKIPPED + 1))
+      continue
+    fi
+    if [ "$DRY_RUN" = "true" ]; then
+      info "[dry-run] would add '$NEW_LABEL' to $repo#$num"
+    else
+      gh issue edit "$num" --repo "$ORG/$repo" --add-label "$NEW_LABEL" >/dev/null 2>&1 \
+        && info "  added '$NEW_LABEL' to $repo#$num" \
+        || warn "  failed to add '$NEW_LABEL' to $repo#$num"
+    fi
+    LABELS_ADDED=$((LABELS_ADDED + 1))
+  done <<< "$issues"
+
+  # 3. Delete the old label object (strips it from all issues/PRs).
+  if [ "$DELETE_OLD_LABEL" = "true" ]; then
+    if [ "$DRY_RUN" = "true" ]; then
+      info "[dry-run] would DELETE label '$OLD_LABEL' from $repo"
+    else
+      gh api -X DELETE "repos/$ORG/$repo/labels/$OLD_LABEL" >/dev/null 2>&1 \
+        && info "  deleted '$OLD_LABEL' label from $repo" \
+        || warn "  failed to delete '$OLD_LABEL' label from $repo"
+    fi
+    LABELS_DELETED=$((LABELS_DELETED + 1))
+  fi
+}
+
+main() {
+  info "migrate-claude-label starting (org=$ORG, $OLD_LABEL -> $NEW_LABEL, dry_run=$DRY_RUN, delete_old=$DELETE_OLD_LABEL)"
+
+  local repos
+  if [ -n "$TARGET_REPO" ]; then
+    repos="${TARGET_REPO#"$ORG/"}"
+  else
+    repos=$(gh repo list "$ORG" --no-archived --limit 200 --json name -q '.[].name')
+  fi
+
+  for repo in $repos; do
+    migrate_repo "$repo"
+  done
+
+  echo ""
+  echo "=========================================="
+  echo "  migrate-claude-label summary"
+  echo "=========================================="
+  echo "  Dry run             : $DRY_RUN"
+  echo "  Repos migrated      : $REPOS_PROCESSED"
+  echo "  Issues re-labelled  : $LABELS_ADDED"
+  echo "  Issues skipped      : $ISSUES_SKIPPED (already had '$NEW_LABEL')"
+  echo "  Old labels deleted  : $LABELS_DELETED"
+  echo "=========================================="
+
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    {
+      echo "## claude → dev-lead label migration"
+      echo ""
+      echo "| Metric | Value |"
+      echo "| ------ | ----- |"
+      echo "| Dry run | $DRY_RUN |"
+      echo "| Repos migrated | $REPOS_PROCESSED |"
+      echo "| Issues re-labelled | $LABELS_ADDED |"
+      echo "| Issues skipped (already \`$NEW_LABEL\`) | $ISSUES_SKIPPED |"
+      echo "| Old labels deleted | $LABELS_DELETED |"
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Two tightly-coupled changes to the org compliance automation:

1. **Re-trigger dev-lead on findings that persist across audits.** The weekly audit creates issues labeled for dev-lead pickup, but `issues:labeled` fires only once per label application — so a finding that persists to the next audit (issue already open + labeled) never re-engaged dev-lead. The audit now cycles the trigger label (remove + re-add) on persistent findings, skipping issues dev-lead is already working (open `dev-lead/issue-<n>` PR or fresh `in-progress` label).

2. **Migrate the trigger label `claude` → `dev-lead`.** Removes all live uses of the legacy `claude` issue-trigger label. dev-lead already accepts `dev-lead`; `claude` was backward-compat from the retired `claude.yml` (deprecated 2026-05). The audit now creates, applies, and cycles `dev-lead`.

## Changes

- **`scripts/lib/dev-lead-retrigger.sh`** (new) — shared `dl_dev_lead_active()` + `dl_cycle_trigger_label()`, used by both the weekly audit and the daily retrigger. Includes pagination, a stale-`in-progress` cap (`IN_PROGRESS_MAX_HOURS`, default 4h), and URL-encoded label paths.
- **`scripts/compliance-audit.sh`** — re-trigger persistent findings; create/label/cycle with `dev-lead`.
- **`scripts/compliance-retrigger.sh`** — `TRIGGER_LABEL` default now `dev-lead`; restores the label if a cycle half-fails.
- **`.github/workflows/compliance-audit-and-improvement.yml`** — new `issues_retriggered` output/summary; analyze prompt instructs `dev-lead` labels.
- **`scripts/migrate-claude-label.sh`** (new) — one-time, idempotent, **DRY_RUN-default** runtime migration: per repo with a `claude` label, ensure `dev-lead` exists, add `dev-lead` to every open `claude` issue (skip those already labeled), then delete the `claude` label object.

### Deliberately left untouched (not the trigger label)
Required-status-check drift logic matching check **names** like `claude-code / claude`; deprecated `claude.yml` checks; `CLAUDE.md` checks; historical `claude.yml` reference docs; `claude-code-action` / OAuth token.

## Runtime migration scope (dry-run)
8 repos, 131 open `claude` issues (87 already on `dev-lead` → skipped), **44 to re-label**, 8 label objects to delete. The live re-label+delete runs separately with the org token after merge.

> Companion PR in `.github-private` removes the `claude` branch from `dev-lead-intent.sh` and updates the spec.

## Verification
shellcheck clean (4 scripts), actionlint clean, unit-tested the shared lib with a mocked `gh` (7/7), migration dry-run validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated label re-engagement capability for agent task assignment.
  * Introduced new migration tooling to consolidate agent labeling across the organization.

* **Chores**
  * Updated compliance audit workflows to use the new agent labeling standard.
  * Migrated from legacy agent label to current labeling convention throughout automation systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->