### PR TITLE
chore(standards): migrate reusable caller templates to <name>/stable channels (#482)

### DIFF
--- a/standards/workflows/agent-shield.yml
+++ b/standards/workflows/agent-shield.yml
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   agent-shield:
-    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@208ec2d69b75227d375edf8745d84fbac05a76b2 # v1
+    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@agent-shield/stable

--- a/standards/workflows/auto-rebase.yml
+++ b/standards/workflows/auto-rebase.yml
@@ -6,9 +6,11 @@
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All branch-update logic lives in the
 #     reusable workflow above.
-#   • You MAY change: the SHA in the `uses:` line when upgrading the reusable
-#     workflow version (bump SHA to latest main of petry-projects/.github).
-#   • You MUST NOT change: trigger event, the concurrency group name,
+#   • You MUST NOT change: the `uses:` ref — it is pinned to the
+#     `auto-rebase/stable` channel, a moving tag advanced centrally. Never
+#     repoint it to `@main`, a SHA, or a frozen `@vX` (see ci-standards.md →
+#     Reusable workflow versioning). Also do not change the trigger event,
+#     the concurrency group name,
 #     or the job-level `permissions:` block — reusable workflows can be
 #     granted no more permissions than the calling job has, so removing
 #     the stanza breaks the reusable's gh API calls.
@@ -48,5 +50,5 @@ jobs:
     permissions:
       contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write # post comments on PRs
-    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@auto-rebase/stable
     secrets: inherit

--- a/standards/workflows/dependabot-automerge.yml
+++ b/standards/workflows/dependabot-automerge.yml
@@ -35,5 +35,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@dependabot-automerge/stable
     secrets: inherit

--- a/standards/workflows/dependabot-rebase.yml
+++ b/standards/workflows/dependabot-rebase.yml
@@ -6,13 +6,11 @@
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All rebase/merge serialization logic
 #     lives in the reusable workflow above.
-#   • You MAY change: the SHA in the `uses:` line when upgrading the reusable
-#     workflow version (bump SHA to latest main of petry-projects/.github).
-#   • SHA-pinned intentionally (not @v1): no semver tags are maintained for
-#     this internal reusable workflow. Downstream repos pin to a specific
-#     commit SHA and bump deliberately. To look up the current SHA:
-#     gh api repos/petry-projects/.github/branches/main --jq '.commit.sha'
-#   • You MUST NOT change: the concurrency group name, the explicit secrets
+#   • You MUST NOT change: the `uses:` ref — it is pinned to the
+#     `dependabot-rebase/stable` channel, a moving tag advanced centrally.
+#     Never repoint it to `@main`, a SHA, or a frozen `@vX` (see
+#     ci-standards.md → Reusable workflow versioning). Also do not change the
+#     concurrency group name, the explicit secrets
 #     block, or the job-level `permissions:` block — reusable workflows can be
 #     granted no more permissions than the calling job has, so removing the
 #     stanza breaks the reusable's gh API calls. Do not remove any trigger
@@ -52,7 +50,7 @@ jobs:
     permissions:
       contents: write   # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write  # re-approve PRs after branch update
-    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@9a694e5798ebb596476e6eda80f11e832d8fd0a9 # main
+    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@dependabot-rebase/stable
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/standards/workflows/dependency-audit.yml
+++ b/standards/workflows/dependency-audit.yml
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   dependency-audit:
-    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@dependency-audit/stable

--- a/standards/workflows/pr-review-mention.yml
+++ b/standards/workflows/pr-review-mention.yml
@@ -6,15 +6,16 @@
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All review-dispatch logic lives in the
 #     reusable workflow above.
-#   • You MAY change: the tag in the `uses:` line when upgrading the reusable
-#     workflow version (e.g. bump `@v1` → `@v2` when petry-projects/.github cuts a new release).
-#   • You MUST NOT change: trigger events or the job-level `permissions:` block —
-#     reusable workflows can be granted no more permissions than the calling job,
-#     so removing the stanza breaks the reusable's gh API calls.
+#   • You MUST NOT change: the `uses:` ref — it is pinned to the
+#     `pr-review-mention/stable` channel, a moving tag advanced centrally.
+#     Never repoint it to `@main`, a SHA, or a frozen `@vX` (see
+#     ci-standards.md → Reusable workflow versioning). Also do not change the
+#     trigger events or the job-level `permissions:` block — reusable workflows
+#     can be granted no more permissions than the calling job, so removing the
+#     stanza breaks the reusable's gh API calls.
 #   • If you need different behaviour, open a PR against the reusable in the
-#     central repo.
-#   • When publishing a new version of this reusable, also update this template and
-#     open a fanout PR across all caller repos.
+#     central repo. A new release is rolled out by moving the channel tag
+#     centrally — never by editing callers, so no fanout PR is needed.
 # ─────────────────────────────────────────────────────────────────────────────
 #
 # PR Review Mention — thin caller for the org-level reusable.
@@ -36,5 +37,5 @@ jobs:
   pr-review-mention:
     permissions:
       pull-requests: write
-    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@v2
+    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@pr-review-mention/stable
     secrets: inherit


### PR DESCRIPTION
## Summary

**Phase 2** of the stub-pin reconciliation (#482). Points the six Tier-1 caller **templates** at the new per-reusable `stable` channels, adopting the documented North Star ([Reusable workflow versioning](../blob/main/standards/ci-standards.md#reusable-workflow-versioning--the-stable-channel)).

**Phase 1 (done):** cut `<name>/stable` (moving) + `<name>/v2.0.0` (immutable) tags at the v2 release commit `376a4fcb` for all six reusables.

This PR:
- `agent-shield`, `auto-rebase`, `dependency-audit`, `dependabot-automerge`, `dependabot-rebase`, `pr-review-mention` templates → `uses: …/<name>-reusable.yml@<name>/stable`.
- Fixes the two off-standard templates: `agent-shield` (was SHA `@208ec2d`) and `dependabot-rebase` (was `@9a694e5 # main`) — neither matched the audit's expected pin *or* the channel model.
- Replaces stale "bump the SHA/tag" comments with channel guidance.

## Safety / phasing

- **No fleet impact from this PR** — these are source-of-truth templates; merging changes no running workflow.
- **Phase 3** (next): re-sync the fleet to the channels via `deploy-standard-workflows.sh` — opens reviewable `standards-sync` PRs per repo. Note `auto-rebase`/`dependabot-rebase` move v1→v2 (the channel points at v2); landing via per-repo PRs means each runs the repo's CI before merge.
- **Phase 4** (last): update `check_centralized_workflow_stubs` to expect `@<name>/stable`. Deliberately ordered **after** Phase 3 so the fleet is never flagged non-compliant mid-migration.

## Validation
- All six templates parse as valid YAML; `uses:` refs point at the cut channels (verified resolving to `376a4fcb`).

Refs #482.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to use stable channel references across multiple automation jobs (agent-shield, auto-rebase, dependabot-automerge, dependabot-rebase, dependency-audit, and pr-review-mention), enabling automatic compatibility updates while maintaining consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->