### PR TITLE
feat(deploy): batch per-repo stub sync into one PR (#482)

### DIFF
--- a/scripts/deploy-standard-workflows.sh
+++ b/scripts/deploy-standard-workflows.sh
@@ -157,57 +157,78 @@ is_already_compliant() {
   echo "$existing_content" | grep -qF "$expected_uses"
 }
 
-# Build the PR body for a stub deployment.
-pr_body_for() {
-  local workflow="$1"
-  printf 'Syncs the org-standard `%s` workflow stub from `%s/.github` (`standards/workflows/%s`), deployed verbatim.\n\nOpened by `scripts/deploy-standard-workflows.sh`; the stub is a thin caller and all behaviour lives in the reusable. See `standards/ci-standards.md`.\n\nThis PR is labeled `%s` and left for the normal review/auto-merge pipeline — the deploy script never merges directly.\n' \
-    "$workflow" "$ORG" "$workflow" "$SYNC_LABEL"
+# Build the PR body for a batched stub deployment (one PR per repo).
+batch_pr_body() {
+  local w lines=""
+  for w in "$@"; do lines+="- \`${w}\`"$'\n'; done
+  printf 'Syncs the following org-standard workflow stub(s) from `%s/.github` (`standards/workflows/`), deployed verbatim:\n\n%s\nOpened by `scripts/deploy-standard-workflows.sh`. Stubs are thin callers; all behaviour lives in the reusables. See `standards/ci-standards.md`. Labeled `%s` and left for the normal review/auto-merge pipeline — the deploy script never merges directly.\n' \
+    "$ORG" "$lines" "$SYNC_LABEL"
 }
 
 # ---------------------------------------------------------------------------
-# Main deploy logic for a single workflow in a single repo
+# Deploy all drifted stubs for a single repo as ONE batched standards-sync PR.
 # ---------------------------------------------------------------------------
-deploy_workflow_to_repo() {
-  local repo="$1" workflow="$2"
-  local template="$STANDARDS_DIR/$workflow"
-  local target_path=".github/workflows/$workflow"
+deploy_repo() {
+  local repo="$1"
 
-  if [[ ! -f "$template" ]]; then
-    err "No template at $template — skipping $workflow for $repo"
-    return
+  # Fully-exempt repos (no per-workflow opt-in) skip with a single log line.
+  if is_skipped_repo "$repo"; then
+    local opts_in_any=false w
+    for w in "${WORKFLOWS[@]}"; do
+      if repo_opts_into "$repo" "$w"; then opts_in_any=true; break; fi
+    done
+    if [[ "$opts_in_any" == "false" ]]; then skip "$repo (exempt)"; return; fi
   fi
 
-  local raw existing_sha existing_content
-  raw=$(fetch_existing "$repo" "$target_path")
-  existing_sha="${raw%%$'\t'*}"
-  existing_content="${raw#*$'\t'}"
+  # Collect the drifted stubs for this repo (path/template pairs + names).
+  local -a paths=() templates=() names=()
+  local workflow template target_path raw existing_sha existing_content
+  for workflow in "${WORKFLOWS[@]}"; do
+    if is_skipped_repo "$repo" && ! repo_opts_into "$repo" "$workflow"; then
+      skip "$repo/$workflow (exempt)"
+      continue
+    fi
+    template="$STANDARDS_DIR/$workflow"
+    target_path=".github/workflows/$workflow"
+    if [[ ! -f "$template" ]]; then
+      err "No template at $template — skipping $workflow for $repo"
+      continue
+    fi
+    raw=$(fetch_existing "$repo" "$target_path")
+    existing_sha="${raw%%$'\t'*}"
+    existing_content="${raw#*$'\t'}"
+    if [[ -n "$existing_sha" ]] && [[ "$FORCE" == "false" ]] && is_already_compliant "$existing_content" "$template"; then
+      skip "$repo/$target_path already compliant"
+      continue
+    fi
+    paths+=("$target_path"); templates+=("$template"); names+=("$workflow")
+  done
 
-  if [[ -n "$existing_sha" ]] && [[ "$FORCE" == "false" ]] && is_already_compliant "$existing_content" "$template"; then
-    skip "$repo/$target_path already compliant"
-    return
-  fi
+  [[ "${#names[@]}" -eq 0 ]] && return  # nothing drifted for this repo
 
-  local branch="${SYNC_BRANCH_PREFIX}/${workflow%.yml}"
-  local title="chore: sync org-standard ${workflow} stub from ${ORG}/.github"
+  local n="${#names[@]}" list branch
+  list=$(IFS=', '; echo "${names[*]}")
+  branch="${SYNC_BRANCH_PREFIX}/workflows-$(date -u +%Y%m%d)"
+  local title="chore: sync ${n} org-standard workflow stub(s) from ${ORG}/.github"
 
   if [[ "$DRY_RUN" == "true" ]]; then
-    if [[ -n "$existing_sha" ]]; then
-      dry "Would open PR to update $repo/$target_path (branch $branch)"
-    else
-      dry "Would open PR to create $repo/$target_path (branch $branch)"
-    fi
+    dry "Would open PR for $repo (branch $branch) — ${n} stub(s): $list"
     return
   fi
 
-  local outcome
-  outcome=$(sd_deploy_via_pr "$ORG/$repo" "$target_path" "$template" \
-    "$branch" "$SYNC_LABEL" "$title" "$(pr_body_for "$workflow")") || true
+  # Interleave (path, template) into the variadic file-pair args.
+  local -a filepairs=() k
+  for (( k = 0; k < n; k++ )); do filepairs+=("${paths[k]}" "${templates[k]}"); done
+
+  local body outcome
+  body=$(batch_pr_body "${names[@]}")
+  outcome=$(sd_deploy_files_via_pr "$ORG/$repo" "$branch" "$SYNC_LABEL" "$title" "$body" "${filepairs[@]}") || true
 
   case "$outcome" in
-    "OPENED "*)       ok   "$repo/$target_path — opened ${outcome#OPENED }" ;;
-    "SKIP_PR_OPEN "*) skip "$repo/$target_path — PR #${outcome#SKIP_PR_OPEN } already open" ;;
-    "FAILED "*)       err  "$repo/$target_path — ${outcome#FAILED }" ;;
-    *)                err  "$repo/$target_path — unexpected outcome: ${outcome:-<none>}" ;;
+    "OPENED "*)       ok   "$repo — opened ${outcome#OPENED } (${n} stub(s): $list)" ;;
+    "SKIP_PR_OPEN "*) skip "$repo — sync PR #${outcome#SKIP_PR_OPEN } already open" ;;
+    "FAILED "*)       err  "$repo — ${outcome#FAILED }" ;;
+    *)                err  "$repo — unexpected outcome: ${outcome:-<none>}" ;;
   esac
 }
 
