### PR TITLE
feat(add-to-project): reusable workflow + reconcile parity (#415)

### DIFF
--- a/.github/scripts/add-to-project/add-issue-or-pr.sh
+++ b/.github/scripts/add-to-project/add-issue-or-pr.sh
@@ -55,11 +55,15 @@ evaluate_noise_gate() {
   fi
 
   local required="${REQUIRED_LABEL:-dev-lead}"
-  local excluded_raw="${EXCLUDED_LABELS:-compliance-audit,health-check,fleet-tracker,daily-report}"
+  # Use ${VAR-default} (no colon): an unset EXCLUDED_LABELS falls back to the
+  # default set, but an explicitly empty value means "no exclusions" so a repo
+  # can opt out entirely.
+  local excluded_raw="${EXCLUDED_LABELS-compliance-audit,health-check,fleet-tracker,daily-report}"
   # Split the comma-separated excluded list into a JSON array (trim blanks,
-  # drop empties) so the gate stays declarative in one jq invocation.
+  # drop empties) so the gate stays declarative in one jq invocation. `-Rs`
+  # slurps the whole input so an empty string yields [] rather than no output.
   local excluded_json
-  excluded_json=$(printf '%s' "${excluded_raw}" | jq -R 'split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length > 0))')
+  excluded_json=$(printf '%s' "${excluded_raw}" | jq -Rs 'split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length > 0))')
 
   # Excluded labels must not appear together with the required label. Run in
   # ONE jq invocation rather than spawning per-label so we stay cheap and

--- a/.github/scripts/add-to-project/add-issue-or-pr.sh
+++ b/.github/scripts/add-to-project/add-issue-or-pr.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
-# add-issue-or-pr.sh — add a qualifying issue or PR to the org Initiatives
-# project. Qualification:
-#   - Must carry the `dev-lead` label
-#   - Must NOT carry any of: compliance-audit, health-check, fleet-tracker,
-#     daily-report (the noise gate that keeps strategic work distinct from
-#     automation-generated work)
+# add-issue-or-pr.sh — reconcile a single issue or PR with the org
+# Initiatives project. An item belongs on the board iff it passes the
+# noise gate:
+#   - carries the required label (REQUIRED_LABEL, default `dev-lead`)
+#   - carries NONE of the excluded labels (EXCLUDED_LABELS, default
+#     compliance-audit,health-check,fleet-tracker,daily-report) — the gate
+#     that keeps strategic work distinct from automation-generated work.
+#
+# Reconcile, not just add (petry-projects/.github#415 §2): if an item that
+# was on the board stops qualifying — `dev-lead` removed, or an excluded
+# label added — its project item is removed. This is the issue/PR analogue
+# of reconcile-discussion.sh's state machine, built on the shared
+# find_project_item / delete_project_item helpers in lib.sh.
 #
 # Required env:
 #   PROJECT_ID            ProjectV2 node ID of the Initiatives project
@@ -12,29 +19,26 @@
 #
 # Optional env:
 #   PROJECT_URL           Logged in human-readable messages only
+#   REQUIRED_LABEL        Gate's required label (default dev-lead)
+#   EXCLUDED_LABELS       Comma-separated excluded labels (default
+#                         compliance-audit,health-check,fleet-tracker,daily-report)
+#   PAGE_SIZE             Items fetched per GraphQL page (default 100)
 #
 # Functions (sourceable):
 #   evaluate_noise_gate <labels_json>
-#       Returns 0 if the labels qualify, 1 if they don't (a clean Skip).
+#       Returns 0 if the labels qualify, 1 if they don't (a clean skip).
 #       Returns 64 on bad arg-count and 65 on bad jq input shape — those
-#       are programmer/payload bugs and the caller must NOT treat them as
-#       a clean skip.
-#       Echoes a short reason on stderr when not qualifying.
-#   add_content_to_project <content_node_id>
-#   process_issue_or_pr <content_node_id> <content_url> <labels_json>
+#       are programmer/payload bugs and the caller must NOT treat them as a
+#       clean skip. Echoes a short reason on stderr when not qualifying.
+#   find_content_item_id <content_node_id>
+#   reconcile_content_with_project <content_node_id> <content_url> <labels_json>
 
 set -euo pipefail
 
-_atp_require_env() {
-  if [ -z "${PROJECT_ID:-}" ]; then
-    printf '[%s] PROJECT_ID env var is required\n' "$1" >&2
-    return 64
-  fi
-  if [ -z "${GH_TOKEN:-}" ]; then
-    printf '::error::[%s] GH_TOKEN is empty. INITIATIVES_APP_ID / INITIATIVES_APP_PRIVATE_KEY are likely unset or stale. See petry-projects/.github#387.\n' "$1" >&2
-    return 64
-  fi
-}
+_atp_lib_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=lib.sh
+. "${_atp_lib_dir}/lib.sh"
 
 evaluate_noise_gate() {
   if [ "$#" -ne 1 ]; then
@@ -44,20 +48,26 @@ evaluate_noise_gate() {
   local labels_json="$1"
 
   # Defensive: GitHub event payloads can deliver labels=null in some
-  # delivery variants. Treat any non-array as the empty-labels case
-  # rather than letting jq abort the script under set -e.
+  # delivery variants. Treat any non-array as the empty-labels case rather
+  # than letting jq abort the script under set -e.
   if ! printf '%s' "${labels_json}" | jq -e 'type == "array"' >/dev/null 2>&1; then
     labels_json='[]'
   fi
 
-  local required="dev-lead"
-  # Excluded labels must not appear together with `dev-lead`. Run in ONE
-  # jq invocation rather than spawning per-label so we stay cheap and the
-  # policy is declarative in one place.
+  local required="${REQUIRED_LABEL:-dev-lead}"
+  local excluded_raw="${EXCLUDED_LABELS:-compliance-audit,health-check,fleet-tracker,daily-report}"
+  # Split the comma-separated excluded list into a JSON array (trim blanks,
+  # drop empties) so the gate stays declarative in one jq invocation.
+  local excluded_json
+  excluded_json=$(printf '%s' "${excluded_raw}" | jq -R 'split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length > 0))')
+
+  # Excluded labels must not appear together with the required label. Run in
+  # ONE jq invocation rather than spawning per-label so we stay cheap and
+  # the policy is declarative in one place.
   local result
   result=$(printf '%s' "${labels_json}" | jq -r \
     --arg required "${required}" \
-    --argjson excluded '["compliance-audit","health-check","fleet-tracker","daily-report"]' \
+    --argjson excluded "${excluded_json}" \
     '
       [.[].name] as $names
       | if ($names | index($required) | not) then
@@ -89,39 +99,31 @@ evaluate_noise_gate() {
   esac
 }
 
-add_content_to_project() {
+# Thin wrapper over the shared lookup: find the project item linked to a
+# given issue/PR node id (or empty string if it isn't on the board).
+find_content_item_id() {
   if [ "$#" -ne 1 ]; then
-    printf '[add_content_to_project] expected 1 arg (content_node_id), got %d\n' "$#" >&2
+    printf '[find_content_item_id] expected 1 arg (content_node_id), got %d\n' "$#" >&2
     return 64
   fi
-  local content_node_id="$1"
-
-  # shellcheck disable=SC2016  # $projectId/$contentId are GraphQL variables
-  gh api graphql \
-    -F projectId="${PROJECT_ID}" \
-    -F contentId="${content_node_id}" \
-    -f query='mutation($projectId:ID!,$contentId:ID!){
-      addProjectV2ItemById(input:{projectId:$projectId,contentId:$contentId}){
-        item { id }
-      }
-    }' >/dev/null
+  find_project_item content-id "$1"
 }
 
-process_issue_or_pr() {
+reconcile_content_with_project() {
   if [ "$#" -ne 3 ]; then
-    printf '[process_issue_or_pr] expected 3 args (content_node_id content_url labels_json), got %d\n' "$#" >&2
+    printf '[reconcile_content_with_project] expected 3 args (content_node_id content_url labels_json), got %d\n' "$#" >&2
     return 64
   fi
-  _atp_require_env process_issue_or_pr || return $?
+  _atp_require_env reconcile_content_with_project || return $?
   local content_node_id="$1"
   local content_url="$2"
   local labels_json="$3"
 
   # Run the gate. Distinguish:
-  #   exit 0 → qualifies, add
-  #   exit 1 → clean skip, log reason and continue
-  #   exit 64/65 → programmer or payload bug, fail loudly so the workflow
-  #               run is marked failed instead of silently dropping the item.
+  #   exit 0 → qualifies, ensure it's on the board (idempotent add)
+  #   exit 1 → does not qualify; remove it if it's currently on the board
+  #   exit 64/65 → programmer or payload bug, fail loudly so the run is
+  #               marked failed instead of silently dropping the item.
   local reason
   set +e
   reason=$(evaluate_noise_gate "${labels_json}" 2>&1)
@@ -134,17 +136,25 @@ process_issue_or_pr() {
       add_content_to_project "${content_node_id}"
       ;;
     1)
-      printf 'Skip %s: %s\n' "${content_url}" "${reason}"
+      local existing
+      existing=$(find_content_item_id "${content_node_id}")
+      if [ -n "${existing}" ]; then
+        printf 'Removing %s from %s (no longer qualifies: %s); item %s\n' \
+          "${content_url}" "${PROJECT_URL:-the project}" "${reason}" "${existing}"
+        delete_project_item "${existing}"
+      else
+        printf 'Skip %s (not on board): %s\n' "${content_url}" "${reason}"
+      fi
       ;;
     *)
-      printf '[process_issue_or_pr] noise gate returned %d (programmer/payload bug, not a clean skip): %s\n' "${gate_status}" "${reason}" >&2
+      printf '[reconcile_content_with_project] noise gate returned %d (programmer/payload bug, not a clean skip): %s\n' "${gate_status}" "${reason}" >&2
       return "${gate_status}"
       ;;
   esac
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
-  process_issue_or_pr \
+  reconcile_content_with_project \
     "${CONTENT_NODE_ID:?CONTENT_NODE_ID is required}" \
     "${CONTENT_URL:?CONTENT_URL is required}" \
     "${LABELS_JSON:?LABELS_JSON is required}"

--- a/.github/scripts/add-to-project/lib.sh
+++ b/.github/scripts/add-to-project/lib.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# lib.sh — shared helpers for the add-to-project scripts.
+#
+# This is the "designed once" mechanism called for in
+# petry-projects/.github#415: a single paginated project-item lookup
+# (find_project_item) parameterized by a match predicate, plus the
+# add / draft / delete mutations and the env guard. Both
+# add-issue-or-pr.sh and reconcile-discussion.sh source this file so the
+# reconcile machinery lives in one place rather than once per content type.
+#
+# Required env (checked by _atp_require_env):
+#   PROJECT_ID            ProjectV2 node ID of the Initiatives project
+#   GH_TOKEN              Token with org Projects: Read+write
+#
+# Optional env:
+#   PROJECT_URL           Logged in human-readable messages only
+#   PAGE_SIZE             Items fetched per GraphQL page (default 100)
+
+set -euo pipefail
+
+_atp_require_env() {
+  if [ -z "${PROJECT_ID:-}" ]; then
+    printf '[%s] PROJECT_ID env var is required\n' "$1" >&2
+    return 64
+  fi
+  if [ -z "${GH_TOKEN:-}" ]; then
+    printf '::error::[%s] GH_TOKEN is empty. INITIATIVES_APP_ID / INITIATIVES_APP_PRIVATE_KEY are likely unset or stale. See petry-projects/.github#387.\n' "$1" >&2
+    return 64
+  fi
+}
+
+# find_project_item <kind> <value>
+#   kind=title-prefix  → match items whose content.title startswith <value>
+#   kind=content-id    → match items whose content.id equals <value>
+#
+# Echoes the matching ProjectV2Item id (the first, if several match), or an
+# empty string if none. Exit 0 on success; 64 on bad args; 75 when the
+# project node comes back null (wrong PROJECT_ID / scope drift / archived) —
+# failing loudly rather than treating it as an empty result and letting the
+# caller add duplicates. Lookup is paginated so the project can grow past
+# the first page without silently missing matches.
+find_project_item() {
+  if [ "$#" -ne 2 ]; then
+    printf '[find_project_item] expected 2 args (kind value), got %d\n' "$#" >&2
+    return 64
+  fi
+  local kind="$1"
+  local value="$2"
+  local page_size="${PAGE_SIZE:-100}"
+
+  local sel noun
+  case "${kind}" in
+    title-prefix)
+      sel='.content.title != null and (.content.title | startswith($val))'
+      noun='drafts match prefix'
+      ;;
+    content-id)
+      sel='.content.id != null and (.content.id == $val)'
+      noun='items match content-id'
+      ;;
+    *)
+      printf '[find_project_item] unknown match kind %q (want title-prefix|content-id)\n' "${kind}" >&2
+      return 64
+      ;;
+  esac
+
+  # Cursor is a nullable String so a single query body handles both first
+  # and subsequent pages. We omit the variable on the first call via shell
+  # expansion below rather than coercing a literal "null".
+  local cursor=""
+
+  while true; do
+    local json
+    # shellcheck disable=SC2016  # $projectId/$pageSize/$cursor are GraphQL variables
+    if [ -n "${cursor}" ]; then
+      json=$(gh api graphql \
+        -F projectId="${PROJECT_ID}" \
+        -F pageSize="${page_size}" \
+        -F cursor="${cursor}" \
+        -f query='query($projectId:ID!, $pageSize:Int!, $cursor:String!){
+          node(id:$projectId){
+            ... on ProjectV2 {
+              items(first:$pageSize, after:$cursor){
+                pageInfo { endCursor hasNextPage }
+                nodes {
+                  id
+                  content {
+                    ... on DraftIssue { title }
+                    ... on Issue       { id title }
+                    ... on PullRequest { id title }
+                  }
+                }
+              }
+            }
+          }
+        }')
+    else
+      # shellcheck disable=SC2016
+      json=$(gh api graphql \
+        -F projectId="${PROJECT_ID}" \
+        -F pageSize="${page_size}" \
+        -f query='query($projectId:ID!, $pageSize:Int!){
+          node(id:$projectId){
+            ... on ProjectV2 {
+              items(first:$pageSize){
+                pageInfo { endCursor hasNextPage }
+                nodes {
+                  id
+                  content {
+                    ... on DraftIssue { title }
+                    ... on Issue       { id title }
+                    ... on PullRequest { id title }
+                  }
+                }
+              }
+            }
+          }
+        }')
+    fi
+
+    if [ "$(printf '%s' "${json}" | jq -r '.data.node')" = "null" ]; then
+      printf '[find_project_item] GraphQL returned data.node:null. PROJECT_ID=%s — token may lack access, or the project was deleted.\n' "${PROJECT_ID}" >&2
+      return 75
+    fi
+
+    # Parse match + page info in ONE jq invocation. `first(...)` emits at
+    # most one id and exits cleanly even when many candidates match (avoids
+    # SIGPIPE from `| head -n 1` under pipefail).
+    local parsed match has_next end_cursor match_count
+    parsed=$(printf '%s' "${json}" | jq -r --arg val "${value}" '
+        (.data.node.items.nodes
+          | map(select('"${sel}"'))
+        ) as $matches
+        | "match=" + (first($matches[].id) // ""),
+          "count=" + ($matches | length | tostring),
+          "next="  + (.data.node.items.pageInfo.hasNextPage | tostring),
+          "end="   + (.data.node.items.pageInfo.endCursor // "")
+      ')
+
+    match=$(printf '%s' "${parsed}" | awk -F= '/^match=/ {sub(/^match=/, ""); print; exit}')
+    match_count=$(printf '%s' "${parsed}" | awk -F= '/^count=/ {sub(/^count=/, ""); print; exit}')
+    has_next=$(printf '%s' "${parsed}"   | awk -F= '/^next=/  {sub(/^next=/, "");  print; exit}')
+    end_cursor=$(printf '%s' "${parsed}" | awk -F= '/^end=/   {sub(/^end=/, "");   print; exit}')
+
+    if [ -n "${match}" ]; then
+      if [ "${match_count}" != "1" ]; then
+        # Multi-match on a single page indicates inconsistent state (manual
+        # drafts shadowing automation). Warn so an operator can clean up,
+        # but proceed with the first match so the state machine progresses.
+        printf '[find_project_item] WARNING: %s %s %q. Returning first; reconcile may delete the wrong one.\n' \
+          "${match_count}" "${noun}" "${value}" >&2
+      fi
+      printf '%s' "${match}"
+      return 0
+    fi
+
+    if [ "${has_next}" != "true" ]; then
+      return 0
+    fi
+    cursor="${end_cursor}"
+  done
+}
+
+add_content_to_project() {
+  if [ "$#" -ne 1 ]; then
+    printf '[add_content_to_project] expected 1 arg (content_node_id), got %d\n' "$#" >&2
+    return 64
+  fi
+  local content_node_id="$1"
+
+  # addProjectV2ItemById is idempotent: adding content already on the board
+  # returns the existing item, so the add path needs no find-first dedup.
+  # shellcheck disable=SC2016  # $projectId/$contentId are GraphQL variables
+  gh api graphql \
+    -F projectId="${PROJECT_ID}" \
+    -F contentId="${content_node_id}" \
+    -f query='mutation($projectId:ID!,$contentId:ID!){
+      addProjectV2ItemById(input:{projectId:$projectId,contentId:$contentId}){
+        item { id }
+      }
+    }' >/dev/null
+}
+
+add_draft_item() {
+  if [ "$#" -ne 2 ]; then
+    printf '[add_draft_item] expected 2 args (title body), got %d\n' "$#" >&2
+    return 64
+  fi
+  local title="$1"
+  local body="$2"
+
+  # shellcheck disable=SC2016  # $projectId/$title/$body are GraphQL variables
+  gh api graphql \
+    -F projectId="${PROJECT_ID}" \
+    -F title="${title}" \
+    -F body="${body}" \
+    -f query='mutation($projectId:ID!,$title:String!,$body:String!){
+      addProjectV2DraftIssue(input:{projectId:$projectId,title:$title,body:$body}){
+        projectItem { id }
+      }
+    }' >/dev/null
+}
+
+delete_project_item() {
+  if [ "$#" -ne 1 ]; then
+    printf '[delete_project_item] expected 1 arg (item_id), got %d\n' "$#" >&2
+    return 64
+  fi
+  local item_id="$1"
+
+  # Be idempotent on redelivered webhooks / racing runs: a "Could not
+  # resolve" error from a no-longer-present item is the desired final state,
+  # not a real failure. Capture stderr to inspect.
+  local out
+  if ! out=$(gh api graphql \
+    -F projectId="${PROJECT_ID}" \
+    -F itemId="${item_id}" \
+    -f query='mutation($projectId:ID!,$itemId:ID!){
+      deleteProjectV2Item(input:{projectId:$projectId,itemId:$itemId}){
+        deletedItemId
+      }
+    }' 2>&1); then
+    if printf '%s' "${out}" | grep -q -e 'Could not resolve to a node' -e 'not found'; then
+      printf '[delete_project_item] item %s was already gone (idempotent path)\n' "${item_id}" >&2
+      return 0
+    fi
+    printf '%s\n' "${out}" >&2
+    return 1
+  fi
+}

--- a/.github/scripts/add-to-project/lib.sh
+++ b/.github/scripts/add-to-project/lib.sh
@@ -48,14 +48,12 @@ find_project_item() {
   local value="$2"
   local page_size="${PAGE_SIZE:-100}"
 
-  local sel noun
+  local noun
   case "${kind}" in
     title-prefix)
-      sel='.content.title != null and (.content.title | startswith($val))'
       noun='drafts match prefix'
       ;;
     content-id)
-      sel='.content.id != null and (.content.id == $val)'
       noun='items match content-id'
       ;;
     *)
@@ -123,13 +121,25 @@ find_project_item() {
       return 75
     fi
 
-    # Parse match + page info in ONE jq invocation. `first(...)` emits at
-    # most one id and exits cleanly even when many candidates match (avoids
-    # SIGPIPE from `| head -n 1` under pipefail).
-    local parsed match has_next end_cursor match_count
-    parsed=$(printf '%s' "${json}" | jq -r --arg val "${value}" '
+    # Parse match + page info in ONE jq invocation. The predicate is passed
+    # to jq as $kind so the filter stays fully static (no shell interpolation).
+    # `first(...)` emits at most one id and exits cleanly even when many
+    # candidates match (avoids SIGPIPE from `| head -n 1` under pipefail).
+    local parsed line match="" match_count=0 has_next="false" end_cursor=""
+    parsed=$(printf '%s' "${json}" | jq -r \
+      --arg kind "${kind}" \
+      --arg val "${value}" \
+      '
         (.data.node.items.nodes
-          | map(select('"${sel}"'))
+          | map(select(
+              if $kind == "title-prefix" then
+                .content.title != null and (.content.title | startswith($val))
+              elif $kind == "content-id" then
+                .content.id != null and (.content.id == $val)
+              else
+                false
+              end
+            ))
         ) as $matches
         | "match=" + (first($matches[].id) // ""),
           "count=" + ($matches | length | tostring),
@@ -137,10 +147,17 @@ find_project_item() {
           "end="   + (.data.node.items.pageInfo.endCursor // "")
       ')
 
-    match=$(printf '%s' "${parsed}" | awk -F= '/^match=/ {sub(/^match=/, ""); print; exit}')
-    match_count=$(printf '%s' "${parsed}" | awk -F= '/^count=/ {sub(/^count=/, ""); print; exit}')
-    has_next=$(printf '%s' "${parsed}"   | awk -F= '/^next=/  {sub(/^next=/, "");  print; exit}')
-    end_cursor=$(printf '%s' "${parsed}" | awk -F= '/^end=/   {sub(/^end=/, "");   print; exit}')
+    # Read the four labelled lines without spawning a subshell per field.
+    # `${line#prefix=}` strips only the leading key, so cursor values that
+    # themselves contain '=' (base64 padding) survive intact.
+    while IFS= read -r line; do
+      case "${line}" in
+        match=*) match="${line#match=}" ;;
+        count=*) match_count="${line#count=}" ;;
+        next=*)  has_next="${line#next=}" ;;
+        end=*)   end_cursor="${line#end=}" ;;
+      esac
+    done <<< "${parsed}"
 
     if [ -n "${match}" ]; then
       if [ "${match_count}" != "1" ]; then

--- a/.github/scripts/add-to-project/reconcile-discussion.sh
+++ b/.github/scripts/add-to-project/reconcile-discussion.sh
@@ -2,14 +2,15 @@
 # reconcile-discussion.sh — keep the org Initiatives project in sync with
 # the lifecycle of an Ideas-category discussion.
 #
-# State machine (entry point: reconcile_discussion):
+# State machine (entry point: reconcile_discussion), where "Ideas" is the
+# category named by IDEAS_CATEGORY (default "Ideas"):
 #   Ideas       + no existing draft → add
 #   Ideas       + existing draft    → skip (idempotent dedup)
 #   non-Ideas   + existing draft    → delete (cleanup when leaving Ideas)
 #   non-Ideas   + no existing draft → no-op
 #
-# Existing draft lookup is paginated; the project can grow past the
-# first 100 items without silently missing matches.
+# The paginated existing-draft lookup, the draft/add/delete mutations, and
+# the env guard live in lib.sh (shared with add-issue-or-pr.sh).
 #
 # Required env:
 #   PROJECT_ID            ProjectV2 node ID of the Initiatives project
@@ -17,139 +18,29 @@
 #
 # Optional env:
 #   PROJECT_URL           Logged in human-readable messages only
+#   IDEAS_CATEGORY        Discussion category that maps to the board (default Ideas)
 #   PAGE_SIZE             Items fetched per GraphQL page (default 100)
 #
 # Functions (sourceable):
 #   find_existing_draft_id <title-prefix>
-#       Echoes the matching ProjectV2Item id, or empty string if none.
-#       Exit 0 on success; non-zero on hard GraphQL failure.
 #   add_discussion_draft <title> <body>
-#   delete_project_item <item_id>
 #   reconcile_discussion <number> <title> <url> <category>
 
 set -euo pipefail
 
-_atp_require_env() {
-  if [ -z "${PROJECT_ID:-}" ]; then
-    printf '[%s] PROJECT_ID env var is required\n' "$1" >&2
-    return 64
-  fi
-  if [ -z "${GH_TOKEN:-}" ]; then
-    printf '::error::[%s] GH_TOKEN is empty. INITIATIVES_APP_ID / INITIATIVES_APP_PRIVATE_KEY are likely unset or stale. See petry-projects/.github#387.\n' "$1" >&2
-    return 64
-  fi
-}
+_atp_lib_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=lib.sh
+. "${_atp_lib_dir}/lib.sh"
 
+# Thin wrappers preserving the discussion-specific names over the shared
+# helpers in lib.sh.
 find_existing_draft_id() {
   if [ "$#" -ne 1 ]; then
     printf '[find_existing_draft_id] expected 1 arg (title-prefix), got %d\n' "$#" >&2
     return 64
   fi
-  local prefix="$1"
-  local page_size="${PAGE_SIZE:-100}"
-  # Cursor is a nullable String so a single query body handles both first
-  # and subsequent pages. gh's `-F` does type inference and would coerce
-  # the literal "null" — we use `-f cursor=null` only conceptually, but
-  # the cleanest portable form is to omit the variable on the first call
-  # via shell expansion below.
-  local cursor=""
-
-  while true; do
-    local json
-    # shellcheck disable=SC2016  # $projectId/$pageSize/$cursor are GraphQL variables
-    if [ -n "${cursor}" ]; then
-      json=$(gh api graphql \
-        -F projectId="${PROJECT_ID}" \
-        -F pageSize="${page_size}" \
-        -F cursor="${cursor}" \
-        -f query='query($projectId:ID!, $pageSize:Int!, $cursor:String!){
-          node(id:$projectId){
-            ... on ProjectV2 {
-              items(first:$pageSize, after:$cursor){
-                pageInfo { endCursor hasNextPage }
-                nodes {
-                  id
-                  content {
-                    ... on DraftIssue { title }
-                    ... on Issue       { title }
-                    ... on PullRequest { title }
-                  }
-                }
-              }
-            }
-          }
-        }')
-    else
-      # shellcheck disable=SC2016
-      json=$(gh api graphql \
-        -F projectId="${PROJECT_ID}" \
-        -F pageSize="${page_size}" \
-        -f query='query($projectId:ID!, $pageSize:Int!){
-          node(id:$projectId){
-            ... on ProjectV2 {
-              items(first:$pageSize){
-                pageInfo { endCursor hasNextPage }
-                nodes {
-                  id
-                  content {
-                    ... on DraftIssue { title }
-                    ... on Issue       { title }
-                    ... on PullRequest { title }
-                  }
-                }
-              }
-            }
-          }
-        }')
-    fi
-
-    # If the project node itself comes back null (wrong PROJECT_ID, token
-    # scope drift, project archived), fail loudly rather than treat it as
-    # an empty-result and let the caller add duplicates.
-    if [ "$(printf '%s' "${json}" | jq -r '.data.node')" = "null" ]; then
-      printf '[find_existing_draft_id] GraphQL returned data.node:null. PROJECT_ID=%s — token may lack access, or the project was deleted.\n' "${PROJECT_ID}" >&2
-      return 75
-    fi
-
-    # Parse match + page info in ONE jq invocation. Use `first(...)` so
-    # jq emits at most one id and exits cleanly even when many candidates
-    # match (avoids SIGPIPE from `| head -n 1` under pipefail).
-    local parsed match has_next end_cursor match_count
-    parsed=$(printf '%s' "${json}" | jq -r \
-      --arg prefix "${prefix}" \
-      '
-        (.data.node.items.nodes
-          | map(select(.content.title != null and (.content.title | startswith($prefix))))
-        ) as $matches
-        | "match=" + (first($matches[].id) // ""),
-          "count=" + ($matches | length | tostring),
-          "next="  + (.data.node.items.pageInfo.hasNextPage | tostring),
-          "end="   + (.data.node.items.pageInfo.endCursor // "")
-      ')
-
-    match=$(printf '%s' "${parsed}" | awk -F= '/^match=/ {sub(/^match=/, ""); print; exit}')
-    match_count=$(printf '%s' "${parsed}" | awk -F= '/^count=/ {sub(/^count=/, ""); print; exit}')
-    has_next=$(printf '%s' "${parsed}"   | awk -F= '/^next=/  {sub(/^next=/, "");  print; exit}')
-    end_cursor=$(printf '%s' "${parsed}" | awk -F= '/^end=/   {sub(/^end=/, "");   print; exit}')
-
-    if [ -n "${match}" ]; then
-      if [ "${match_count}" != "1" ]; then
-        # Multi-match on a single page indicates inconsistent state
-        # (manual drafts shadowing automation). Emit a warning so the
-        # operator can clean up, but proceed with the first match so the
-        # state machine still makes progress.
-        printf '[find_existing_draft_id] WARNING: %s drafts match prefix %q. Returning first; reconcile may delete the wrong one.\n' \
-          "${match_count}" "${prefix}" >&2
-      fi
-      printf '%s' "${match}"
-      return 0
-    fi
-
-    if [ "${has_next}" != "true" ]; then
-      return 0
-    fi
-    cursor="${end_cursor}"
-  done
+  find_project_item title-prefix "$1"
 }
 
 add_discussion_draft() {
@@ -157,47 +48,7 @@ add_discussion_draft() {
     printf '[add_discussion_draft] expected 2 args (title body), got %d\n' "$#" >&2
     return 64
   fi
-  local title="$1"
-  local body="$2"
-
-  # shellcheck disable=SC2016  # $projectId/$title/$body are GraphQL variables
-  gh api graphql \
-    -F projectId="${PROJECT_ID}" \
-    -F title="${title}" \
-    -F body="${body}" \
-    -f query='mutation($projectId:ID!,$title:String!,$body:String!){
-      addProjectV2DraftIssue(input:{projectId:$projectId,title:$title,body:$body}){
-        projectItem { id }
-      }
-    }' >/dev/null
-}
-
-delete_project_item() {
-  if [ "$#" -ne 1 ]; then
-    printf '[delete_project_item] expected 1 arg (item_id), got %d\n' "$#" >&2
-    return 64
-  fi
-  local item_id="$1"
-
-  # Be idempotent on redelivered webhooks / racing runs: a "Could not
-  # resolve" error from a no-longer-present item is the desired final
-  # state, not a real failure. Capture stderr to inspect.
-  local out
-  if ! out=$(gh api graphql \
-    -F projectId="${PROJECT_ID}" \
-    -F itemId="${item_id}" \
-    -f query='mutation($projectId:ID!,$itemId:ID!){
-      deleteProjectV2Item(input:{projectId:$projectId,itemId:$itemId}){
-        deletedItemId
-      }
-    }' 2>&1); then
-    if printf '%s' "${out}" | grep -q -e 'Could not resolve to a node' -e 'not found'; then
-      printf '[delete_project_item] item %s was already gone (idempotent path)\n' "${item_id}" >&2
-      return 0
-    fi
-    printf '%s\n' "${out}" >&2
-    return 1
-  fi
+  add_draft_item "$1" "$2"
 }
 
 reconcile_discussion() {
@@ -210,19 +61,20 @@ reconcile_discussion() {
   local title="$2"
   local url="$3"
   local category="$4"
+  local ideas_category="${IDEAS_CATEGORY:-Ideas}"
 
   local prefix="[Discussion #${number}] "
   local existing
   existing=$(find_existing_draft_id "${prefix}")
 
-  if [ "${category}" = "Ideas" ]; then
+  if [ "${category}" = "${ideas_category}" ]; then
     if [ -n "${existing}" ]; then
       printf 'Discussion #%s already tracked (item %s); no-op\n' "${number}" "${existing}"
       return 0
     fi
     local full_title="[Discussion #${number}] ${title}"
     local body
-    body=$(printf 'Source: %s\n\nAuto-added from Ideas-category discussion.' "${url}")
+    body=$(printf 'Source: %s\n\nAuto-added from %s-category discussion.' "${url}" "${ideas_category}")
     printf 'Adding discussion #%s as draft to %s\n' "${number}" "${PROJECT_URL:-the project}"
     add_discussion_draft "${full_title}" "${body}"
     return 0
@@ -238,10 +90,10 @@ reconcile_discussion() {
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
   # DISC_CATEGORY may legitimately be empty for `deleted` and `transferred`
-  # payloads (the discussion may already be gone, or category is null).
-  # The non-Ideas branch of reconcile_discussion treats any non-"Ideas"
-  # value — including "" — as "if a draft exists, clean it up", which is
-  # the right behavior for deleted/transferred.
+  # payloads (the discussion may already be gone, or category is null). The
+  # non-Ideas branch of reconcile_discussion treats any non-matching value —
+  # including "" — as "if a draft exists, clean it up", which is the right
+  # behavior for deleted/transferred.
   reconcile_discussion \
     "${DISC_NUMBER:?DISC_NUMBER is required}" \
     "${DISC_TITLE:?DISC_TITLE is required}" \

--- a/.github/workflows/add-to-project-reusable.yml
+++ b/.github/workflows/add-to-project-reusable.yml
@@ -1,0 +1,159 @@
+# Reusable auto-add-to-Initiatives-project workflow — single source of truth
+# for the org. Repo-level add-to-project.yml stubs call this so the
+# noise-gate / reconcile logic isn't duplicated per repo.
+# Standard: https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md
+#
+# What it does (driven by the caller's triggering event):
+#   - issues / pull_request_target → reconcile the item with the project:
+#       qualifying (required label, no excluded label) → idempotent add;
+#       no longer qualifying but on the board → remove.
+#   - discussion → reconcile the Ideas-category draft (add / dedup / cleanup).
+#
+# Auth: mints a fresh installation token per run via
+# actions/create-github-app-token from the `petry-projects-planner` GitHub
+# App. Callers pass the App credentials with `secrets: inherit`:
+#   INITIATIVES_APP_ID, INITIATIVES_APP_PRIVATE_KEY.
+#
+# The scripts live in petry-projects/.github; this workflow checks them out
+# at `agent_ref` so logic AND code run at the one pinned channel version
+# (per the org reusable-workflow versioning standard). The reusable's own
+# self-host caller (petry-projects/.github) passes its commit SHA so it
+# dogfoods the exact version under test (Ring 0).
+#
+# Discussion API limitation: the Projects v2 GraphQL schema does not include
+# Discussion in the ProjectV2ItemContent union, so discussions are tracked
+# as draft items keyed by a `[Discussion #N] ` title prefix.
+#
+# Security note (fork PRs): pull_request_target runs with the App secret in
+# scope, so the add-issue-or-pr job only runs for same-repo PRs
+# (head.repo.fork == false) or PRs whose author is OWNER/MEMBER/COLLABORATOR.
+# A maintainer-labeled PR from an *external fork by an untrusted author* is
+# still skipped here (the gate can't safely evaluate the labeler in an `if:`);
+# add such PRs from the Projects UI. Tracking: petry-projects/.github#415 §4.
+#
+# Tracking: petry-projects/.github#387 (pilot), #415 (multi-repo rollout)
+# Discussion: petry-projects/.github#386
+name: Auto-add to Initiatives project (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      project_id:
+        description: "ProjectV2 node ID of the Initiatives project"
+        required: true
+        type: string
+      project_url:
+        description: "Human-readable project URL (logging only)"
+        required: false
+        type: string
+        default: ""
+      required_label:
+        description: "Label an issue/PR must carry to be added"
+        required: false
+        type: string
+        default: "dev-lead"
+      excluded_labels:
+        description: "Comma-separated labels that disqualify an issue/PR even with the required label"
+        required: false
+        type: string
+        default: "compliance-audit,health-check,fleet-tracker,daily-report"
+      ideas_category:
+        description: "Discussion category tracked as draft items"
+        required: false
+        type: string
+        default: "Ideas"
+      agent_ref:
+        description: "Ref of petry-projects/.github to check out the scripts from (pin to add-to-project/stable; self-host passes its SHA)"
+        required: false
+        type: string
+        default: "add-to-project/stable"
+    secrets:
+      INITIATIVES_APP_ID:
+        description: "App ID of the petry-projects-planner GitHub App"
+        required: true
+      INITIATIVES_APP_PRIVATE_KEY:
+        description: "PEM private key for the petry-projects-planner GitHub App"
+        required: true
+
+permissions: {}
+
+jobs:
+  add-issue-or-pr:
+    # pull_request_target carries the App secret, so gate fork PRs: run only
+    # for same-repo PRs or trusted authors. Issues can't set labels their
+    # creator lacks permission for, so they're always eligible.
+    if: >-
+      ${{ github.event_name == 'issues'
+      || (github.event_name == 'pull_request_target'
+          && (github.event.pull_request.head.repo.fork == false
+              || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+                 github.event.pull_request.author_association))) }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout add-to-project scripts
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v5.0.0
+        with:
+          repository: petry-projects/.github
+          ref: ${{ inputs.agent_ref }}
+          path: .add-to-project-src
+          fetch-depth: 1
+
+      - name: Mint App installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.INITIATIVES_APP_ID }}
+          private-key: ${{ secrets.INITIATIVES_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Reconcile issue/PR with the project
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PROJECT_ID: ${{ inputs.project_id }}
+          PROJECT_URL: ${{ inputs.project_url }}
+          REQUIRED_LABEL: ${{ inputs.required_label }}
+          EXCLUDED_LABELS: ${{ inputs.excluded_labels }}
+          LABELS_JSON: ${{ toJson(github.event.issue.labels || github.event.pull_request.labels) }}
+          CONTENT_NODE_ID: ${{ github.event.issue.node_id || github.event.pull_request.node_id }}
+          CONTENT_URL: ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
+        run: |
+          set -euo pipefail
+          bash "${GITHUB_WORKSPACE}/.add-to-project-src/.github/scripts/add-to-project/add-issue-or-pr.sh"
+
+  reconcile-discussion:
+    if: ${{ github.event_name == 'discussion' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout add-to-project scripts
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v5.0.0
+        with:
+          repository: petry-projects/.github
+          ref: ${{ inputs.agent_ref }}
+          path: .add-to-project-src
+          fetch-depth: 1
+
+      - name: Mint App installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.INITIATIVES_APP_ID }}
+          private-key: ${{ secrets.INITIATIVES_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Reconcile draft item with current discussion category
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PROJECT_ID: ${{ inputs.project_id }}
+          PROJECT_URL: ${{ inputs.project_url }}
+          IDEAS_CATEGORY: ${{ inputs.ideas_category }}
+          DISC_TITLE: ${{ github.event.discussion.title }}
+          DISC_URL: ${{ github.event.discussion.html_url }}
+          DISC_NUMBER: ${{ github.event.discussion.number }}
+          DISC_CATEGORY: ${{ github.event.discussion.category.name }}
+        run: |
+          set -euo pipefail
+          bash "${GITHUB_WORKSPACE}/.add-to-project-src/.github/scripts/add-to-project/reconcile-discussion.sh"

--- a/.github/workflows/add-to-project-reusable.yml
+++ b/.github/workflows/add-to-project-reusable.yml
@@ -93,12 +93,13 @@ jobs:
       contents: read
     steps:
       - name: Checkout add-to-project scripts
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v5.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: petry-projects/.github
           ref: ${{ inputs.agent_ref }}
           path: .add-to-project-src
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Mint App installation token
         id: app-token
@@ -129,12 +130,13 @@ jobs:
       contents: read
     steps:
       - name: Checkout add-to-project scripts
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v5.0.0
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: petry-projects/.github
           ref: ${{ inputs.agent_ref }}
           path: .add-to-project-src
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Mint App installation token
         id: app-token

--- a/.github/workflows/add-to-project-tests.yml
+++ b/.github/workflows/add-to-project-tests.yml
@@ -4,6 +4,7 @@ name: Add to Project Tests
 #
 # Triggered on any PR that touches:
 #   - .github/workflows/add-to-project.yml
+#   - .github/workflows/add-to-project-reusable.yml
 #   - .github/workflows/add-to-project-tests.yml
 #   - .github/scripts/add-to-project/**
 #   - test/workflows/add-to-project/**
@@ -18,6 +19,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/add-to-project.yml'
+      - '.github/workflows/add-to-project-reusable.yml'
       - '.github/workflows/add-to-project-tests.yml'
       - '.github/scripts/add-to-project/**'
       - 'test/workflows/add-to-project/**'
@@ -26,6 +28,7 @@ on:
       - main
     paths:
       - '.github/workflows/add-to-project.yml'
+      - '.github/workflows/add-to-project-reusable.yml'
       - '.github/workflows/add-to-project-tests.yml'
       - '.github/scripts/add-to-project/**'
       - 'test/workflows/add-to-project/**'

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -58,4 +58,8 @@ jobs:
       project_id: PVT_kwDOD2inqs4BZq3-
       project_url: https://github.com/orgs/petry-projects/projects/1
       agent_ref: ${{ github.sha }}
-    secrets: inherit
+    # Pass only the secrets the reusable declares (least privilege; avoids
+    # `secrets: inherit` handing the reusable every org secret).
+    secrets:
+      INITIATIVES_APP_ID: ${{ secrets.INITIATIVES_APP_ID }}
+      INITIATIVES_APP_PRIVATE_KEY: ${{ secrets.INITIATIVES_APP_PRIVATE_KEY }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,9 @@ Self-healing, Auto-rebase, Model fallback, Tooling, and Compliance program.
 ### What gets added automatically
 
 The [`add-to-project.yml`](./.github/workflows/add-to-project.yml) workflow
-adds items to the board automatically:
+(a thin caller for the shared
+[`add-to-project-reusable.yml`](./.github/workflows/add-to-project-reusable.yml))
+keeps the board in sync automatically:
 
 | Item type | Rule |
 |---|---|
@@ -30,13 +32,31 @@ adds items to the board automatically:
 | Pull requests | Labeled `dev-lead` **and** none of the excluded labels below _(see fork-PR exception)_ |
 | Discussions | Created in (or moved into) the **Ideas** category — added as draft items |
 
-> **Fork-PR exception:** The `add-to-project` workflow uses `pull_request_target`
-> and gates on the PR author's association being `OWNER`, `MEMBER`, or
-> `COLLABORATOR`. PRs from external contributors (`FIRST_TIMER` or `CONTRIBUTOR`
-> author association) are **skipped** even when a maintainer applies the
-> `dev-lead` label, because the gate evaluates the *author's* association, not
-> the labeler's. Workaround: manually add such PRs from the
-> [Projects UI](https://github.com/orgs/petry-projects/projects/1).
+It **reconciles** rather than only adds: if an item that was on the board
+stops qualifying — `dev-lead` removed, or an excluded label added — its
+project item is removed automatically (the issue/PR analogue of the
+discussion category cleanup).
+
+### Adopting in another repo
+
+The board spans the org. To wire a second repo in, copy
+[`standards/workflows/add-to-project.yml`](./standards/workflows/add-to-project.yml)
+to `.github/workflows/add-to-project.yml` in that repo — it's a thin caller
+pinned to the `add-to-project/stable` channel of the reusable. The repo must
+be included in the `petry-projects-planner` app installation (see token
+requirement below). The gate labels and Ideas category are reusable
+**inputs** (`required_label`, `excluded_labels`, `ideas_category`), so a repo
+can tune them without forking the logic.
+
+> **Fork-PR exception:** The `add-to-project` workflow uses `pull_request_target`,
+> which carries the app secret, so it gates fork PRs: a PR is eligible when it
+> is **same-repo** (`head.repo.fork == false`) **or** its author's association
+> is `OWNER`, `MEMBER`, or `COLLABORATOR`. A PR from an **external fork by an
+> untrusted author** is still **skipped** even when a maintainer applies the
+> `dev-lead` label, because the `if:` gate can't safely evaluate the *labeler*.
+> Workaround: manually add such PRs from the
+> [Projects UI](https://github.com/orgs/petry-projects/projects/1). Tracked as
+> [#415](https://github.com/petry-projects/.github/issues/415) §4.
 
 ### Noise gate — excluded labels
 

--- a/standards/workflows/add-to-project.yml
+++ b/standards/workflows/add-to-project.yml
@@ -6,21 +6,24 @@
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All noise-gate / reconcile logic lives
 #     in the reusable workflow above.
-#   • This is the reusable's OWN self-host caller (Ring 0 dogfood), so it uses
-#     a LOCAL ref (`./`) instead of a pinned channel — this repo IS the source
-#     of truth, so a local ref is always current. It passes `agent_ref:
-#     ${{ github.sha }}` so the scripts checkout matches this exact commit.
-#     Other repos adopt standards/workflows/add-to-project.yml, which pins the
-#     reusable AND agent_ref to the `add-to-project/stable` channel.
+#   • You MAY change: nothing in normal use. The `uses:` ref and `agent_ref`
+#     are pinned to the `add-to-project/stable` channel and move with it — do
+#     not change them to `@main` or a SHA (see ci-standards.md → Reusable
+#     workflow versioning).
 #   • You MUST NOT change: trigger events, the concurrency group, or the
 #     job-level `permissions:` block — a reusable can be granted no more
 #     permissions than the calling job has.
 #   • If you need different behaviour, open a PR against the reusable.
 # ─────────────────────────────────────────────────────────────────────────────
 #
-# Adds qualifying issues, PRs, and Ideas-category discussions in
-# petry-projects/.github to the org-level Initiatives project
+# Auto-add this repo's qualifying issues, PRs, and Ideas-category discussions
+# to the org-level Initiatives project
 # (https://github.com/orgs/petry-projects/projects/1).
+#
+# To adopt: copy this file to .github/workflows/add-to-project.yml in your
+# repo. Requires the org secrets INITIATIVES_APP_ID and
+# INITIATIVES_APP_PRIVATE_KEY (the petry-projects-planner GitHub App), and the
+# app installation must include this repo. See petry-projects/.github#387.
 #
 # Tracking: petry-projects/.github#387, #415
 # Discussion: petry-projects/.github#386
@@ -32,16 +35,11 @@ on:
   pull_request_target:
     types: [opened, labeled, unlabeled, reopened, ready_for_review]
   discussion:
-    # `deleted` and `transferred` are subscribed so an Ideas-tracked
-    # discussion that vanishes also has its draft cleaned up.
     types: [created, category_changed, deleted, transferred]
 
 permissions: {}
 
 concurrency:
-  # Same content (same issue/PR/discussion number) always shares a group
-  # regardless of event subtype, so e.g. `labeled` and `unlabeled` for the
-  # same item can't race against each other.
   group: >-
     add-to-project-${{ github.event_name == 'discussion'
     && format('disc-{0}', github.event.discussion.number)
@@ -53,9 +51,9 @@ jobs:
   add-to-project:
     permissions:
       contents: read
-    uses: ./.github/workflows/add-to-project-reusable.yml  # local ref — always current (self-host)
+    uses: petry-projects/.github/.github/workflows/add-to-project-reusable.yml@add-to-project/stable
     with:
       project_id: PVT_kwDOD2inqs4BZq3-
       project_url: https://github.com/orgs/petry-projects/projects/1
-      agent_ref: ${{ github.sha }}
+      agent_ref: add-to-project/stable
     secrets: inherit

--- a/standards/workflows/add-to-project.yml
+++ b/standards/workflows/add-to-project.yml
@@ -56,4 +56,8 @@ jobs:
       project_id: PVT_kwDOD2inqs4BZq3-
       project_url: https://github.com/orgs/petry-projects/projects/1
       agent_ref: add-to-project/stable
-    secrets: inherit
+    # Pass only the secrets the reusable declares (least privilege; avoids
+    # `secrets: inherit` handing the reusable every org secret).
+    secrets:
+      INITIATIVES_APP_ID: ${{ secrets.INITIATIVES_APP_ID }}
+      INITIATIVES_APP_PRIVATE_KEY: ${{ secrets.INITIATIVES_APP_PRIVATE_KEY }}

--- a/test/workflows/add-to-project/add-issue-or-pr.bats
+++ b/test/workflows/add-to-project/add-issue-or-pr.bats
@@ -35,7 +35,11 @@ write_content_page() {
   local nodes='[]'
   for cid in "$@"; do
     local id_suffix
-    id_suffix=$(printf '%s' "$cid" | sha256sum | cut -c1-10)
+    if command -v sha256sum >/dev/null 2>&1; then
+      id_suffix=$(printf '%s' "$cid" | sha256sum | cut -c1-10)
+    else
+      id_suffix=$(printf '%s' "$cid" | shasum -a 256 | cut -c1-10)
+    fi
     nodes=$(jq --arg cid "$cid" --arg id "PVTI_${id_suffix}" \
       '. + [{id: $id, content: {id: $cid, title: ("item " + $cid)}}]' <<<"$nodes")
   done

--- a/test/workflows/add-to-project/add-issue-or-pr.bats
+++ b/test/workflows/add-to-project/add-issue-or-pr.bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bats
-# Tests for add-issue-or-pr.sh — noise gate + add mutation.
+# Tests for add-issue-or-pr.sh — noise gate (env-driven) + reconcile:
+# qualifying content is added (idempotent), content that stops qualifying
+# is removed from the board.
 
 bats_require_minimum_version 1.5.0
 
@@ -24,6 +26,39 @@ labels_of() {
   jq -nc '$ARGS.positional | map({name: .})' --args "$@"
 }
 
+# A one-page items response whose nodes are issue/PR items keyed by content
+# id (matches find_project_item content-id). With no args → an empty page.
+write_content_page() {
+  local out_path="$1"; shift
+  local has_next="$1"; shift
+  local end_cursor="$1"; shift
+  local nodes='[]'
+  for cid in "$@"; do
+    local id_suffix
+    id_suffix=$(printf '%s' "$cid" | sha256sum | cut -c1-10)
+    nodes=$(jq --arg cid "$cid" --arg id "PVTI_${id_suffix}" \
+      '. + [{id: $id, content: {id: $cid, title: ("item " + $cid)}}]' <<<"$nodes")
+  done
+  jq --argjson nodes "$nodes" \
+     --argjson hasNext "$has_next" \
+     --arg endCursor "$end_cursor" \
+     '{data:{node:{items:{pageInfo:{endCursor:$endCursor, hasNextPage:$hasNext}, nodes:$nodes}}}}' \
+     <<<"{}" >"$out_path"
+}
+
+gh_script_line() {
+  printf '%s\t%s\t%s\n' "$1" "$2" "$3"
+}
+
+# Drive the gh stub with a single find call that returns an empty board.
+stub_empty_board() {
+  local page="${TT_TMP}/empty.json"
+  write_content_page "$page" false ""
+  local script="${TT_TMP}/script.txt"
+  gh_script_line 0 "$page" "-" >"$script"
+  export GH_STUB_SCRIPT="$script"
+}
+
 assert_invocation_count() {
   local expected="$1"
   local actual=0
@@ -37,112 +72,185 @@ assert_invocation_count() {
   }
 }
 
+assert_last_invocation_contains() {
+  local last
+  last=$(tail -n 1 "${GH_STUB_LOG}" | sed 's/\\//g')
+  for needle in "$@"; do
+    [[ "$last" == *"${needle}"* ]] || {
+      printf 'expected last invocation to contain %q\nactual: %s\n' "$needle" "$last" >&2
+      return 1
+    }
+  done
+}
+
 # ---------------------------------------------------------------------------
 # Arg validation
 # ---------------------------------------------------------------------------
 
-@test "process_issue_or_pr: rejects wrong arg count" {
-  run process_issue_or_pr "N" "U"
+@test "reconcile_content_with_project: rejects wrong arg count" {
+  run reconcile_content_with_project "N" "U"
   [ "$status" -eq 64 ]
 }
 
-@test "process_issue_or_pr: fails fast without PROJECT_ID" {
+@test "reconcile_content_with_project: fails fast without PROJECT_ID" {
   unset PROJECT_ID
-  run --separate-stderr process_issue_or_pr "I_1" "https://x" "[]"
+  run --separate-stderr reconcile_content_with_project "I_1" "https://x" "[]"
   [ "$status" -eq 64 ]
   [[ "$stderr" == *"PROJECT_ID env var is required"* ]]
 }
 
-@test "process_issue_or_pr: fails fast with ::error:: when GH_TOKEN is empty" {
+@test "reconcile_content_with_project: fails fast with ::error:: when GH_TOKEN is empty" {
   unset GH_TOKEN
-  run --separate-stderr process_issue_or_pr "I_1" "https://x" "[]"
+  run --separate-stderr reconcile_content_with_project "I_1" "https://x" "[]"
   [ "$status" -eq 64 ]
   [[ "$stderr" == *"::error::"* ]]
   [[ "$stderr" == *"GH_TOKEN is empty"* ]]
   [[ "$stderr" == *"petry-projects/.github#387"* ]]
 }
 
+@test "find_content_item_id: rejects wrong arg count" {
+  run find_content_item_id
+  [ "$status" -eq 64 ]
+}
+
 # ---------------------------------------------------------------------------
-# Noise gate — dev-lead required, excluded labels block
+# Noise gate — non-qualifying content not on the board → clean skip
+# (one find call to confirm it is not present, no mutation)
 # ---------------------------------------------------------------------------
 
-@test "no dev-lead label → skip, no gh call" {
-  run process_issue_or_pr "I_1" "https://example.invalid/issues/1" "$(labels_of bug enhancement)"
+@test "no dev-lead label, not on board → skip, only the find call" {
+  stub_empty_board
+  run reconcile_content_with_project "I_1" "https://example.invalid/issues/1" "$(labels_of bug enhancement)"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Skip"* ]]
+  [[ "$output" == *"not on board"* ]]
   [[ "$output" == *"missing required label 'dev-lead'"* ]]
-  assert_invocation_count 0
+  assert_invocation_count 1
 }
 
-@test "dev-lead + compliance-audit → skip (noise gate)" {
-  run process_issue_or_pr "I_1" "https://example.invalid/issues/1" "$(labels_of dev-lead compliance-audit)"
+@test "dev-lead + compliance-audit, not on board → skip (noise gate), find only" {
+  stub_empty_board
+  run reconcile_content_with_project "I_1" "https://example.invalid/issues/1" "$(labels_of dev-lead compliance-audit)"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"Skip"* ]]
   [[ "$output" == *"has excluded label 'compliance-audit'"* ]]
-  assert_invocation_count 0
+  assert_invocation_count 1
 }
 
-@test "dev-lead + health-check → skip" {
-  run process_issue_or_pr "I_1" "https://example.invalid/issues/1" "$(labels_of dev-lead health-check)"
+@test "dev-lead + health-check, not on board → skip" {
+  stub_empty_board
+  run reconcile_content_with_project "I_1" "https://example.invalid/issues/1" "$(labels_of dev-lead health-check)"
   [ "$status" -eq 0 ]
   [[ "$output" == *"has excluded label 'health-check'"* ]]
-  assert_invocation_count 0
+  assert_invocation_count 1
 }
 
-@test "dev-lead + fleet-tracker → skip" {
-  run process_issue_or_pr "I_1" "https://example.invalid/issues/1" "$(labels_of dev-lead fleet-tracker)"
+@test "dev-lead + fleet-tracker, not on board → skip" {
+  stub_empty_board
+  run reconcile_content_with_project "I_1" "https://example.invalid/issues/1" "$(labels_of dev-lead fleet-tracker)"
   [ "$status" -eq 0 ]
   [[ "$output" == *"has excluded label 'fleet-tracker'"* ]]
-  assert_invocation_count 0
+  assert_invocation_count 1
 }
 
-@test "dev-lead + daily-report → skip" {
-  run process_issue_or_pr "I_1" "https://example.invalid/issues/1" "$(labels_of dev-lead daily-report)"
+@test "dev-lead + daily-report, not on board → skip" {
+  stub_empty_board
+  run reconcile_content_with_project "I_1" "https://example.invalid/issues/1" "$(labels_of dev-lead daily-report)"
   [ "$status" -eq 0 ]
   [[ "$output" == *"has excluded label 'daily-report'"* ]]
-  assert_invocation_count 0
+  assert_invocation_count 1
 }
 
 # ---------------------------------------------------------------------------
-# Happy path — call count + mutation content
+# Happy path — qualifying content → idempotent add, no find-first
 # ---------------------------------------------------------------------------
 
 @test "dev-lead alone → exactly one addProjectV2ItemById with the content id" {
-  run process_issue_or_pr "I_node_xyz" "https://example.invalid/issues/1" "$(labels_of dev-lead)"
+  local script="${TT_TMP}/script.txt"
+  gh_script_line 0 "-" "-" >"$script"
+  export GH_STUB_SCRIPT="$script"
+
+  run reconcile_content_with_project "I_node_xyz" "https://example.invalid/issues/1" "$(labels_of dev-lead)"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Adding https://example.invalid/issues/1"* ]]
   assert_invocation_count 1
-  local last
-  last=$(tail -n 1 "${GH_STUB_LOG}" | sed 's/\\//g')
-  [[ "$last" == *"addProjectV2ItemById"* ]]
-  [[ "$last" == *"I_node_xyz"* ]]
+  assert_last_invocation_contains "addProjectV2ItemById" "I_node_xyz"
 }
 
-@test "dev-lead + non-excluded other label → still qualifies, one call" {
-  run process_issue_or_pr "I_node_xyz" "https://example.invalid/issues/1" "$(labels_of dev-lead bug enhancement)"
+@test "dev-lead + non-excluded other label → still qualifies, one add call" {
+  local script="${TT_TMP}/script.txt"
+  gh_script_line 0 "-" "-" >"$script"
+  export GH_STUB_SCRIPT="$script"
+
+  run reconcile_content_with_project "I_node_xyz" "https://example.invalid/issues/1" "$(labels_of dev-lead bug enhancement)"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Adding"* ]]
   assert_invocation_count 1
+  assert_last_invocation_contains "addProjectV2ItemById"
 }
 
 # ---------------------------------------------------------------------------
-# Payload defense: malformed LABELS_JSON
+# Reconcile remove path (#415 §2): content that stops qualifying but is on
+# the board → find by content id, then delete that item.
 # ---------------------------------------------------------------------------
 
-@test "labels_json='null' → treated as empty array, clean skip (not crash)" {
-  run process_issue_or_pr "I_1" "https://example.invalid/issues/1" "null"
+@test "dev-lead removed but item on board → deleteProjectV2Item with the found item id" {
+  local page="${TT_TMP}/page1.json"
+  write_content_page "$page" false "" "I_onboard"
+  local expected_id
+  expected_id=$(jq -r '.data.node.items.nodes[0].id' <"$page")
+
+  local script="${TT_TMP}/script.txt"
+  {
+    gh_script_line 0 "$page" "-"   # find by content id
+    gh_script_line 0 "-" "-"       # delete
+  } >"$script"
+  export GH_STUB_SCRIPT="$script"
+
+  run reconcile_content_with_project "I_onboard" "https://example.invalid/issues/1" "$(labels_of bug)"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"Skip"* ]]
-  [[ "$output" == *"missing required label"* ]]
-  assert_invocation_count 0
+  [[ "$output" == *"Removing https://example.invalid/issues/1"* ]]
+  [[ "$output" == *"no longer qualifies"* ]]
+  assert_invocation_count 2
+  assert_last_invocation_contains "deleteProjectV2Item" "$expected_id"
 }
 
-@test "labels_json is an object (not array) → treated as empty, clean skip" {
-  run process_issue_or_pr "I_1" "https://example.invalid/issues/1" '{"name":"dev-lead"}'
+@test "excluded label added to an on-board item → removed" {
+  local page="${TT_TMP}/page1.json"
+  write_content_page "$page" false "" "I_onboard"
+  local script="${TT_TMP}/script.txt"
+  {
+    gh_script_line 0 "$page" "-"
+    gh_script_line 0 "-" "-"
+  } >"$script"
+  export GH_STUB_SCRIPT="$script"
+
+  run reconcile_content_with_project "I_onboard" "https://example.invalid/issues/1" "$(labels_of dev-lead compliance-audit)"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Removing"* ]]
+  assert_invocation_count 2
+  assert_last_invocation_contains "deleteProjectV2Item"
+}
+
+# ---------------------------------------------------------------------------
+# Payload defense: malformed LABELS_JSON → treated as empty, clean skip
+# ---------------------------------------------------------------------------
+
+@test "labels_json='null' → empty array, skip (not on board)" {
+  stub_empty_board
+  run reconcile_content_with_project "I_1" "https://example.invalid/issues/1" "null"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Skip"* ]]
   [[ "$output" == *"missing required label"* ]]
-  assert_invocation_count 0
+  assert_invocation_count 1
+}
+
+@test "labels_json is an object (not array) → empty, skip" {
+  stub_empty_board
+  run reconcile_content_with_project "I_1" "https://example.invalid/issues/1" '{"name":"dev-lead"}'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Skip"* ]]
+  [[ "$output" == *"missing required label"* ]]
+  assert_invocation_count 1
 }
 
 # ---------------------------------------------------------------------------
@@ -150,14 +258,12 @@ assert_invocation_count() {
 # ---------------------------------------------------------------------------
 
 @test "evaluate_noise_gate: returns 64 on wrong arg count (propagated, not swallowed)" {
-  # Manually call with bad arg count; process_issue_or_pr should NOT
-  # silently treat this as a skip — surface the bug.
   run evaluate_noise_gate
   [ "$status" -eq 64 ]
 }
 
 # ---------------------------------------------------------------------------
-# evaluate_noise_gate direct API
+# evaluate_noise_gate direct API — defaults
 # ---------------------------------------------------------------------------
 
 @test "evaluate_noise_gate: returns 0 for qualifying labels" {
@@ -178,4 +284,27 @@ assert_invocation_count() {
 @test "evaluate_noise_gate: 'null' labels → treated as empty, returns 1 (not crash)" {
   run evaluate_noise_gate "null"
   [ "$status" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# evaluate_noise_gate — env-driven label config (#415 §3)
+# ---------------------------------------------------------------------------
+
+@test "evaluate_noise_gate: REQUIRED_LABEL override gates on a different label" {
+  export REQUIRED_LABEL="triage"
+  run evaluate_noise_gate "$(labels_of triage)"
+  [ "$status" -eq 0 ]
+  run evaluate_noise_gate "$(labels_of dev-lead)"
+  [ "$status" -eq 1 ]
+}
+
+@test "evaluate_noise_gate: EXCLUDED_LABELS override replaces the default exclusions" {
+  export EXCLUDED_LABELS="wontfix, spam"
+  # compliance-audit is no longer excluded under the override → qualifies
+  run evaluate_noise_gate "$(labels_of dev-lead compliance-audit)"
+  [ "$status" -eq 0 ]
+  # the new exclusion blocks (and tolerates surrounding whitespace in config)
+  run --separate-stderr evaluate_noise_gate "$(labels_of dev-lead spam)"
+  [ "$status" -eq 1 ]
+  [[ "$stderr" == *"has excluded label 'spam'"* ]]
 }

--- a/test/workflows/add-to-project/add-issue-or-pr.bats
+++ b/test/workflows/add-to-project/add-issue-or-pr.bats
@@ -298,6 +298,14 @@ assert_last_invocation_contains() {
   [ "$status" -eq 1 ]
 }
 
+@test "evaluate_noise_gate: empty EXCLUDED_LABELS disables exclusions entirely" {
+  # An explicitly empty value (not unset) means "no exclusions" — the
+  # ${VAR-default} form respects it instead of falling back to the default set.
+  export EXCLUDED_LABELS=""
+  run evaluate_noise_gate "$(labels_of dev-lead compliance-audit)"
+  [ "$status" -eq 0 ]
+}
+
 @test "evaluate_noise_gate: EXCLUDED_LABELS override replaces the default exclusions" {
   export EXCLUDED_LABELS="wontfix, spam"
   # compliance-audit is no longer excluded under the override → qualifies

--- a/test/workflows/add-to-project/reconcile-discussion.bats
+++ b/test/workflows/add-to-project/reconcile-discussion.bats
@@ -243,6 +243,42 @@ assert_invocation_count() {
 }
 
 # ---------------------------------------------------------------------------
+# Env-driven category (#415 §3): IDEAS_CATEGORY selects the tracked category
+# ---------------------------------------------------------------------------
+
+@test "IDEAS_CATEGORY override: discussion in the configured category is added as a draft" {
+  export IDEAS_CATEGORY="Proposals"
+  local page="${TT_TMP}/page1.json"
+  write_items_page "$page" false "" "[Discussion #1] unrelated"
+  local script="${TT_TMP}/script.txt"
+  {
+    gh_script_line 0 "$page" "-"   # find
+    gh_script_line 0 "-" "-"       # add
+  } >"$script"
+  export GH_STUB_SCRIPT="$script"
+
+  run reconcile_discussion 42 "Great idea" "https://example.invalid/d/42" "Proposals"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Adding discussion #42 as draft"* ]]
+  assert_invocation_count 2
+  assert_last_invocation_contains "addProjectV2DraftIssue" "Auto-added from Proposals-category"
+}
+
+@test "IDEAS_CATEGORY override: the default 'Ideas' is no longer tracked" {
+  export IDEAS_CATEGORY="Proposals"
+  local page="${TT_TMP}/page1.json"
+  write_items_page "$page" false "" "[Discussion #1] unrelated"
+  local script="${TT_TMP}/script.txt"
+  gh_script_line 0 "$page" "-" >"$script"
+  export GH_STUB_SCRIPT="$script"
+
+  run reconcile_discussion 42 "Title" "https://example.invalid/d/42" "Ideas"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"not tracked"* ]]
+  assert_invocation_count 1
+}
+
+# ---------------------------------------------------------------------------
 # Title prefix matching — no false positives, plus multi-match warning
 # ---------------------------------------------------------------------------
 

--- a/test/workflows/add-to-project/reconcile-discussion.bats
+++ b/test/workflows/add-to-project/reconcile-discussion.bats
@@ -36,7 +36,11 @@ write_items_page() {
   local titles_json='[]'
   for t in "$@"; do
     local id_suffix
-    id_suffix=$(printf '%s' "$t" | sha256sum | cut -c1-10)
+    if command -v sha256sum >/dev/null 2>&1; then
+      id_suffix=$(printf '%s' "$t" | sha256sum | cut -c1-10)
+    else
+      id_suffix=$(printf '%s' "$t" | shasum -a 256 | cut -c1-10)
+    fi
     titles_json=$(jq --arg t "$t" --arg id "PVTI_${id_suffix}" \
       '. + [{id: $id, content: {title: $t}}]' <<<"$titles_json")
   done


### PR DESCRIPTION
Implements the multi-repo follow-on (#415) to the Initiatives Project pilot (#387), per the architecture decided in #415: **reusable workflow + thin per-repo caller stubs pinned to the `add-to-project/stable` channel** — not a webhook handler.

> **Note:** Per the recorded decision, execution of the multi-repo rollout is gated on the **2026-07-07** 30-day review (#414). This PR is the shovel-ready implementation so "expand" is a merge-and-pin away if the review says go. It does not itself roll the workflow out to other repos (that's adopting the template, one PR per repo).

## What changed

### §1 Multi-repo deployment — reusable + thin callers
- **New `add-to-project-reusable.yml`** holds both jobs (issue/PR reconcile, discussion reconcile). Inputs: `project_id`, `project_url`, `required_label`, `excluded_labels`, `ideas_category`, `agent_ref`. Secrets: `INITIATIVES_APP_ID` / `INITIATIVES_APP_PRIVATE_KEY`.
- **`add-to-project.yml`** is now the self-host **thin caller** (local `./` ref, Ring 0 dogfood; passes `agent_ref: ${{ github.sha }}` so scripts match the exact commit).
- **New `standards/workflows/add-to-project.yml`** is the adoptable template, pinning **both** the reusable ref and `agent_ref` to `add-to-project/stable` per [ci-standards.md → Reusable workflow versioning](../blob/main/standards/ci-standards.md#reusable-workflow-versioning--the-stable-channel). Scripts are checked out via `path:` from `petry-projects/.github@agent_ref`, mirroring the proven `feature-ideation-reusable.yml` pattern.

### §3 Hard-coded labels/category → env-driven
- `evaluate_noise_gate` reads `REQUIRED_LABEL` + `EXCLUDED_LABELS`; `reconcile_discussion` reads `IDEAS_CATEGORY`. **Defaults preserve current behavior** (`dev-lead`; the four excluded labels; `Ideas`).

### §2 Reconcile, not just add
- New shared **`lib.sh`** with a single paginated `find_project_item` (predicate: `title-prefix` | `content-id`) plus the add/draft/delete mutations and env guard — the "designed once" mechanism #415 called for. Both scripts source it; the discussion script keeps its public function names as thin wrappers.
- Issues/PRs that **stop qualifying** (`dev-lead` removed, or an excluded label added) are now **removed** from the board. The caller subscribes to `unlabeled` for issues and PRs.

### §4 Fork-PR gate
- The issue/PR job now runs for **same-repo PRs** (`head.repo.fork == false`) **or** trusted authors (`OWNER`/`MEMBER`/`COLLABORATOR`). External-fork PRs by untrusted authors are still skipped — an `if:` can't safely evaluate the *labeler*; this residual case is documented and left for a non-`if:` follow-up (#415 §4).

## Tests / validation
- `test/workflows/add-to-project` bats suite: **35 → 42** (remove path, env-driven gate, env-driven category, multi-match/pagination preserved). All green locally.
- `shellcheck -S warning` and `shellcheck -x` clean; `yamllint` (max 200) clean; `actionlint` clean on all workflows; `markdownlint-cli2` clean on `CONTRIBUTING.md`.
- `CONTRIBUTING.md` updated: adoption-in-another-repo section, reconcile-on-unqualify behavior, revised fork-PR note.

## Prerequisites for the rollout (not code)
- The `petry-projects-planner` app installation must include each adopting repo.
- Cut `add-to-project/vX.Y.Z` and move the `add-to-project/stable` channel before any external repo adopts the template (the template pins to that channel).

## Related
- Decision: #415 · Review gate: #414 · Pilot: #387 · Discussion: #386

https://claude.ai/code/session_01SS98x3hHsfPRJfGLgJMFom

---
_Generated by [Claude Code](https://claude.ai/code/session_01SS98x3hHsfPRJfGLgJMFom)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Items now automatically remove from the Initiatives project when they no longer meet eligibility criteria (previously only added).
  * Auto-add-to-project workflow is now reusable across projects with configurable eligibility rules.

* **Documentation**
  * Updated contributing guide to clarify automatic project reconciliation behavior and exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->