### PR TITLE
feat(standards): fleet caller stubs for the idea→initiative pipeline

### DIFF
--- a/.github/workflows/idea-enhancer-reusable.yml
+++ b/.github/workflows/idea-enhancer-reusable.yml
@@ -1,0 +1,70 @@
+# Reusable Idea Enhancer — fleet dispatch workflow.
+# Single source of truth for the org: the dispatch logic lives here. Repo-level
+# idea-enhancer.yml files are thin caller stubs.
+# Standard: https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md
+#
+# When a human opens a new Ideas Discussion (or on a weekly safety-net sweep), it
+# re-dispatches the CENTRAL idea-enhancer in petry-projects/.github-private with
+# the CALLER repo as `target_repo`. The analyst enriches THIS repo's open,
+# human-authored, not-yet-enhanced Ideas Discussions (one comment each: sharpened
+# problem/goal, repo + market context, impact/effort, suggested acceptance
+# criteria). Enhancement is idempotent (a hidden marker prevents re-enhancement),
+# so the per-discussion fan-in to a full backlog sweep is safe.
+#
+# Why dispatch instead of running inline: claude-code-action aborts on a
+# `discussion` event context, so the enhancement must run under the central
+# workflow_dispatch, the same bridge the initiative-planner uses.
+#
+# IMPORTANT — the dispatch requires a PAT, not GITHUB_TOKEN (loop prevention).
+#
+# Requires:
+#   GH_PAT_WORKFLOWS — org secret, classic PAT (repo + workflow scope).
+name: Idea Enhancer — Fleet Dispatch (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      central_repo:
+        description: "owner/repo hosting the central idea-enhancer.yml workflow."
+        required: false
+        default: "petry-projects/.github-private"
+        type: string
+    secrets:
+      GH_PAT_WORKFLOWS:
+        description: "Classic PAT with repo + workflow scope used to dispatch the central idea-enhancer (GITHUB_TOKEN cannot start a workflow_dispatch run)."
+        required: true
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # On the `discussion` trigger, only fire for new ideas in the Ideas category
+    # and skip the bot's own creations (bot-authored ideas are already AI-written).
+    # Schedule/dispatch runs are unaffected by this guard.
+    if: >-
+      github.event_name != 'discussion' ||
+      (github.event.discussion.category.slug == 'ideas' &&
+       github.event.discussion.user.type != 'Bot')
+    permissions: {}
+    steps:
+      - name: Guard — PAT present
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::GH_PAT_WORKFLOWS is required — a workflow_dispatch fired with GITHUB_TOKEN will not start a run."
+            exit 1
+          fi
+
+      - name: Dispatch central idea-enhancer for this repo
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
+          CENTRAL_REPO: ${{ inputs.central_repo }}
+          TARGET_REPO: ${{ github.repository }}
+        run: |
+          echo "Enhancing ${TARGET_REPO}'s ideas → dispatching central idea-enhancer in ${CENTRAL_REPO}."
+          gh workflow run idea-enhancer.yml \
+            --repo "${CENTRAL_REPO}" \
+            -f target_repo="${TARGET_REPO}" \
+            -f dry_run=false
+          echo "Dispatched idea-enhancer.yml (target_repo=${TARGET_REPO}, dry_run=false)."

--- a/.github/workflows/idea-triage-reusable.yml
+++ b/.github/workflows/idea-triage-reusable.yml
@@ -1,0 +1,60 @@
+# Reusable Idea Triage — fleet dispatch workflow.
+# Single source of truth for the org: the dispatch logic lives here. Repo-level
+# idea-triage.yml files are thin caller stubs.
+# Standard: https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md
+#
+# Weekly (and on demand) it re-dispatches the CENTRAL idea-triage workflow in
+# petry-projects/.github-private with the CALLER repo as `target_repo`, so the
+# BMAD analyst scores THIS repo's Ideas backlog and refreshes THIS repo's "Idea
+# Promotion Queue" tracking issue. The triage tooling and vendored personas stay
+# vendored once, centrally — fleet repos only ship this thin trigger.
+#
+# IMPORTANT — the dispatch requires a PAT, not GITHUB_TOKEN:
+#   GitHub does not start new workflow runs from a workflow_dispatch fired with
+#   the default GITHUB_TOKEN (loop prevention). The dispatch MUST use a PAT with
+#   workflow scope (GH_PAT_WORKFLOWS).
+#
+# Requires:
+#   GH_PAT_WORKFLOWS — org secret, classic PAT (repo + workflow scope).
+name: Idea Triage — Fleet Dispatch (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      central_repo:
+        description: "owner/repo hosting the central idea-triage.yml workflow."
+        required: false
+        default: "petry-projects/.github-private"
+        type: string
+    secrets:
+      GH_PAT_WORKFLOWS:
+        description: "Classic PAT with repo + workflow scope used to dispatch the central idea-triage (GITHUB_TOKEN cannot start a workflow_dispatch run)."
+        required: true
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Guard — PAT present
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::GH_PAT_WORKFLOWS is required — a workflow_dispatch fired with GITHUB_TOKEN will not start a run."
+            exit 1
+          fi
+
+      - name: Dispatch central idea-triage for this repo
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
+          CENTRAL_REPO: ${{ inputs.central_repo }}
+          TARGET_REPO: ${{ github.repository }}
+        run: |
+          echo "Triaging ${TARGET_REPO} → dispatching central idea-triage in ${CENTRAL_REPO}."
+          gh workflow run idea-triage.yml \
+            --repo "${CENTRAL_REPO}" \
+            -f target_repo="${TARGET_REPO}" \
+            -f dry_run=false
+          echo "Dispatched idea-triage.yml (target_repo=${TARGET_REPO}, dry_run=false)."

--- a/.github/workflows/initiative-planner-reusable.yml
+++ b/.github/workflows/initiative-planner-reusable.yml
@@ -1,0 +1,103 @@
+# Reusable Initiative Planner — Approval Trigger workflow.
+# Single source of truth for the org: all idea→initiative dispatch logic lives
+# here. Repo-level initiative-planner.yml files are thin caller stubs.
+# Standard: https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md
+#
+# Fires when a maintainer adds the `idea:approved` label to an Ideas Discussion
+# in a fleet repo. It does NOT plan inline — the BMAD Scrum Master (Bob) and the
+# vendored BMAD frameworks live centrally in petry-projects/.github-private, and
+# claude-code-action aborts on `discussion` event contexts ("Unsupported event
+# type: discussion"). So this reusable resolves the discussion number and
+# re-dispatches the CENTRAL initiative-planner via workflow_dispatch, passing the
+# CALLER repo as `target_repo` so Bob reads that repo's Discussion and
+# materializes the epic + sub-issue DAG there. The `idea:approved` label stays
+# the human gate; the dispatch is an invisible bridge.
+#
+# IMPORTANT — the dispatch requires a PAT, not GITHUB_TOKEN:
+#   GitHub does not start new workflow runs from a workflow_dispatch fired with
+#   the default GITHUB_TOKEN (loop prevention). The dispatch MUST use a PAT with
+#   workflow scope (GH_PAT_WORKFLOWS), the same constraint documented in
+#   petry-projects/.github-private scripts/initiative-planner/redispatch.sh.
+#
+# Requires:
+#   GH_PAT_WORKFLOWS — org secret, classic PAT (repo + workflow scope) used to
+#                      dispatch the central planner and resolve trust.
+name: Initiative Planner — Approval Trigger (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      planner_repo:
+        description: "owner/repo hosting the central initiative-planner.yml workflow."
+        required: false
+        default: "petry-projects/.github-private"
+        type: string
+    secrets:
+      GH_PAT_WORKFLOWS:
+        description: "Classic PAT with repo + workflow scope used to dispatch the central initiative-planner (GITHUB_TOKEN cannot start a workflow_dispatch run)."
+        required: true
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Only fire on the `idea:approved` label, and only when a trusted maintainer
+    # added it. requested actors below MEMBER/OWNER/COLLABORATOR must never be
+    # able to spend planning quota by labelling a Discussion.
+    if: >-
+      github.event_name == 'discussion' &&
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'idea:approved'
+    permissions: {}
+    steps:
+      - name: Guard — PAT present
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::GH_PAT_WORKFLOWS is required — a workflow_dispatch fired with GITHUB_TOKEN will not start a run."
+            exit 1
+          fi
+
+      - name: Guard — trusted actor
+        id: trust
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.event.sender.login }}
+        run: |
+          # Only admin/write collaborators may approve an idea for planning.
+          # The discussion `labeled` payload carries no author_association, so
+          # query the collaborator permission API (.permission: admin|write|read|none).
+          PERM=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" --jq '.permission' 2>/dev/null || echo "none")
+          case "$PERM" in
+            admin|write)
+              echo "Actor @${ACTOR} has permission ${PERM} — trusted."
+              echo "trusted=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::warning::Actor @${ACTOR} has permission ${PERM} — not trusted; not dispatching the planner."
+              echo "trusted=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: Dispatch central planner for this repo
+        if: steps.trust.outputs.trusted == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
+          PLANNER_REPO: ${{ inputs.planner_repo }}
+          TARGET_REPO: ${{ github.repository }}
+          DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
+        run: |
+          # Validate the discussion number before it reaches the gh command line.
+          if ! [[ "${DISCUSSION_NUMBER}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::discussion number must be a positive integer, got: '${DISCUSSION_NUMBER}'"
+            exit 1
+          fi
+          echo "idea:approved on ${TARGET_REPO} discussion #${DISCUSSION_NUMBER} → dispatching central planner in ${PLANNER_REPO}."
+          gh workflow run initiative-planner.yml \
+            --repo "${PLANNER_REPO}" \
+            -f discussion="${DISCUSSION_NUMBER}" \
+            -f target_repo="${TARGET_REPO}" \
+            -f dry_run=false
+          echo "Dispatched initiative-planner.yml (discussion=${DISCUSSION_NUMBER}, target_repo=${TARGET_REPO}, dry_run=false)."

--- a/standards/workflows/idea-enhancer.yml
+++ b/standards/workflows/idea-enhancer.yml
@@ -1,0 +1,49 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/idea-enhancer.yml
+# Standard:        petry-projects/.github/standards/ci-standards.md
+# Reusable:        petry-projects/.github/.github/workflows/idea-enhancer-reusable.yml
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. All enhancement-dispatch logic (including
+#     the Ideas-category / non-bot guard) lives in the reusable above.
+#   • You MUST NOT change: the `uses:` ref — it is pinned to the
+#     `idea-enhancer/stable` channel, a moving tag advanced centrally. Never
+#     repoint it to `@main`, a SHA, or a frozen `@vX`. Do not change the trigger
+#     events or the `secrets:` block.
+#   • You MAY change: the cron schedule if the weekly cadence doesn't suit.
+#   • If you need different behaviour, open a PR against the reusable in the
+#     central repo. A new release is rolled out by moving the channel tag
+#     centrally — never by editing callers.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Idea Enhancer — enrich human-authored ideas, thin caller for the org reusable.
+#
+# When a human opens a new Ideas Discussion in this repo (or on a weekly sweep),
+# this re-dispatches the CENTRAL idea-enhancer (BMAD analyst) in
+# petry-projects/.github-private with this repo as the target. It posts one
+# enrichment comment per open, human-authored, not-yet-enhanced idea. It is
+# idempotent (a hidden marker prevents re-enhancement) and never approves,
+# labels, or promotes — that stays with triage and the human gates.
+#
+# To adopt:
+#   1. Copy this file to .github/workflows/idea-enhancer.yml in your repo.
+#   2. Ensure GitHub Discussions is enabled with an "Ideas" category.
+#   3. Confirm the org-level secret GH_PAT_WORKFLOWS is accessible.
+#   4. (Optional) Adjust the schedule cron.
+#
+# Standard: https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md
+name: Idea Enhancer — Enrich Ideas
+
+on:
+  discussion:
+    types: [created]
+  schedule:
+    - cron: '0 8 * * 3' # Wednesday 08:00 UTC — safety-net sweep (after the central run)
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  idea-enhancer:
+    uses: petry-projects/.github/.github/workflows/idea-enhancer-reusable.yml@idea-enhancer/stable
+    secrets: inherit

--- a/standards/workflows/idea-triage.yml
+++ b/standards/workflows/idea-triage.yml
@@ -1,0 +1,46 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/idea-triage.yml
+# Standard:        petry-projects/.github/standards/ci-standards.md
+# Reusable:        petry-projects/.github/.github/workflows/idea-triage-reusable.yml
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. All triage-dispatch logic lives in the
+#     reusable above.
+#   • You MUST NOT change: the `uses:` ref — it is pinned to the
+#     `idea-triage/stable` channel, a moving tag advanced centrally. Never
+#     repoint it to `@main`, a SHA, or a frozen `@vX`. Do not change the
+#     `secrets:` block.
+#   • You MAY change: the cron schedule if the weekly cadence doesn't suit.
+#   • If you need different behaviour, open a PR against the reusable in the
+#     central repo. A new release is rolled out by moving the channel tag
+#     centrally — never by editing callers.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Idea Triage — weekly ripeness shortlist, thin caller for the org-level reusable.
+#
+# Weekly, this re-dispatches the CENTRAL idea-triage (BMAD analyst) in
+# petry-projects/.github-private with this repo as the target. It scores this
+# repo's open Ideas Discussions (Ripe / Soon / Not yet) and refreshes this repo's
+# "Idea Promotion Queue" tracking issue (label `idea-triage`). It never applies
+# `idea:approved` — that stays the human's pick.
+#
+# To adopt:
+#   1. Copy this file to .github/workflows/idea-triage.yml in your repo.
+#   2. Ensure GitHub Discussions is enabled with an "Ideas" category.
+#   3. Confirm the org-level secret GH_PAT_WORKFLOWS is accessible.
+#   4. (Optional) Adjust the schedule cron.
+#
+# Standard: https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md
+name: Idea Triage — Weekly Shortlist
+
+on:
+  schedule:
+    - cron: '30 13 * * 1' # Monday 13:30 UTC (just after the central dogfood run)
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  idea-triage:
+    uses: petry-projects/.github/.github/workflows/idea-triage-reusable.yml@idea-triage/stable
+    secrets: inherit

--- a/standards/workflows/initiative-planner.yml
+++ b/standards/workflows/initiative-planner.yml
@@ -1,0 +1,48 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/initiative-planner.yml
+# Standard:        petry-projects/.github/standards/ci-standards.md
+# Reusable:        petry-projects/.github/.github/workflows/initiative-planner-reusable.yml
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. All idea→initiative dispatch logic (the
+#     `idea:approved` gate, the trusted-actor check, and the cross-repo dispatch
+#     to the central BMAD Scrum Master planner) lives in the reusable above.
+#   • You MUST NOT change: the `uses:` ref — it is pinned to the
+#     `initiative-planner/stable` channel, a moving tag advanced centrally.
+#     Never repoint it to `@main`, a SHA, or a frozen `@vX` (see
+#     ci-standards.md → Reusable workflow versioning). Also do not change the
+#     trigger events or the `secrets:` block.
+#   • If you need different behaviour, open a PR against the reusable in the
+#     central repo. A new release is rolled out by moving the channel tag
+#     centrally — never by editing callers, so no fanout PR is needed.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Initiative Planner — approval trigger, thin caller for the org-level reusable.
+#
+# When a maintainer adds `idea:approved` to an Ideas Discussion in this repo,
+# the reusable re-dispatches the CENTRAL initiative-planner (BMAD Scrum Master
+# "Bob") in petry-projects/.github-private with this repo as the target. Bob
+# reads this repo's Discussion and materializes an inert epic + sub-issue DAG
+# here (labelled `initiative`, NOT `initiative:auto`). A maintainer then adds
+# `initiative:auto` to the epic to hand it to initiative-driver. The frameworks
+# and planning logic stay vendored once, centrally.
+#
+# To adopt:
+#   1. Copy this file to .github/workflows/initiative-planner.yml in your repo.
+#   2. Ensure GitHub Discussions is enabled with an "Ideas" category.
+#   3. Ensure the `idea:approved` label exists on the repo.
+#   4. Confirm the org-level secret GH_PAT_WORKFLOWS is accessible.
+#
+# Standard: https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md
+name: Initiative Planner — Approval Trigger
+
+on:
+  discussion:
+    types: [labeled]
+
+permissions: {}
+
+jobs:
+  initiative-planner:
+    uses: petry-projects/.github/.github/workflows/initiative-planner-reusable.yml@initiative-planner/stable
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adds the **public-repo half** of fleet-enabling the idea→initiative pipeline (epic `petry-projects/.github-private#817`, Option A). Three thin caller stubs + their dispatch reusables let any BMAD-enabled repo run the pipeline against **its own** Ideas Discussions, while the BMAD frameworks and planning logic stay vendored once in `.github-private`.

This delivers the pieces that the `.github-private`-side PRs (#827, #828, #829) could **not** create — dev-lead runs there can't write to this public repo, so #820 closed on only a `lint.yml` one-liner and #821 closed with its public stubs still missing. This PR is their real deliverable.

## What's here

| Stub (`standards/workflows/`) | Reusable (`.github/workflows/`) | Trigger → action |
|---|---|---|
| `initiative-planner.yml` | `initiative-planner-reusable.yml` | `discussion [labeled] idea:approved` (trusted actor) → dispatch central planner with `target_repo=<host>` |
| `idea-triage.yml` | `idea-triage-reusable.yml` | weekly + dispatch → dispatch central triage with `target_repo=<host>` |
| `idea-enhancer.yml` | `idea-enhancer-reusable.yml` | new Ideas Discussion + weekly → dispatch central enhancer with `target_repo=<host>` |

## Design

- **Pattern:** thin stub → reusable that *dispatches* the central workflow, mirroring `pr-review-mention`. `claude-code-action` aborts on `discussion` event contexts (the #591 root cause), so the reusables re-dispatch the central `workflow_dispatch` rather than plan inline.
- **Cross-repo writes** rely on the central workflows' `target_repo` parameterization (now on `main` via #827/#829) + the `GH_PAT_WORKFLOWS` PAT for dispatch (GITHUB_TOKEN can't start a `workflow_dispatch` run — loop prevention).
- **Adoptable, not force-deployed:** like `feature-ideation.yml`, these are **not** in `DEPLOYABLE_WORKFLOWS`. BMAD repos opt in (the S8 pilot/rollout drives adoption). No fanout on merge.

## Release follow-ups (not in this PR)

- Cut the channel tags `initiative-planner/stable`, `idea-triage/stable`, `idea-enhancer/stable` (+ `vX.Y.Z`) so adopting repos' `@*/stable` pins resolve.
- S8 (`.github-private#825`) adds the `ci-standards.md` section + pipeline-doc diagram + one-repo pilot.
- S1 (`#818`, GitHub App creds) refines the cross-repo token from `GH_PAT_WORKFLOWS` to a least-privilege App token.

Refs `petry-projects/.github-private#817`, `#820`, `#821`

🤖 Generated with [Claude Code](https://claude.com/claude-code)