### PR TITLE
feat(standards): all reusable workflows pin the moving `stable` channel tag

### DIFF
--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -841,14 +841,22 @@ check_dev_lead_stub() {
       "standards/ci-standards.md#dev-lead-agent"
   fi
 
-  # 2) No per-stub concurrency block — concurrency is owned by the reusable.
+  # 2) agent_ref must be threaded through to pin the same channel inside the
+  #    reusable's own script/prompt checkout (prevents split-brain on promotion).
+  if ! printf '%s\n' "$decoded" | grep -qE "^[[:space:]]*agent_ref:[[:space:]]*dev-lead/stable([[:space:]]|$)"; then
+    add_finding "$repo" "ci-workflows" "dev-lead-stub-agent-ref" "error" \
+      "The \`dev-lead.yml\` caller stub must pass \`with: agent_ref: dev-lead/stable\` so the reusable checks out its own scripts/prompts from the same channel. Re-sync from \`standards/workflows/dev-lead.yml\`." \
+      "standards/ci-standards.md#dev-lead-agent"
+  fi
+
+  # 3) No per-stub concurrency block — concurrency is owned by the reusable.
   if echo "$decoded" | grep -qE "^concurrency:"; then
     add_finding "$repo" "ci-workflows" "dev-lead-stub-concurrency" "warning" \
       "The \`dev-lead.yml\` stub defines its own \`concurrency:\` block. Concurrency is centralized in the reusable (per-issue/per-PR lanes); a per-stub block drifts and can cancel issue pickups. Remove it — see petry-projects/.github#402." \
       "standards/ci-standards.md#dev-lead-agent"
   fi
 
-  # 3) Caller permissions must grant `statuses: read`.
+  # 4) Caller permissions must grant `statuses: read`.
   if ! echo "$decoded" | grep -qE "^[[:space:]]*statuses:[[:space:]]*read([[:space:]]|$)"; then
     add_finding "$repo" "ci-workflows" "dev-lead-stub-statuses-perm" "error" \
       "The \`dev-lead.yml\` stub is missing \`statuses: read\` in \`jobs.dev-lead.permissions\`. The reusable requests it (since #435), so without it every run fails at startup (\`startup_failure\`). Add \`statuses: read\`." \

--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -835,7 +835,7 @@ check_dev_lead_stub() {
 
   # 1) Canonical pin (non-comment `uses:` line, exact ref) — the moving
   #    dev-lead/stable channel tag (self-host channel model).
-  if ! echo "$decoded" | grep -qE "^[[:space:]]*uses:[[:space:]]*petry-projects/\\.github-private/\\.github/workflows/dev-lead-reusable\\.yml@dev-lead/stable([[:space:]]|$)"; then
+  if ! printf '%s\n' "$decoded" | grep -qE "^[[:space:]]*uses:[[:space:]]*petry-projects/\\.github-private/\\.github/workflows/dev-lead-reusable\\.yml@dev-lead/stable([[:space:]]|$)"; then
     add_finding "$repo" "ci-workflows" "dev-lead-stub-pin" "error" \
       "The \`dev-lead.yml\` caller stub must pin \`petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable\`. Re-sync from \`standards/workflows/dev-lead.yml\`." \
       "standards/ci-standards.md#dev-lead-agent"

--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -808,11 +808,12 @@ check_centralized_workflow_stubs() {
 # Check: dev-lead.yml caller stub conforms to the centralized contract
 #
 # Unlike the other reusables, dev-lead lives in the PRIVATE repo and is pinned
-# @main, and its concurrency + permissions are owned centrally (see
-# standards/ci-standards.md#dev-lead-agent). A stub drifts — and breaks — in
-# three ways this check catches (all root causes of petry-projects/.github#402):
+# to the moving `dev-lead/stable` channel tag (not @main, not a frozen @vN — see
+# standards/ci-standards.md#dev-lead-agent for the self-host channel model), and
+# its concurrency + permissions are owned centrally. A stub drifts — and breaks —
+# in three ways this check catches (all root causes of petry-projects/.github#402):
 #
-#   1. Wrong pin: not petry-projects/.github-private/.../dev-lead-reusable.yml@main.
+#   1. Wrong pin: not petry-projects/.github-private/.../dev-lead-reusable.yml@dev-lead/stable.
 #   2. Local concurrency block: per-stub concurrency drifts and cancels issue
 #      pickups; concurrency is owned by the reusable (per-issue/per-PR lanes).
 #   3. Missing `statuses: read`: the reusable requests it since #435, so without
@@ -832,10 +833,11 @@ check_dev_lead_stub() {
   decoded=$(echo "$content" | base64 -d 2>/dev/null || echo "")
   [ -z "$decoded" ] && return
 
-  # 1) Canonical pin (non-comment `uses:` line, exact ref).
-  if ! echo "$decoded" | grep -qE "^[[:space:]]*uses:[[:space:]]*petry-projects/\\.github-private/\\.github/workflows/dev-lead-reusable\\.yml@main([[:space:]]|$)"; then
+  # 1) Canonical pin (non-comment `uses:` line, exact ref) — the moving
+  #    dev-lead/stable channel tag (self-host channel model).
+  if ! echo "$decoded" | grep -qE "^[[:space:]]*uses:[[:space:]]*petry-projects/\\.github-private/\\.github/workflows/dev-lead-reusable\\.yml@dev-lead/stable([[:space:]]|$)"; then
     add_finding "$repo" "ci-workflows" "dev-lead-stub-pin" "error" \
-      "The \`dev-lead.yml\` caller stub must pin \`petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@main\`. Re-sync from \`standards/workflows/dev-lead.yml\`." \
+      "The \`dev-lead.yml\` caller stub must pin \`petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable\`. Re-sync from \`standards/workflows/dev-lead.yml\`." \
       "standards/ci-standards.md#dev-lead-agent"
   fi
 

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -46,11 +46,11 @@ reusable, not a local edit.
 > review, and ship changes *to themselves*. Pinning their callers to `@main`
 > would mean a broken change instantly gates its own fix (the self-host circular
 > dependency); pinning to a frozen `@vN` would strand security fixes behind a
-> manual re-pin of every caller. Instead each agent has a **moving per-agent
+> manual re-pin of every caller. Instead, each agent has a **moving per-agent
 > channel tag** — `@dev-lead/stable`, `@pr-review/stable` — that callers pin
 > **once**. A new version is cut as an immutable `@<agent>/vX.Y.Z` audit/rollback
 > tag, validated, then promoted by **moving the channel tag centrally** in
-> `.github-private` — no caller is ever edited, and rollback is a single tag move
+> `.github-private` — no caller is ever edited, and rollback is as simple as moving the tag
 > back. Callers also thread `agent_ref: <agent>/stable` so the agent's own
 > scripts/prompts checkout runs at the same pinned channel. This is the ratified
 > standard for the private agentic reusables; see
@@ -1223,8 +1223,8 @@ centrally so they cannot drift per repo:
   — the moving **per-agent channel tag**, not `@main` and not a frozen `@vN`.
   A new dev-lead version is cut as an immutable `dev-lead/vX.Y.Z` tag, validated
   on ring 0 (`.github-private` self-host), then promoted by **moving the
-  `dev-lead/stable` tag centrally** — no caller is edited, and a rollback is the
-  same tag move back. This breaks dev-lead's self-host circular dependency (a
+  `dev-lead/stable` tag centrally** — no caller is edited, and rollback is as simple as
+  moving the tag back. This breaks dev-lead's self-host circular dependency (a
   broken change can no longer gate its own fix) while keeping security fixes a
   single central tag-move away. The stub also passes
   `with: { agent_ref: dev-lead/stable }` so dev-lead's own scripts/prompts

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -75,9 +75,15 @@ back by moving it back.
 
 1. **Develop & merge** the change to the reusable's `main` as normal (reviewed, CI-green).
 2. **Cut** an immutable release tag `<name>/vX.Y.Z` at the merged commit — the audit trail and rollback target; never moved or deleted.
-3. **Promote through concentric rings** — advance each ring's channel to the new `vX.Y.Z` from the innermost ring outward, moving to the next ring only after the inner one has run it healthy for a soak window (see [Staged promotion through concentric rings](#staged-promotion-through-concentric-rings) below). Each promotion is a single central tag move, gated to an authorized identity.
+3. **Promote through concentric rings** — advance each ring's channel to the new
+   `vX.Y.Z` from the innermost ring outward, moving to the next ring only after
+   the inner one has run it healthy for a soak window (see
+   [Staged promotion through concentric rings](#staged-promotion-through-concentric-rings)
+   below). Each promotion is a single central tag move, gated to an authorized identity.
 4. **`<name>/stable`** is the outermost ring and advances last — that is full-production rollout.
-5. **Roll back** (if a regression surfaces in any ring) by moving that ring's channel back to the prior `vX.Y.Z` — the same move in reverse; callers recover on their next run with no change on their side.
+5. **Roll back** (if a regression surfaces in any ring) by moving that ring's
+   channel back to the prior `vX.Y.Z` — the same move in reverse; callers recover
+   on their next run with no change on their side.
 
 Where a reusable also checks out its own scripts or prompts, thread an
 `agent_ref`-style input pinned to the same channel, so logic **and** code run at

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -40,11 +40,22 @@ reusable, not a local edit.
 > when a backward-compatible release is ready; breaking changes publish a new
 > tag that downstream repos opt into explicitly.
 >
-> **Exception — `dev-lead`.** The dev-lead reusable lives in the private
-> `petry-projects/.github-private` repo (it checks out private prompts/scripts)
-> and is pinned `@main`, not a tag — so permission and security fixes
-> propagate immediately instead of waiting for a tag bump or the monthly
-> standards-sync. See [Dev-Lead Agent](#dev-lead-agent).
+> **Self-hosted agentic reusables use moving channel tags, not `@v1`.** The
+> `dev-lead` and `pr-review` agents live in the private
+> `petry-projects/.github-private` repo and are **self-hosting** — they build,
+> review, and ship changes *to themselves*. Pinning their callers to `@main`
+> would mean a broken change instantly gates its own fix (the self-host circular
+> dependency); pinning to a frozen `@vN` would strand security fixes behind a
+> manual re-pin of every caller. Instead each agent has a **moving per-agent
+> channel tag** — `@dev-lead/stable`, `@pr-review/stable` — that callers pin
+> **once**. A new version is cut as an immutable `@<agent>/vX.Y.Z` audit/rollback
+> tag, validated, then promoted by **moving the channel tag centrally** in
+> `.github-private` — no caller is ever edited, and rollback is a single tag move
+> back. Callers also thread `agent_ref: <agent>/stable` so the agent's own
+> scripts/prompts checkout runs at the same pinned channel. This is the ratified
+> standard for the private agentic reusables; see
+> [Dev-Lead Agent](#dev-lead-agent) and the release-strategy initiative
+> (`petry-projects/.github-private` `docs/initiatives/agentic-release-strategy.md`).
 
 ### Available templates
 
@@ -951,8 +962,8 @@ pins** — and are exempt from this policy.
 # CORRECT — tag ref for a public internal reusable workflow
 uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@v2
 
-# CORRECT — dev-lead lives in the private repo and tracks @main (see Dev-Lead Agent)
-uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@main
+# CORRECT — dev-lead/pr-review pin the moving per-agent channel tag (see Dev-Lead Agent)
+uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable
 
 # WRONG — do not SHA-pin internal reusable workflow refs
 uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@ee22b427cbce9ecadcf2b436acb57c3adf0cb63d
@@ -1208,10 +1219,16 @@ centrally so they cannot drift per repo:
   (petry-projects/.github#402). Running lanes in parallel is safe because the
   agent checks out PR branches in an isolated worktree (petry-projects/.github-private#448).
 - **Pin.** The stub pins
-  `petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@main`
-  — `@main`, not a tag — so a permission or security fix reaches every
-  repo immediately rather than waiting for a tag bump or the monthly
-  standards-sync.
+  `petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable`
+  — the moving **per-agent channel tag**, not `@main` and not a frozen `@vN`.
+  A new dev-lead version is cut as an immutable `dev-lead/vX.Y.Z` tag, validated
+  on ring 0 (`.github-private` self-host), then promoted by **moving the
+  `dev-lead/stable` tag centrally** — no caller is edited, and a rollback is the
+  same tag move back. This breaks dev-lead's self-host circular dependency (a
+  broken change can no longer gate its own fix) while keeping security fixes a
+  single central tag-move away. The stub also passes
+  `with: { agent_ref: dev-lead/stable }` so dev-lead's own scripts/prompts
+  checkout runs at the same pinned channel (it defaults to `main` when omitted).
 - **Permissions.** The stub's `jobs.dev-lead.permissions` must grant the **full
   set that the reusable requests**:
 

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -22,7 +22,7 @@ where to send a fix when behavior needs to change.
 
 | Tier | Examples | What lives in `standards/workflows/` | Where logic lives | Edits allowed in adopting repo |
 |---|---|---|---|---|
-| **1. Stub** | `dev-lead.yml`, `dependency-audit.yml`, `dependabot-automerge.yml`, `dependabot-rebase.yml`, `agent-shield.yml`, `feature-ideation.yml`, `pr-review-mention.yml` | A thin caller stub that delegates via `uses: petry-projects/.github/.github/workflows/<name>-reusable.yml@<version>`, where `<version>` is the canonical tag for that reusable (see `check_centralized_workflow_stubs` in `scripts/compliance-audit.sh`; most are `@v1`, `pr-review-mention` is `@v2`) | The matching `*-reusable.yml` in this repo (single source of truth) | **None** in normal use. May tune `with:` inputs where the reusable exposes them (e.g. `agent-shield` accepts `min-severity`, `required-files`; `feature-ideation` requires `project_context`). To change behavior, open a PR against the reusable in this repo — the canonical tag is bumped deliberately when a release is ready. |
+| **1. Stub** | `dev-lead.yml`, `dependency-audit.yml`, `dependabot-automerge.yml`, `dependabot-rebase.yml`, `agent-shield.yml`, `feature-ideation.yml`, `pr-review-mention.yml` | A thin caller stub that delegates via `uses: …/<name>-reusable.yml@<name>/stable` — the reusable's moving `stable` channel tag ([Reusable workflow versioning](#reusable-workflow-versioning--the-stable-channel)). Reusables not yet migrated to a channel keep their current canonical pin in the interim; `check_centralized_workflow_stubs` in `scripts/compliance-audit.sh` enforces the expected pin per reusable. | The matching `*-reusable.yml` (single source of truth) | **None** in normal use. May tune `with:` inputs where the reusable exposes them (e.g. `agent-shield` accepts `min-severity`, `required-files`; `feature-ideation` requires `project_context`). To change behavior, open a PR against the reusable; a release is cut and promoted by moving the channel tag, never by editing callers. |
 | **2. Per-repo template** | `ci.yml`, `sonarcloud.yml` | _(no template — see the patterns documented below)_ | In each repo, because the workflow is tech-stack-specific (language matrix, build tool, test framework) | **Limited.** Each adopting repo carries its own copy. Stay within the patterns in this document; do not change action SHAs, permission scopes, trigger events, or job names without raising a standards PR first. |
 | **GitHub-managed** | CodeQL default setup | _(no workflow file — managed via repo Settings → Code security)_ | GitHub | None. Configured via `apply-repo-settings.sh`; per-repo `codeql.yml` files are treated as drift by the compliance audit. See [§2 CodeQL Analysis](#2-codeql-analysis-github-managed-default-setup). |
 | **3. Free per-repo** | `release.yml`, project-specific automation | _(out of scope for this standard)_ | Per-repo | Free, but must still comply with the [Action Pinning Policy](#action-pinning-policy) and the [Required Workflows](#required-workflows) constraints. |
@@ -33,29 +33,63 @@ file with that header, **stop and read the header first** — if the change
 isn't allowed by the contract, the right move is a PR against the central
 reusable, not a local edit.
 
-> **Why pin to a canonical tag?** Stubs reference reusables by tag, not `@main`, so a
-> bad commit on the central repo's `main` branch cannot break every
-> downstream repo simultaneously. Each reusable has its own canonical tag
-> (most are `@v1`; `pr-review-mention` is `@v2`). A tag is bumped deliberately
-> when a backward-compatible release is ready; breaking changes publish a new
-> tag that downstream repos opt into explicitly.
->
-> **Self-hosted agentic reusables use moving channel tags, not `@v1`.** The
-> `dev-lead` and `pr-review` agents live in the private
-> `petry-projects/.github-private` repo and are **self-hosting** — they build,
-> review, and ship changes *to themselves*. Pinning their callers to `@main`
-> would mean a broken change instantly gates its own fix (the self-host circular
-> dependency); pinning to a frozen `@vN` would strand security fixes behind a
-> manual re-pin of every caller. Instead, each agent has a **moving per-agent
-> channel tag** — `@dev-lead/stable`, `@pr-review/stable` — that callers pin
-> **once**. A new version is cut as an immutable `@<agent>/vX.Y.Z` audit/rollback
-> tag, validated, then promoted by **moving the channel tag centrally** in
-> `.github-private` — no caller is ever edited, and rollback is as simple as moving the tag
-> back. Callers also thread `agent_ref: <agent>/stable` so the agent's own
-> scripts/prompts checkout runs at the same pinned channel. This is the ratified
-> standard for the private agentic reusables; see
-> [Dev-Lead Agent](#dev-lead-agent) and the release-strategy initiative
-> (`petry-projects/.github-private` `docs/initiatives/agentic-release-strategy.md`).
+### Reusable workflow versioning — the `stable` channel
+
+**Standard.** Every reusable workflow is versioned by a **moving `stable`
+channel tag**, and every caller pins to it **once** —
+`uses: …/<name>-reusable.yml@<name>/stable`. A caller must **never** pin a
+reusable to `@main` (a branch) and **never** to a frozen `@vX.Y.Z` (a version).
+This applies to **every** reusable workflow regardless of which repo hosts it
+(public or private) or which repo calls it (a downstream consumer or the
+reusable's own self-host duty).
+
+**Why not `@main` (a branch).** `@main` has no version boundary: the instant a
+commit lands on the reusable's default branch it is live for every caller at
+once — no canary, no health gate, no rollback. For a *self-hosting* reusable
+(one that gates changes to itself — e.g. an agent that reviews or merges its own
+PRs) it is worse: a broken change becomes the very version that must approve its
+own fix, so the fix is gated by the breakage — a circular dependency that fails
+closed.
+
+**Why not a frozen `@vX.Y.Z` (a version).** A bare version pin is immutable, so
+rolling out a change means **editing every caller** to the new tag: a fan-out PR
+per release, a partially-migrated fleet in between, and security fixes that wait
+behind that churn.
+
+**The `stable` channel gets both right.** It is a *moving* tag that always
+points at the current known-good release. Callers pin it once and are never
+edited again; a release is rolled out by **moving the tag centrally** and rolled
+back by moving it back.
+
+**Benefits.**
+
+- **Version boundary** — `main` can move freely; callers only ever see what `stable` points at.
+- **No caller churn** — pin once; promotion and rollback never touch caller repos.
+- **Instant, uniform rollback** — one tag move restores the last good release fleet-wide; no caller edits, no file surgery.
+- **Health-gated promotion** — a candidate is validated before `stable` advances, so callers never run an unvalidated version.
+- **Breaks self-host circular dependencies** — production runs the pinned channel, so an in-development version can no longer gate its own fix.
+- **Single source of version truth** — the `stable` tag is the one place that defines "what is in production"; immutable `vX.Y.Z` tags are the audit trail and rollback targets.
+- **Bounded supply-chain risk** — channel tags are first-party refs the org owns; a tag-protection ruleset restricts who may move them (see [Action Pinning Policy](#action-pinning-policy)).
+
+**Expected release process.**
+
+1. **Develop & merge** the change to the reusable's `main` as normal (reviewed, CI-green).
+2. **Cut** an immutable release tag `<name>/vX.Y.Z` at the merged commit — the audit trail and rollback target; never moved or deleted.
+3. **Validate** that release on a candidate channel / canary ring (e.g. a `next` channel, or the reusable's own self-host duty) before it reaches production callers.
+4. **Promote** by moving `<name>/stable` to the validated `vX.Y.Z` — a single central tag move, gated to an authorized identity.
+5. **Roll back** (if a regression surfaces) by moving `<name>/stable` back to the prior `vX.Y.Z` — the same move in reverse; callers recover on their next run with no change on their side.
+
+Where a reusable also checks out its own scripts or prompts, thread an
+`agent_ref`-style input pinned to the same channel, so logic **and** code run at
+the one validated version.
+
+**Migration.** This is the target for all reusable workflows; they adopt it
+incrementally. A reusable that has not yet published a `stable` channel keeps its
+current pin until it migrates, at which point its callers re-pin once and the
+compliance audit (`scripts/compliance-audit.sh`) tightens to the channel for
+that reusable. The reference implementation and the full rationale live in the
+release-strategy initiative
+(`petry-projects/.github-private/docs/initiatives/agentic-release-strategy.md`).
 
 ### Available templates
 
@@ -954,19 +988,22 @@ incorrect pinned one.
 
 ### Exception: Internal Reusable Workflow References
 
-Calls to `petry-projects/.github` and `petry-projects/.github-private` reusable
-workflows use tag or branch references (`@v1`, `@v2`, or `@main`) — **not SHA
-pins** — and are exempt from this policy.
+Calls to first-party `petry-projects/*` reusable workflows are **exempt from
+SHA-pinning** — they are refs to workflows the org owns, not third-party
+actions. Per [Reusable workflow versioning](#reusable-workflow-versioning--the-stable-channel),
+pin them to the reusable's moving `stable` channel tag (a reusable still being
+migrated keeps its current canonical tag in the interim). Never `@main`, never a
+SHA.
 
 ```yaml
-# CORRECT — tag ref for a public internal reusable workflow
-uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@v2
+# CORRECT — pin a reusable workflow to its moving `stable` channel tag (pin once)
+uses: petry-projects/<repo>/.github/workflows/<name>-reusable.yml@<name>/stable
 
-# CORRECT — dev-lead/pr-review pin the moving per-agent channel tag (see Dev-Lead Agent)
-uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable
+# WRONG — a branch ref has no version boundary; a bad commit is instantly live for all callers
+uses: petry-projects/<repo>/.github/workflows/<name>-reusable.yml@main
 
-# WRONG — do not SHA-pin internal reusable workflow refs
-uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@ee22b427cbce9ecadcf2b436acb57c3adf0cb63d
+# WRONG — do not SHA-pin first-party reusable workflow refs (and a frozen pin needs a per-caller edit to roll out)
+uses: petry-projects/<repo>/.github/workflows/<name>-reusable.yml@ee22b427cbce9ecadcf2b436acb57c3adf0cb63d
 ```
 
 **Why:** Pinning the `uses:` line in a Tier 1 caller stub creates a diff from
@@ -1218,17 +1255,13 @@ centrally so they cannot drift per repo:
   drifted into three incompatible variants and starved issue pickups
   (petry-projects/.github#402). Running lanes in parallel is safe because the
   agent checks out PR branches in an isolated worktree (petry-projects/.github-private#448).
-- **Pin.** The stub pins
+- **Pin.** The stub pins the reusable's moving `stable` channel tag —
   `petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable`
-  — the moving **per-agent channel tag**, not `@main` and not a frozen `@vN`.
-  A new dev-lead version is cut as an immutable `dev-lead/vX.Y.Z` tag, validated
-  on ring 0 (`.github-private` self-host), then promoted by **moving the
-  `dev-lead/stable` tag centrally** — no caller is edited, and rollback is as simple as
-  moving the tag back. This breaks dev-lead's self-host circular dependency (a
-  broken change can no longer gate its own fix) while keeping security fixes a
-  single central tag-move away. The stub also passes
-  `with: { agent_ref: dev-lead/stable }` so dev-lead's own scripts/prompts
-  checkout runs at the same pinned channel (it defaults to `main` when omitted).
+  — and passes `with: { agent_ref: dev-lead/stable }` so dev-lead's own
+  scripts/prompts checkout runs at the same pinned channel (it defaults to `main`
+  when omitted). This is the org reusable-workflow versioning standard; see
+  [Reusable workflow versioning](#reusable-workflow-versioning--the-stable-channel)
+  for the policy, benefits, and release process.
 - **Permissions.** The stub's `jobs.dev-lead.permissions` must grant the **full
   set that the reusable requests**:
 

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -75,13 +75,52 @@ back by moving it back.
 
 1. **Develop & merge** the change to the reusable's `main` as normal (reviewed, CI-green).
 2. **Cut** an immutable release tag `<name>/vX.Y.Z` at the merged commit — the audit trail and rollback target; never moved or deleted.
-3. **Validate** that release on a candidate channel / canary ring (e.g. a `next` channel, or the reusable's own self-host duty) before it reaches production callers.
-4. **Promote** by moving `<name>/stable` to the validated `vX.Y.Z` — a single central tag move, gated to an authorized identity.
-5. **Roll back** (if a regression surfaces) by moving `<name>/stable` back to the prior `vX.Y.Z` — the same move in reverse; callers recover on their next run with no change on their side.
+3. **Promote through concentric rings** — advance each ring's channel to the new `vX.Y.Z` from the innermost ring outward, moving to the next ring only after the inner one has run it healthy for a soak window (see [Staged promotion through concentric rings](#staged-promotion-through-concentric-rings) below). Each promotion is a single central tag move, gated to an authorized identity.
+4. **`<name>/stable`** is the outermost ring and advances last — that is full-production rollout.
+5. **Roll back** (if a regression surfaces in any ring) by moving that ring's channel back to the prior `vX.Y.Z` — the same move in reverse; callers recover on their next run with no change on their side.
 
 Where a reusable also checks out its own scripts or prompts, thread an
 `agent_ref`-style input pinned to the same channel, so logic **and** code run at
 the one validated version.
+
+#### Staged promotion through concentric rings
+
+`stable` is not a single hop. A release reaches full production by passing
+through a series of **concentric rings** — channels ordered from the smallest
+blast radius to the whole fleet. A release is promoted **one ring at a time**,
+advancing to the next ring only after it has run healthy in the inner ring for a
+defined **soak window**:
+
+| Ring | Channel | Blast radius | Pinned by |
+|---|---|---|---|
+| 0 — canary | `<name>/next` | The reusable's **own self-host** duty (dogfood) | the host repo itself |
+| 1 | `<name>/ring1` | One low-traffic consumer | that consumer |
+| _n_ | `<name>/ring`_n_ | Progressively more consumers | those consumers |
+| Production | `<name>/stable` | The whole fleet | everyone else |
+
+How it works:
+
+- **One immutable release, many channels.** Cut `<name>/vX.Y.Z` once; promotion is moving each ring's channel forward to it, innermost ring first.
+- **Callers stay put; the release moves.** A caller pins exactly one ring's
+  channel (most pin `stable`) and is never edited — the *release* advances
+  through the rings, the *callers* don't. Which ring a repo sits in is a
+  deployment choice, set once.
+- **Soak + health gate.** A ring's channel advances to the new release only
+  after the inner ring has run it healthy for the soak window (no regressions,
+  error budget intact). A failure in any ring **stops promotion** — the outer
+  rings never receive the bad version.
+- **Bounded blast radius + fast rollback.** A regression that slips past an inner ring is contained to that ring and rolled back with one tag move, long before it could reach `stable`.
+
+Ring 0 is the reusable's **own self-host**: it dogfoods every release first, at
+zero external blast radius. This is also what breaks the self-host circular
+dependency — production callers keep running `stable` while the new version is
+exercised on `next`, so a broken candidate can never gate its own fix.
+
+> **Rollout status.** The `stable` channel and single-hop manual promotion are in
+> place today (Phase 1). The `next`/`ring`_n_ channels and automated,
+> soak-gated ring-by-ring promotion are the next phase — the model above is the
+> target the `stable` foundation is built for. A reusable with only `stable`
+> defined today promotes in one gated hop until its ring channels exist.
 
 **Migration.** This is the target for all reusable workflows; they adopt it
 incrementally. A reusable that has not yet published a `stable` channel keeps its

--- a/standards/workflows/dev-lead.yml
+++ b/standards/workflows/dev-lead.yml
@@ -43,7 +43,14 @@ permissions: {}
 
 jobs:
   dev-lead:
-    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@main
+    # Pinned to the moving dev-lead/stable channel tag, not @main, so a broken
+    # change to dev-lead can no longer gate its own fix (the self-host circular
+    # dependency). Promotion = moving the dev-lead/stable tag centrally; this
+    # caller is never edited on release. agent_ref threads the same channel into
+    # dev-lead's own scripts/prompts checkout. See ci-standards.md#dev-lead-agent.
+    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable
+    with:
+      agent_ref: dev-lead/stable
     secrets: inherit
     permissions:
       contents: write

--- a/standards/workflows/dev-lead.yml
+++ b/standards/workflows/dev-lead.yml
@@ -45,7 +45,7 @@ jobs:
   dev-lead:
     # Pinned to the moving dev-lead/stable channel tag, not @main, so a broken
     # change to dev-lead can no longer gate its own fix (the self-host circular
-    # dependency). Promotion = moving the dev-lead/stable tag centrally; this
+    # dependency). Promotion is done by moving the dev-lead/stable tag centrally; this
     # caller is never edited on release. agent_ref threads the same channel into
     # dev-lead's own scripts/prompts checkout. See ci-standards.md#dev-lead-agent.
     uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable


### PR DESCRIPTION
## What
Establish a single, generic org standard for **versioning every reusable workflow**: callers pin the reusable's **moving `stable` channel tag** (`uses: …/<name>-reusable.yml@<name>/stable`) — **never `@main`** (a branch) and **never a frozen `@vX.Y.Z`** (a version). Applies to **all** reusable workflows regardless of which repo hosts them (public or private) or which repo calls them (downstream consumer or the reusable's own self-host duty).

## Why
- **`@main` (a branch)** has no version boundary — a bad commit is instantly live for every caller; for a *self-hosting* reusable it lets a broken change gate its own fix (circular dependency, fails closed).
- **A frozen `@vX.Y.Z`** is immutable, so rolling out a change means editing **every caller** — a fan-out PR per release, partial-fleet states, security fixes stuck behind churn.
- **The moving `stable` channel** is pinned once and rolled out / back by **moving the tag centrally** — no caller churn, instant uniform rollback, health-gated promotion, single source of version truth, and it breaks self-host circular dependencies.

## Release process (now documented in the standard)
1. Develop & merge to the reusable's `main`.
2. Cut an immutable `<name>/vX.Y.Z` (audit + rollback target).
3. Validate on a candidate channel / canary ring.
4. Promote by moving `<name>/stable` → the validated `vX.Y.Z` (gated central tag move).
5. Roll back by moving `<name>/stable` back to the prior `vX.Y.Z`.

## Changes
- **`standards/ci-standards.md`** — new generic *Reusable workflow versioning — the `stable` channel* standard (policy, benefits, release process, migration); tier-table and action-pinning-policy references genericized to the channel model.
- **`standards/workflows/dev-lead.yml`** — reference implementation: pins `@dev-lead/stable` + `agent_ref`.
- **`scripts/compliance-audit.sh`** — `check_dev_lead_stub` enforces the channel pin (keeps the audit in sync with the already-migrated dev-lead consumers).

**Migration is incremental:** a reusable not yet publishing a `stable` channel keeps its current pin until it migrates, when its callers re-pin once and the audit tightens for that reusable. `dev-lead`/`pr-review` are the reference implementation, proven end-to-end in `petry-projects/.github-private` (release-strategy initiative #495).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CI standards to adopt a moving "stable" channel for reusable-workflow promotion/rollback and clarified exception rules for internal references.

* **Tests**
  * Strengthened compliance checks to require stable-channel pinning and the matching agent/channel parameter on caller stubs.

* **Chores**
  * Adjusted workflow wiring to pin caller stubs to the stable channel and align promotion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->