### PR TITLE
fix(workflows): inline add-to-project if-condition (PRs were silently skipped)

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -75,10 +75,7 @@ jobs:
     # Gate pull_request_target on trusted author to prevent fork PRs from
     # triggering a secret-bearing runner. Issues don't have this concern
     # (creators can't set labels they don't have permission for).
-    if: >-
-      ${{ github.event_name == 'issues' ||
-          (github.event_name == 'pull_request_target' &&
-           contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)) }}
+    if: ${{ github.event_name == 'issues' || (github.event_name == 'pull_request_target' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

The `add-to-project.yml` workflow's `if:` on the `add-issue-or-pr` job uses a YAML folded scalar (`>-`) for a multi-line `${{ }}` expression. On main today, this **skips both jobs for every `pull_request_target` event** — even when the author's association is in the allowlist.

## Reproduction

PR #417 (the docs PR) was opened by don-petry (author_association: `MEMBER`, which is in the allowlist `["OWNER","MEMBER","COLLABORATOR"]`). Run [27094298629](https://github.com/petry-projects/.github/actions/runs/27094298629) shows both `add-issue-or-pr` and `reconcile-discussion` jobs as `skipped`. The PR was not added to the Initiatives project (it had to be added manually).

## Fix

Inline the if-expression on a single line. The expression is now 197 characters, well under yamllint's 200-character limit.

This is the same expression, just single-line — semantics unchanged.

## Test plan

- [ ] Merge with CI green
- [ ] Open a smoke-test issue with `dev-lead` label → verify it appears on the Initiatives board within ~30s
- [ ] Open a smoke-test PR with `dev-lead` label → verify it appears on the board

## Related

- Tracking: #387
- Multi-repo + reconciliation parity follow-on: #415