@@ -235,29 +256,7 @@ fi
 log "Deploying ${#WORKFLOWS[@]} workflow(s) to ${#REPOS[@]} repo(s)"
 
 for repo in "${REPOS[@]}"; do
-  # Fully-exempt repos (no per-workflow opt-in) skip with a single log line
-  # instead of one per workflow.
-  if is_skipped_repo "$repo"; then
-    opts_in_any=false
-    for w in "${WORKFLOWS[@]}"; do
-      if repo_opts_into "$repo" "$w"; then
-        opts_in_any=true
-        break
-      fi
-    done
-    if [[ "$opts_in_any" == "false" ]]; then
-      skip "$repo (exempt)"
-      continue
-    fi
-  fi
-
-  for workflow in "${WORKFLOWS[@]}"; do
-    if is_skipped_repo "$repo" && ! repo_opts_into "$repo" "$workflow"; then
-      skip "$repo/$workflow (exempt)"
-      continue
-    fi
-    deploy_workflow_to_repo "$repo" "$workflow"
-  done
+  deploy_repo "$repo"
 done
 
 log "Done."

--- a/scripts/lib/standards-deploy.sh
+++ b/scripts/lib/standards-deploy.sh
@@ -39,22 +39,42 @@ _STANDARDS_DEPLOY_SOURCED=1
 #
 # Prints exactly one outcome token line to stdout:
 #   OPENED <pr-url>            a PR was opened
-#   SKIP_PR_OPEN <pr-number>   an open PR already exists on this branch
+#   SKIP_PR_OPEN <pr-number>   an open labeled sync PR already exists for the repo
 #   FAILED <reason>            a hard error occurred (reason is a short slug)
 #
 # Returns 0 for OPENED/SKIP_PR_OPEN, non-zero for FAILED. Emits no other stdout,
 # so callers can capture the outcome with a command substitution.
+# Single-file convenience wrapper around sd_deploy_files_via_pr.
 sd_deploy_via_pr() {
   local repo="$1" path="$2" local_file="$3" branch="$4" label="$5" title="$6" body="$7"
+  sd_deploy_files_via_pr "$repo" "$branch" "$label" "$title" "$body" "$path" "$local_file"
+}
 
