### PR TITLE
chore(deploy): enable add-to-project.yml stub deployment (#415)

### DIFF
--- a/scripts/deploy-standard-workflows.sh
+++ b/scripts/deploy-standard-workflows.sh
@@ -103,8 +103,16 @@ is_skipped_repo() {
 # SKIP_OVERRIDES — lets a self-managed repo receive one stub while staying
 # exempt from the rest.
 repo_opts_into() {
-  local repo="$1" workflow="$2" r
-  for r in ${SKIP_OVERRIDES[$workflow]:-}; do
+  local repo="$1" workflow="$2"
+  local opt_in="${SKIP_OVERRIDES[$workflow]:-}"
+  [[ -z "$opt_in" ]] && return 1
+
+  # Split the space-separated opt-in list into an array (read -r -a avoids the
+  # pathname expansion an unquoted expansion would be subject to).
+  local -a allowed_repos
+  read -r -a allowed_repos <<< "$opt_in"
+  local r
+  for r in "${allowed_repos[@]}"; do
     [[ "$repo" == "$r" ]] && return 0
   done
   return 1
@@ -220,6 +228,22 @@ fi
 log "Deploying ${#WORKFLOWS[@]} workflow(s) to ${#REPOS[@]} repo(s)"
 
 for repo in "${REPOS[@]}"; do
+  # Fully-exempt repos (no per-workflow opt-in) skip with a single log line
+  # instead of one per workflow.
+  if is_skipped_repo "$repo"; then
+    opts_in_any=false
+    for w in "${WORKFLOWS[@]}"; do
+      if repo_opts_into "$repo" "$w"; then
+        opts_in_any=true
+        break
+      fi
+    done
+    if [[ "$opts_in_any" == "false" ]]; then
+      skip "$repo (exempt)"
+      continue
+    fi
+  fi
+
   for workflow in "${WORKFLOWS[@]}"; do
     if is_skipped_repo "$repo" && ! repo_opts_into "$repo" "$workflow"; then
       skip "$repo/$workflow (exempt)"

--- a/scripts/deploy-standard-workflows.sh
+++ b/scripts/deploy-standard-workflows.sh
@@ -29,8 +29,22 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 STANDARDS_DIR="$REPO_ROOT/standards/workflows"
 
-# Repos to never touch.
+# Repos exempt from blanket standard-workflow deployment.
+#   .github         — self-host source of truth; its own callers use local refs
+#                     (e.g. add-to-project.yml pins ./.github/...), which a
+#                     channel-pinned stub must never overwrite.
+#   .github-private — self-manages its workflow fleet (dev-lead runs inline, etc).
+# A repo here may still opt into a *specific* workflow via SKIP_OVERRIDES below.
 SKIP_REPOS=(".github" ".github-private")
+
+# Per-workflow opt-ins for otherwise-skipped repos. Keyed by workflow filename;
+# value is a space-separated list of SKIP_REPOS that should still receive it.
+# .github-private participates in the org Initiatives board, so it receives the
+# add-to-project.yml caller (the org board is a single shared target — the stub
+# is identical for every repo) while staying exempt from all other stubs.
+declare -A SKIP_OVERRIDES=(
+  ["add-to-project.yml"]=".github-private"
+)
 
 # Workflows deployable from standards/workflows/<name> verbatim.
 # Excludes ci.yml, sonarcloud.yml (tech-stack-specific) and
@@ -43,6 +57,7 @@ DEPLOYABLE_WORKFLOWS=(
   dependabot-automerge.yml
   dependabot-rebase.yml
   dependency-audit.yml
+  add-to-project.yml
 )
 
 # ---------------------------------------------------------------------------
@@ -80,6 +95,17 @@ is_skipped_repo() {
   local repo="$1" s
   for s in "${SKIP_REPOS[@]}"; do
     [[ "$repo" == "$s" ]] && return 0
+  done
+  return 1
+}
+
+# True if a normally-skipped repo has opted into this specific workflow via
+# SKIP_OVERRIDES — lets a self-managed repo receive one stub while staying
+# exempt from the rest.
+repo_opts_into() {
+  local repo="$1" workflow="$2" r
+  for r in ${SKIP_OVERRIDES[$workflow]:-}; do
+    [[ "$repo" == "$r" ]] && return 0
   done
   return 1
 }
@@ -194,12 +220,11 @@ fi
 log "Deploying ${#WORKFLOWS[@]} workflow(s) to ${#REPOS[@]} repo(s)"
 
 for repo in "${REPOS[@]}"; do
-  if is_skipped_repo "$repo"; then
-    skip "$repo (exempt)"
-    continue
-  fi
-
   for workflow in "${WORKFLOWS[@]}"; do
+    if is_skipped_repo "$repo" && ! repo_opts_into "$repo" "$workflow"; then
+      skip "$repo/$workflow (exempt)"
+      continue
+    fi
     deploy_workflow_to_repo "$repo" "$workflow"
   done
 done


### PR DESCRIPTION
## Summary

Enables the canonical deploy mechanism to roll out the org-standard **add-to-project** Initiatives caller stub to consumer repos — Step 2a of the multi-repo rollout (#415, follow-on to PR #466).

- Adds `add-to-project.yml` to `DEPLOYABLE_WORKFLOWS` in `scripts/deploy-standard-workflows.sh`.
- Adds a narrow, self-documenting `SKIP_OVERRIDES` map so `.github-private` (normally skipped — it self-manages its fleet) receives **only** the `add-to-project.yml` stub, while staying exempt from all other stubs.
- `.github` stays fully exempt: it hosts its own **local-ref** self-host caller (`uses: ./.github/...`, `agent_ref: ${{ github.sha }}`), which a channel-pinned stub must never overwrite.

The reusable now publishes the `add-to-project/stable` channel (immutable `add-to-project/v1.0.0` cut at the #466 merge commit `151347e`), so the stub's pinned `uses:` / `agent_ref` resolve at workflow startup.

## Dry-run (this branch)

```
$ deploy-standard-workflows.sh --dry-run --workflow add-to-project.yml
Would create .github-private/.github/workflows/add-to-project.yml
Would create bmad-bgreat-suite/...
Would create google-app-scripts/...
Would create broodly/...
Would create markets/...
Would create ContentTwin/...
Would create TalkTerm/...
SKIP  .github/add-to-project.yml (exempt)
```

→ exactly the 7 rollout targets; `.github` correctly skipped.

## Compliance impact: none

`check_centralized_workflow_stubs` in `scripts/compliance-audit.sh` keys off its **own hardcoded `centralized` list** (not `DEPLOYABLE_WORKFLOWS`) and only validates a stub **if the file already exists**. `add-to-project.yml` is not in `REQUIRED_WORKFLOWS` and is not referenced by the audit, so adding it here cannot flag any repo non-compliant. The enabler (this PR) and the deploy (2b) still land close together per the rollout plan.

## Context

Owner-authorized to start ahead of the documented 2026-07-07 review gate (#414).

Refs #415, #414, #466.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment system flexibility by allowing specific repositories to selectively opt into workflows, even when otherwise excluded from standard deployment.
  * Added new project management workflow capability to the deployment suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->