### PR TITLE
fix(deploy): ensure standards-sync label exists + document the deploy standard

### DIFF
--- a/scripts/lib/standards-deploy.sh
+++ b/scripts/lib/standards-deploy.sh
@@ -100,7 +100,16 @@ sd_deploy_via_pr() {
     return 1
   fi
 
-  # 5. Open the PR.
+  # 5. Ensure the label exists, then open the PR. `gh pr create --label` fails
+  #    outright if the label is absent, and consumer repos do not carry the
+  #    standards-sync label by default. Create-if-missing (no --force, so an
+  #    existing curated label is never clobbered); ignore the "already exists"
+  #    error.
+  gh label create "$label" --repo "$repo" \
+    --color ededed \
+    --description "Org-standard workflow stub synced from ${repo%%/*}/.github" \
+    >/dev/null 2>&1 || true
+
   local pr_url
   pr_url=$(gh pr create --repo "$repo" --head "$branch" --base "$default_branch" \
     --title "$title" --body "$body" --label "$label" 2>/dev/null || true)

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -163,6 +163,39 @@ gh api repos/petry-projects/.github/contents/standards/workflows/<file>.yml \
   --jq '.content' | base64 -d > .github/workflows/<file>.yml
 ```
 
+### Deploying & syncing stubs
+
+**Standard.** Caller stubs are deployed and re-synced to consumer repos **via
+pull requests**, never by pushing directly to a repo's default branch.
+`scripts/deploy-standard-workflows.sh` is the canonical mechanism: for each
+target repo it creates a `standards-sync/<workflow>` branch off the default
+branch, writes the verbatim template onto it, and opens a PR labeled
+`standards-sync` (creating the label if the repo lacks it). It **never merges and
+never uses `--admin`** — the opened PRs run the repo's own CI and are landed by
+the normal review/auto-merge pipeline. The shared primitive lives in
+`scripts/lib/standards-deploy.sh` (`sd_deploy_via_pr`).
+
+**Why a PR, not a direct push.** A direct Contents-API push to the default
+branch is rejected (HTTP 409 `Required status check … expected`) on any repo
+whose ruleset enforces required status checks — the Contents API does **not**
+honor the org-admin ruleset bypass. It also skips review and CI on the repos
+where it *would* succeed. A PR works uniformly on protected and unprotected
+repos, runs CI against the change (e.g. AgentShield scans the new workflow), and
+leaves an auditable record. (Background: [#478](https://github.com/petry-projects/.github/issues/478).)
+
+```bash
+# Plan only — opens nothing:
+scripts/deploy-standard-workflows.sh --dry-run [--workflow <name>.yml] [--repo <name>]
+# Open the standards-sync PRs:
+scripts/deploy-standard-workflows.sh [--workflow <name>.yml] [--repo <name>] [--force]
+```
+
+The script is idempotent: it skips a repo whose stub already pins the template's
+`uses:` ref, and skips opening a second PR when a `standards-sync` one is already
+open for that workflow. Deployment never edits a caller's `uses:`/`agent_ref`
+pins by hand — a release is rolled out by moving the channel tag (see
+[Reusable workflow versioning](#reusable-workflow-versioning--the-stable-channel)).
+
 ---
 
 ## Required Workflows

--- a/test/scripts/lib/standards-deploy.bats
+++ b/test/scripts/lib/standards-deploy.bats
@@ -94,6 +94,19 @@ deploy() {
   grep -q -- '--label standards-sync' "$GH_CALLS"
 }
 
+# Regression: consumer repos don't carry the standards-sync label, and
+# `gh pr create --label` fails outright if it's absent — so the lib must ensure
+# the label exists, before the PR is created. (petry-projects/.github#480.)
+@test "ensures the label exists before opening the PR" {
+  run deploy
+  [ "$status" -eq 0 ]
+  grep -q 'gh label create standards-sync --repo petry-projects/markets' "$GH_CALLS"
+  local label_line prc_line
+  label_line=$(grep -n 'gh label create' "$GH_CALLS" | head -1 | cut -d: -f1)
+  prc_line=$(grep -n 'gh pr create' "$GH_CALLS" | head -1 | cut -d: -f1)
+  [ "$label_line" -lt "$prc_line" ]
+}
+
 # ---------------------------------------------------------------------------
 # Idempotency: an open PR already exists → skip, no mutations
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two follow-ups to #480 (PR-based stub deploy):

1. **Bugfix** — `sd_deploy_via_pr` passed `gh pr create --label standards-sync`, which **fails outright** on any target repo lacking that label. None of the 7 consumer repos carry it (only `.github-private` does), so #480 as merged would fail PR creation on every real target. The lib now **creates the label if missing** (create-if-missing, no `--force` so an existing curated label is never clobbered) before opening the PR. Regression test added.
2. **Docs** — adds a **"Deploying & syncing stubs"** standard to `standards/ci-standards.md`: stubs are deployed via PRs (`deploy-standard-workflows.sh`, `standards-sync` label, never direct-push / never `--admin`), with the ruleset-protected-repo rationale.

## How it was found

Caught by the controlled **live verification** requested for #480: running the real script on a ruleset-protected repo (`ContentTwin`) showed branch + Contents-API PUT + PR all work (no 409 — the original bug is fixed), but `gh pr create` failed on the missing label. After this fix, a live re-run opened a correctly-labeled PR (label auto-created) on `ContentTwin` with no 409; the throwaway PR was closed.

## Validation

- `bats` — 14/14 pass (added: "ensures the label exists before opening the PR", asserting `gh label create` precedes `gh pr create`).
- `shellcheck --severity=warning -x` — clean.
- Live: fixed script opened a labeled `standards-sync` PR on the protected repo `ContentTwin` end-to-end (closed afterward).

## Related (separate, not in this PR)

The verification also surfaced a three-way pin inconsistency between the deploy **templates**, the compliance audit's expected pins (`check_centralized_workflow_stubs`), and the **fleet** (e.g. `dependency-audit`/`dependabot-automerge`: template+audit `@v1` but repos run `@v2`; `agent-shield`/`dependabot-rebase` templates SHA-pinned vs audit `@v1`). Filed separately — a blind re-sync would push downgrades/pin-flips, so it needs its own remediation.

Refs #478, #480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)