### PR TITLE
feat(feature-ideation): auto-enhance new Ideas Discussions on creation

### DIFF
--- a/.github/workflows/feature-ideation-reusable.yml
+++ b/.github/workflows/feature-ideation-reusable.yml
@@ -64,6 +64,16 @@ on:
         required: false
         default: false
         type: boolean
+      target_discussion:
+        description: |
+          When set to a Discussion number, run in SINGLE-IDEA ENHANCEMENT mode:
+          research and refine that one Discussion and post a single enhancement
+          comment to it, instead of the broad scheduled scan. Empty (default) =
+          normal scheduled/dispatch ideation. Set by the caller from
+          `github.event.discussion.number` on the `discussion: created` trigger.
+        required: false
+        default: ''
+        type: string
       tooling_ref:
         description: |
           Ref of petry-projects/.github to source the feature-ideation scripts from.
@@ -213,6 +223,7 @@ jobs:
           MATCH_PLAN_PATH: ${{ runner.temp }}/match-plan.json
           TOOLING_DIR: ${{ github.workspace }}/.feature-ideation-tooling/.github/scripts/feature-ideation
           FOCUS_AREA: ${{ inputs.focus_area || '' }}
+          TARGET_DISCUSSION: ${{ inputs.target_discussion || '' }}
           SOURCES_FILE_PATH: ${{ inputs.sources_file }}
           RESEARCH_DEPTH: ${{ inputs.research_depth }}
         uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
@@ -265,11 +276,41 @@ jobs:
             - `$TOOLING_DIR`      — path to `.github/scripts/feature-ideation/` (canonical scripts)
             - `$DRY_RUN`          — "1" = mutations are logged to `$DRY_RUN_LOG`, not executed
             - `$FOCUS_AREA`       — optional focus area (empty = open exploration)
+            - `$TARGET_DISCUSSION`— if non-empty, a Discussion number to enhance (single-idea mode)
             - `$RESEARCH_DEPTH`   — quick | standard | deep
             - `$GH_TOKEN`         — workflow token with `discussions: write`
 
             The current date is in `$SIGNALS_PATH` as `.scan_date` — read it from there
             when you need it for Discussion timestamps.
+
+            ## Mode selection (read `$TARGET_DISCUSSION` first)
+
+            **If `$TARGET_DISCUSSION` is non-empty**, run in **single-idea enhancement
+            mode** and SKIP the broad scheduled scan:
+
+            1. Read that one Discussion (title, body, and any existing comments) via the
+               GraphQL API with `$GH_TOKEN`, e.g.:
+               ```bash
+               gh api graphql -f query='{repository(owner:"OWNER",name:"REPO"){discussion(number:NUM){id title body category{slug} comments(first:50){nodes{author{login} body}}}}}'
+               ```
+               (Derive OWNER/REPO from `${{ github.repository }}`, NUM from `$TARGET_DISCUSSION`.)
+            2. Do focused Phase 2–4 research **on that idea only** (market scan, prior art,
+               competitive landscape, feasibility) at `$RESEARCH_DEPTH` depth, applying the
+               same adversarial rigor.
+            3. Produce ONE enhancement that ADDS to the idea — do not restate it. Include:
+               sharper problem framing, prior art / competitive signal, a small options
+               table with trade-offs, risks/unknowns, a phased validation/pilot path, and
+               concrete success metrics. Be additive and specific; cite sources.
+            4. Post it as a **single comment** on that Discussion via
+               `comment_on_discussion "$DISCUSSION_ID" "$BODY"` (the Phase-8 helper).
+               Do **NOT** create new Discussions, run the matcher, or comment on anything
+               else. If the Discussion is not in the `ideas` category, exit without posting.
+            5. Idempotency: if a prior comment already carries the marker
+               `<!-- feature-ideation:enhanced -->`, do nothing. Otherwise begin your comment
+               with that exact HTML marker so re-runs are safe.
+
+            **If `$TARGET_DISCUSSION` is empty**, ignore this section and run the normal
+            scheduled ideation below.
 
             ## Phase 1: Load Context
 

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -779,7 +779,7 @@ is a separate Discussion, updated by subsequent runs as the market and project
 evolve.
 
 **Triggers:** the weekly `schedule`, manual `workflow_dispatch`, **and
-`discussion: created`**. On the discussion trigger the stub passes
+`discussion: created`**. On the discussion trigger, the stub passes
 `target_discussion: ${{ github.event.discussion.number }}`, putting the reusable
 in **single-idea enhancement mode**: it researches and refines that one new idea
 and posts a single enhancement comment, rather than running the broad scan. A

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -778,6 +778,15 @@ feature proposals as GitHub Discussions in the **Ideas** category. Each proposal
 is a separate Discussion, updated by subsequent runs as the market and project
 evolve.
 
