### PR TITLE
fix(audit): accept <name>/stable channel pins with transitional legacy grace (#482)

### DIFF
--- a/.github/workflows/compliance-audit-tests.yml
+++ b/.github/workflows/compliance-audit-tests.yml
@@ -1,0 +1,58 @@
+# Quality gates for the compliance-audit script and its unit tests.
+#
+# Triggered on any PR that touches:
+#   - scripts/compliance-audit.sh
+#   - test/scripts/compliance-audit/**
+#
+# Gates (all must pass before merge):
+#   1. shellcheck — static analysis for the audit script
+#   2. bats       — unit tests for its pure helpers (pin matching, ruleset
+#                   targeting, codeowners catch-all, …)
+
+name: Compliance Audit Tests
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/compliance-audit.sh'
+      - 'test/scripts/compliance-audit/**'
+      - '.github/workflows/compliance-audit-tests.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'scripts/compliance-audit.sh'
+      - 'test/scripts/compliance-audit/**'
+      - '.github/workflows/compliance-audit-tests.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: compliance-audit-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Lint and bats
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 1
+
+      - name: Install bats, shellcheck, and jq
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends bats shellcheck jq
+
+      - name: shellcheck
+        run: |
+          set -euo pipefail
+          shellcheck --severity=warning -x scripts/compliance-audit.sh
+
+      - name: Run bats suite
+        run: bats --print-output-on-failure test/scripts/compliance-audit/

--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -923,8 +923,33 @@ check_ci_concurrency() {
 # exempt because it owns the reusables and may legitimately reference
 # its own workflows by @main during release prep.
 #
-# Array format: "workflow-filename:expected-reusable-basename:version-tag"
+# Array format: "workflow-filename:reusable-basename:canonical-pin:legacy-csv"
 # ---------------------------------------------------------------------------
+
+# stub_pin_acceptable <decoded> <reusable-basename> <canonical-ref> <legacy-csv>
+# True if a non-comment `uses:` line pins petry-projects/.github's <reusable> at
+# the canonical ref OR one of the comma-separated transitional legacy refs. The
+# legacy grace keeps a stub on its old @vN pin compliant while the fleet migrates
+# to the <name>/stable channel, so the audit neither flags nor reverts it
+# mid-migration (#482). Anchored to start-of-line so a `# uses: …` comment never
+# counts.
+stub_pin_acceptable() {
+  local decoded="$1" reusable="$2" canonical="$3" legacy_csv="$4"
+  local esc_reusable; esc_reusable=$(escape_ere "$reusable")
+
+  local -a legacy_arr=()
+  [ -n "$legacy_csv" ] && IFS=',' read -r -a legacy_arr <<< "$legacy_csv"
+
+  local alt="" r
+  for r in "$canonical" "${legacy_arr[@]}"; do
+    [ -z "$r" ] && continue
+    alt+="${alt:+|}$(escape_ere "$r")"
+  done
+
+  local expected="petry-projects/\\.github/\\.github/workflows/${esc_reusable}\\.yml@(${alt})"
+  printf '%s\n' "$decoded" | grep -qE "^[[:space:]]*uses:[[:space:]]*${expected}([[:space:]]|$)"
+}
+
 check_centralized_workflow_stubs() {
   local repo="$1"
 
@@ -932,19 +957,24 @@ check_centralized_workflow_stubs() {
   # own reusables by @main; skip the stub check for it.
   [ "$repo" = ".github" ] && return
 
-  # workflow-filename:expected-reusable-basename:version-tag
+  # workflow-filename:reusable-basename:canonical-pin:legacy-accepted-csv
+  #   canonical-pin       — the org-standard ref a stub should pin (the moving
+  #                         <name>/stable channel for migrated reusables).
+  #   legacy-accepted-csv — comma-separated refs still accepted *during the
+  #                         channel migration* so the audit neither flags nor
+  #                         reverts a stub still on its old @vN pin (#482). Empty
+  #                         once the fleet is fully migrated (then drop the grace).
   # NOTE: dev-lead.yml is intentionally NOT listed here — its reusable lives in
-  # the private petry-projects/.github-private repo and is pinned @main (not a
-  # .github @v1 tag), so it doesn't fit this check's .github/@version model. It
-  # is validated by check_dev_lead_stub() below.
+  # the private petry-projects/.github-private repo and is pinned to the
+  # dev-lead/stable channel, validated by check_dev_lead_stub() below.
   local centralized=(
-    "auto-rebase.yml:auto-rebase-reusable:v1"
-    "dependency-audit.yml:dependency-audit-reusable:v1"
-    "dependabot-automerge.yml:dependabot-automerge-reusable:v1"
-    "dependabot-rebase.yml:dependabot-rebase-reusable:v1"
-    "agent-shield.yml:agent-shield-reusable:v1"
-    "feature-ideation.yml:feature-ideation-reusable:v1"
-    "pr-review-mention.yml:pr-review-mention-reusable:v2"
+    "auto-rebase.yml:auto-rebase-reusable:auto-rebase/stable:v1,v2"
+    "dependency-audit.yml:dependency-audit-reusable:dependency-audit/stable:v1,v2"
+    "dependabot-automerge.yml:dependabot-automerge-reusable:dependabot-automerge/stable:v1,v2"
+    "dependabot-rebase.yml:dependabot-rebase-reusable:dependabot-rebase/stable:v1,v2"
+    "agent-shield.yml:agent-shield-reusable:agent-shield/stable:v1,v2"
+    "feature-ideation.yml:feature-ideation-reusable:v1:"
+    "pr-review-mention.yml:pr-review-mention-reusable:pr-review-mention/stable:v1,v2"
   )
 
   # List the repo's workflow directory once instead of probing each file.
@@ -953,10 +983,10 @@ check_centralized_workflow_stubs() {
   workflow_list=$(gh_api "repos/$ORG/$repo/contents/.github/workflows" --jq '.[].name' 2>/dev/null || echo "")
   [ -z "$workflow_list" ] && return
 
-  local entry wf reusable version
+  local entry wf reusable canonical legacy
   for entry in "${centralized[@]}"; do
-    IFS=':' read -r wf reusable version <<< "$entry"
-    [ -z "$version" ] && { echo "::error::centralized entry '$entry' missing version tag — expected format 'wf:reusable:version'" >&2; exit 1; }
+    IFS=':' read -r wf reusable canonical legacy <<< "$entry"
+    [ -z "$canonical" ] && { echo "::error::centralized entry '$entry' missing canonical pin — expected format 'wf:reusable:canonical:legacy-csv'" >&2; exit 1; }
 
     # Skip workflows that don't exist in this repo. Required workflows are
     # checked separately by check_required_workflows; conditional ones
@@ -973,23 +1003,19 @@ check_centralized_workflow_stubs() {
     decoded=$(echo "$content" | base64 -d 2>/dev/null || echo "")
     [ -z "$decoded" ] && continue
 
-    # Required pattern: a non-comment line whose `uses:` value is exactly
-    # petry-projects/.github/.github/workflows/<reusable>.yml@<version>
-    # Anchor to start-of-line + optional indent so a `# uses: ...` comment
-    # cannot satisfy the check.
-    local esc_reusable esc_version
-    esc_reusable=$(escape_ere "$reusable")
-    esc_version=$(escape_ere "$version")
-    local expected="petry-projects/\\.github/\\.github/workflows/${esc_reusable}\\.yml@${esc_version}"
-
-    if echo "$decoded" | grep -qE "^[[:space:]]*uses:[[:space:]]*${expected}([[:space:]]|$)"; then
-      continue  # stub is correctly pinned to the canonical version — compliant
+    # Compliant if a non-comment `uses:` line pins the reusable at the canonical
+    # channel or — transitionally, during the #482 migration — an accepted legacy
+    # @vN ref. stub_pin_acceptable anchors to start-of-line so a `# uses: …`
+    # comment never satisfies the check.
+    if stub_pin_acceptable "$decoded" "$reusable" "$canonical" "$legacy"; then
+      continue
     fi
 
     # Determine why it's non-compliant for a more actionable message.
-    local why
+    local esc_reusable why
+    esc_reusable=$(escape_ere "$reusable")
     if echo "$decoded" | grep -qE "^[[:space:]]*uses:[[:space:]]*petry-projects/\\.github/\\.github/workflows/${esc_reusable}\\.yml@"; then
-      why="references the reusable but is not pinned to \`@${version}\` (org standard)"
+      why="references the reusable but is not pinned to \`@${canonical}\` (org standard)"
     elif echo "$decoded" | grep -qF "petry-projects/.github/.github/workflows/${reusable}"; then
       why="references the reusable but the \`uses:\` line does not match the canonical stub"
     else
@@ -997,7 +1023,7 @@ check_centralized_workflow_stubs() {
     fi
 
     add_finding "$repo" "ci-workflows" "non-stub-$wf" "error" \
-      "Centralized workflow \`$wf\` $why. Replace with the canonical stub from \`standards/workflows/${wf}\` which delegates to \`petry-projects/.github/.github/workflows/${reusable}.yml@${version}\`." \
+      "Centralized workflow \`$wf\` $why. Replace with the canonical stub from \`standards/workflows/${wf}\` which delegates to \`petry-projects/.github/.github/workflows/${reusable}.yml@${canonical}\`." \
       "standards/ci-standards.md#centralization-tiers"
   done
 }
@@ -2156,4 +2182,8 @@ HEREDOC
   cat "$SUMMARY_FILE"
 }
 
-main "$@"
+# Run main only when executed directly, not when sourced (e.g. by bats tests
+# that exercise individual helper functions).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/test/scripts/compliance-audit/centralized-stub-pins.bats
+++ b/test/scripts/compliance-audit/centralized-stub-pins.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+# Tests for stub_pin_acceptable() in scripts/compliance-audit.sh — the pin-match
+# used by check_centralized_workflow_stubs.
+#
+# During the #482 channel migration a stub is compliant if it pins the reusable
+# at the canonical <name>/stable channel OR, transitionally, an accepted legacy
+# @vN ref — so the audit neither flags nor reverts a stub mid-migration. A SHA
+# pin, a commented-out line, or the wrong reusable must NOT satisfy the check.
+#
+# The script is sourced in an isolated subshell (its `main` is guarded, so
+# sourcing only defines functions) and the real helper is exercised directly.
+
+bats_require_minimum_version 1.5.0
+
+SCRIPT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)/scripts/compliance-audit.sh"
+
+# Run the real helper with the given uses-line and (canonical, legacy) spec.
+accept() {
+  local line="$1" canonical="$2" legacy="$3"
+  run bash -c 'source "$1" >/dev/null 2>&1; stub_pin_acceptable "$2" agent-shield-reusable "$3" "$4"' \
+    _ "$SCRIPT" "$line" "$canonical" "$legacy"
+}
+
+C="agent-shield/stable"   # canonical channel for these tests
+L="v1,v2"                 # transitional legacy grace
+R="petry-projects/.github/.github/workflows/agent-shield-reusable.yml"
+
+@test "canonical channel pin is accepted" {
+  accept "    uses: $R@$C" "$C" "$L"
+  [ "$status" -eq 0 ]
+}
+
+@test "transitional legacy @v1 is accepted" {
+  accept "    uses: $R@v1" "$C" "$L"
+  [ "$status" -eq 0 ]
+}
+
+@test "transitional legacy @v2 is accepted" {
+  accept "    uses: $R@v2" "$C" "$L"
+  [ "$status" -eq 0 ]
+}
+
+@test "a SHA pin is rejected (must move to the channel)" {
+  accept "    uses: $R@376a4fcb1117444595e3e702fa450873d0e54310 # v2" "$C" "$L"
+  [ "$status" -ne 0 ]
+}
+
+@test "a commented-out uses line does not satisfy the check" {
+  accept "    # uses: $R@$C" "$C" "$L"
+  [ "$status" -ne 0 ]
+}
+
+@test "the wrong reusable is rejected" {
+  accept "    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@v1" "$C" "$L"
+  [ "$status" -ne 0 ]
+}
+
+@test "with no legacy grace, only the canonical ref is accepted" {
+  # mirrors the feature-ideation entry (canonical @v1, empty legacy)
+  accept "    uses: $R@v1" "v1" ""
+  [ "$status" -eq 0 ]
+  accept "    uses: $R@v2" "v1" ""
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary

**Phase 4** of the channel migration (#482), re-sequenced to land **before** the rest of the fleet sync. `check_centralized_workflow_stubs` now treats the per-reusable `<name>/stable` channel as the canonical stub pin, and — transitionally — still accepts the legacy `@v1`/`@v2` pins so a stub on its old major is **neither flagged nor reverted** while the fleet migrates.

## Why the re-sequence (a real collision)

The audit previously expected `@v1`, and the **dev-lead agent actively remediates** stubs to that expectation (30 open compliance-audit issues fleet-wide). During the broodly pilot it **reverted a freshly-merged channel stub back to `@v1`** within ~20 min (broodly#338 migrated → broodly#323 "Compliance: non-stub-dependency-audit.yml" reverted). Pinning the audit to the channel (with a grace window) stops that fight; the fleet then converges on channels instead of being pulled back to `@v1`.

## Changes

- **`stub_pin_acceptable()`** — pure helper matching the canonical channel or an accepted legacy ref; anchored to start-of-line so a `# uses: …` comment never satisfies it.
- **`centralized` array** → `wf:reusable:canonical:legacy-csv`. The six migrated reusables pin `<name>/stable` (legacy grace `v1,v2`); `feature-ideation` stays `@v1` (not migrated). **SHA pins stay non-compliant** → they re-sync to the channel template (converge).
- **Sourceable script** — guarded `main "$@"` so bats can exercise the real helper.
- **Tests + CI** — `test/scripts/compliance-audit/centralized-stub-pins.bats` (7 cases, against the real function) and a new `compliance-audit-tests.yml` gate running the **full** `test/scripts/compliance-audit/` suite (40 tests — previously not run in CI).

## Validation
- shellcheck clean; 40/40 compliance-audit bats pass; helper verified: channel + `@v1`/`@v2` accepted, SHA / commented / wrong-reusable rejected.

## Next
With the audit no longer reverting channel stubs, resume the **batched** fleet re-sync (Phase 3). A later follow-up drops the legacy grace (channel-only) once everyone's migrated.

Refs #482.

🤖 Generated with [Claude Code](https://claude.com/claude-code)