-  if [ ! -f "$local_file" ]; then
-    echo "FAILED missing-local-file"
+# sd_deploy_files_via_pr <repo> <branch> <label> <title> <body> \
+#                        <path> <local_file> [<path> <local_file> ...]
+#
+# Deploys one OR MORE files to a repo in a SINGLE labeled PR. A fleet re-sync of
+# N stubs for a repo is therefore N files in one PR, not N PRs. Idempotency is
+# keyed by the label — at most one open sync PR per repo; if one already exists
+# it is reused (skip). Trailing args are (path, local_file) pairs.
+sd_deploy_files_via_pr() {
+  local repo="$1" branch="$2" label="$3" title="$4" body="$5"
+  shift 5
+
+  if [ "$#" -eq 0 ] || [ $(( $# % 2 )) -ne 0 ]; then
+    echo "FAILED bad-file-args"
     return 1
   fi
 
-  # 1. Idempotency — an open PR already exists for this head branch.
+  # Validate every local file up front, before touching the remote.
+  local i
+  for (( i = 2; i <= $#; i += 2 )); do
+    if [ ! -f "${!i}" ]; then echo "FAILED missing-local-file"; return 1; fi
+  done
+
+  # 1. Idempotency — at most one open sync PR per repo, keyed by label.
   local existing_pr
-  existing_pr=$(gh pr list --repo "$repo" --head "$branch" --state open \
+  existing_pr=$(gh pr list --repo "$repo" --label "$label" --state open \
     --json number --jq '.[0].number // ""' 2>/dev/null || true)
   if [ -n "$existing_pr" ]; then
     echo "SKIP_PR_OPEN $existing_pr"
@@ -81,24 +101,27 @@ sd_deploy_via_pr() {
     fi
   fi
 
-  # 4. PUT the file verbatim onto the branch. Look up the blob SHA on the branch
-  #    so this handles both create (absent → empty SHA) and update (drifted stub)
-  #    regardless of whether the branch is fresh or reused.
-  local branch_sha encoded
-  branch_sha=$(gh api "repos/${repo}/contents/${path}?ref=${branch}" \
-    --jq '.sha // ""' 2>/dev/null || true)
-  encoded=$(base64 -w 0 "$local_file" 2>/dev/null || base64 -b 0 "$local_file")
+  # 4. PUT each file verbatim onto the branch. The blob SHA is looked up per file
+  #    on the branch so both create (absent → empty SHA) and update (drifted stub)
+  #    work, whether the branch is fresh or reused.
+  local path local_file branch_sha encoded j
+  for (( i = 1; i < $#; i += 2 )); do
+    j=$(( i + 1 )); path="${!i}"; local_file="${!j}"
+    branch_sha=$(gh api "repos/${repo}/contents/${path}?ref=${branch}" \
+      --jq '.sha // ""' 2>/dev/null || true)
+    encoded=$(base64 -w 0 "$local_file" 2>/dev/null || base64 -b 0 "$local_file")
 
-  local put_args=(--method PUT
-    --raw-field "message=${title}"
-    --raw-field "content=${encoded}"
-    --raw-field "branch=${branch}")
-  [ -n "$branch_sha" ] && put_args+=(--raw-field "sha=${branch_sha}")
+    local put_args=(--method PUT
+      --raw-field "message=${title}"
+      --raw-field "content=${encoded}"
+      --raw-field "branch=${branch}")
+    [ -n "$branch_sha" ] && put_args+=(--raw-field "sha=${branch_sha}")
 
-  if ! gh api "repos/${repo}/contents/${path}" "${put_args[@]}" --silent 2>/dev/null; then
-    echo "FAILED put-failed"
-    return 1
-  fi
+    if ! gh api "repos/${repo}/contents/${path}" "${put_args[@]}" --silent 2>/dev/null; then
+      echo "FAILED put-failed"
+      return 1
+    fi
+  done
 
   # 5. Ensure the label exists, then open the PR. `gh pr create --label` fails
   #    outright if the label is absent, and consumer repos do not carry the

--- a/test/scripts/deploy-standard-workflows/dry-run.bats
+++ b/test/scripts/deploy-standard-workflows/dry-run.bats
@@ -47,7 +47,7 @@ STUB
   run env GH_TOKEN=x bash "$SCRIPT" --dry-run --repo markets --workflow add-to-project.yml
   [ "$status" -eq 0 ]
   echo "$output" | grep -q 'DRY RUN — no PRs will be opened'
-  echo "$output" | grep -q 'Would open PR to create markets/.github/workflows/add-to-project.yml (branch standards-sync/add-to-project)'
+  echo "$output" | grep -qE 'Would open PR for markets \(branch standards-sync/workflows-[0-9]+\) — 1 stub\(s\): add-to-project.yml'
   # dry-run must not mutate: no branch creation, no PUT, no PR create
   ! grep -q 'git/refs --method POST' "$GH_CALLS"
   ! grep -q 'gh pr create' "$GH_CALLS"

--- a/test/scripts/lib/standards-deploy.bats
+++ b/test/scripts/lib/standards-deploy.bats
@@ -87,11 +87,35 @@ deploy() {
 @test "happy path makes the full create call sequence" {
   run deploy
   [ "$status" -eq 0 ]
-  grep -q 'gh pr list --repo petry-projects/markets --head standards-sync/add-to-project' "$GH_CALLS"
+  grep -q 'gh pr list --repo petry-projects/markets --label standards-sync' "$GH_CALLS"
   grep -q 'gh api repos/petry-projects/markets/git/refs --method POST' "$GH_CALLS"
   grep -q 'gh api repos/petry-projects/markets/contents/.github/workflows/add-to-project.yml --method PUT' "$GH_CALLS"
   grep -q 'gh pr create --repo petry-projects/markets --head standards-sync/add-to-project --base main' "$GH_CALLS"
   grep -q -- '--label standards-sync' "$GH_CALLS"
+}
+
+# The multi-file primitive: two stubs deploy as a single PR (two PUTs, one
+# pr create) — the per-repo batching used by the fleet re-sync.
+@test "deploys multiple files in a single PR" {
+  local f2="${TT_TMP}/dependency-audit.yml"
+  printf 'name: stub2\non: [push]\n' > "$f2"
+  run sd_deploy_files_via_pr "petry-projects/markets" "standards-sync/workflows" \
+    "standards-sync" "chore: sync 2 stubs" "body" \
+    ".github/workflows/add-to-project.yml" "$LOCAL_FILE" \
+    ".github/workflows/dependency-audit.yml" "$f2"
+  [ "$status" -eq 0 ]
+  [ "$output" = "OPENED https://github.com/o/r/pull/1" ]
+  grep -q 'contents/.github/workflows/add-to-project.yml --method PUT' "$GH_CALLS"
+  grep -q 'contents/.github/workflows/dependency-audit.yml --method PUT' "$GH_CALLS"
+  # exactly one PR opened for the batch
+  [ "$(grep -c 'gh pr create' "$GH_CALLS")" -eq 1 ]
+}
+
+@test "rejects an odd number of file arguments" {
+  run sd_deploy_files_via_pr "petry-projects/markets" "b" "l" "t" "body" \
+    ".github/workflows/only-a-path.yml"
+  [ "$status" -ne 0 ]
+  [ "$output" = "FAILED bad-file-args" ]
 }
 
 # Regression: consumer repos don't carry the standards-sync label, and


### PR DESCRIPTION
## Summary

Phase 3a of #482. The deploy tooling opened **one PR per (repo, workflow)** — so the channel-migration fleet re-sync would be ~36 PRs (6 workflows × 6 repos). This batches all drifted stubs for a repo into a **single** `standards-sync` PR.

## Changes

- **`sd_deploy_files_via_pr`** (lib) — multi-file primitive: writes every file onto one branch, opens one labeled PR. Idempotency is now keyed by the **label** (at most one open sync PR per repo). `sd_deploy_via_pr` stays as a thin single-file wrapper that delegates to it.
- **`deploy-standard-workflows.sh`** — `deploy_repo` collects a repo's drifted stubs and opens **one** PR (branch `standards-sync/workflows-<date>`); dry-run reports the batch.
- **Tests** — added multi-file-in-one-PR + odd-arg-rejection; updated idempotency/dry-run assertions for the label-keyed batched behavior. 16/16 bats; shellcheck clean.

## Dry-run (markets)

```
SKIP  markets/.github/workflows/dev-lead.yml already compliant
SKIP  markets/.github/workflows/add-to-project.yml already compliant
DRY   Would open PR for markets (branch standards-sync/workflows-20260619) — 6 stub(s): pr-review-mention.yml,agent-shield.yml,auto-rebase.yml,dependabot-automerge.yml,dependabot-rebase.yml,dependency-audit.yml
```

→ one PR, six stubs.

## Next
Once merged, resume Phase 3 — re-sync the 5 remaining repos (~5 PRs) to the channels, plus re-fix broodly's `dependency-audit` (reverted by the collision in #492's context).

Refs #482.

🤖 Generated with [Claude Code](https://claude.com/claude-code)