+**Triggers:** the weekly `schedule`, manual `workflow_dispatch`, **and
+`discussion: created`**. On the discussion trigger the stub passes
+`target_discussion: ${{ github.event.discussion.number }}`, putting the reusable
+in **single-idea enhancement mode**: it researches and refines that one new idea
+and posts a single enhancement comment, rather than running the broad scan. A
+job-level `if` restricts this to new Discussions in the **Ideas** category and
+skips the bot's own creations; enhancement is a comment (which does not re-fire
+`created`), so there is no trigger loop.
+
 **The pipeline (the reason this workflow exists):**
 
 | Phase | Skill | Purpose |

--- a/standards/workflows/feature-ideation.yml
+++ b/standards/workflows/feature-ideation.yml
@@ -64,6 +64,10 @@ on:
         required: false
         default: false
         type: boolean
+  # Auto-enhance a freshly-created idea: when a new Discussion is opened in the
+  # Ideas category, the analyst researches and refines it in single-idea mode.
+  discussion:
+    types: [created]
 
 permissions: {}
 
@@ -73,6 +77,14 @@ concurrency:
 
 jobs:
   ideate:
+    # On the `discussion` trigger, only run for new ideas in the Ideas category
+    # and skip the bot's own creations (avoids re-enhancing scheduled output;
+    # enhancement posts a comment, which does not re-fire `discussion: created`).
+    # Schedule/dispatch runs are unaffected by this guard.
+    if: >-
+      github.event_name != 'discussion' ||
+      (github.event.discussion.category.slug == 'ideas' &&
+       github.event.discussion.user.login != 'github-actions[bot]')
     # Permissions cascade from the calling job to the reusable workflow.
     # The reusable workflow's two jobs (gather-signals + analyze) need:
     #   - contents:      read   (checkout, file reads)
@@ -90,6 +102,10 @@ jobs:
       actions: read
     uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@ee22b427cbce9ecadcf2b436acb57c3adf0cb63d # v1
     with:
+      # On the `discussion: created` trigger this carries the new Discussion's
+      # number → the reusable runs single-idea enhancement mode. Empty on
+      # schedule/dispatch → normal scan. Do not edit this line.
+      target_discussion: ${{ github.event.discussion.number }}
       # === CUSTOMISE THIS PER REPO — the only required edit ===
       # Replace this paragraph with a 3-5 sentence description of your project,
       # its target users, and the competitive landscape. The more specific you

--- a/standards/workflows/feature-ideation.yml
+++ b/standards/workflows/feature-ideation.yml
@@ -84,7 +84,7 @@ jobs:
     if: >-
       github.event_name != 'discussion' ||
       (github.event.discussion.category.slug == 'ideas' &&
-       github.event.discussion.user.login != 'github-actions[bot]')
+       github.event.discussion.user.type != 'Bot')
     # Permissions cascade from the calling job to the reusable workflow.
     # The reusable workflow's two jobs (gather-signals + analyze) need:
     #   - contents:      read   (checkout, file reads)


### PR DESCRIPTION
## What
Make Feature Ideation **trigger on a new Discussion** so a freshly-opened idea gets researched + refined automatically (instead of waiting for the Friday scan). Requested to enhance ideas like [.github-private#578](https://github.com/petry-projects/.github-private/discussions/578) the moment they're posted.

## How
- **Reusable** — new optional `target_discussion` input. When set, the BMAD analyst runs **single-idea enhancement mode**: read that one Discussion, focused Phase 2–4 research at `research_depth`, and post **one** additive enhancement comment via the existing `comment_on_discussion` helper. No broad scan, no new threads. Idempotent via a `<!-- feature-ideation:enhanced -->` marker. **Empty input = unchanged scheduled behaviour (backward-compatible).**
- **Stub template** — add `on: discussion: types: [created]`; a job-level `if` that limits it to new **Ideas**-category discussions and skips `github-actions[bot]` creations; pass `target_discussion: ${{ github.event.discussion.number }}`.
- **Loop-safe:** enhancement posts a *comment*, which does not re-fire `discussion: created`; scheduled bot-created ideas are filtered out by the `if`.
- **Docs:** ci-standards.md §9 updated.

## Validation
- YAML parses; stub triggers = `schedule, workflow_dispatch, discussion`; `if` + `target_discussion` present; reusable input present with default `''`.
- Compliance audit unaffected (feature-ideation stub check validates the `@v1` pin, not trigger shape).

## Rollout (after merge)
1. Advance the reusable's `@v1` (canonical tag) so callers get the new input.
2. Adopt the updated stub (trigger + `if` + `target_discussion`) in consumer repos (e.g. `.github-private`) — follow-up PR; must come **after** the reusable accepts the new input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feature ideation workflow now auto-enhances newly created discussions in the Ideas category.
  * Workflow supports manual triggering to focus on a specific discussion.

* **Documentation**
  * Updated CI standards documentation with new workflow triggers and execution conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->