### PR TITLE
ci(dev-lead): pin .github to @dev-lead/ring0 + accept ring channels in audit

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -43,7 +43,9 @@ permissions: {}
 
 jobs:
   dev-lead:
-    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@main
+    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/ring0
+    with:
+      agent_ref: dev-lead/ring0
     secrets: inherit
     permissions:
       contents: write

--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -1057,19 +1057,24 @@ check_dev_lead_stub() {
   decoded=$(echo "$content" | base64 -d 2>/dev/null || echo "")
   [ -z "$decoded" ] && return
 
-  # 1) Canonical pin (non-comment `uses:` line, exact ref) — the moving
-  #    dev-lead/stable channel tag (self-host channel model).
-  if ! printf '%s\n' "$decoded" | grep -qE "^[[:space:]]*uses:[[:space:]]*petry-projects/\\.github-private/\\.github/workflows/dev-lead-reusable\\.yml@dev-lead/stable([[:space:]]|$)"; then
+  # 1) Canonical pin (non-comment `uses:` line) — a moving dev-lead channel tag
+  #    (self-host channel model). The production default is `stable`; the staged
+  #    canary model (versioning.md Phase 2, #499/#500) also permits the candidate
+  #    channel `next` and per-ring channels `ring0`, `ring1`, … A frozen `@vX.Y.Z`
+  #    or `@<sha>` is NOT a channel and is intentionally rejected — callers pin the
+  #    moving channel so rollout/rollback is a single central tag move.
+  if ! printf '%s\n' "$decoded" | grep -qE "^[[:space:]]*uses:[[:space:]]*petry-projects/\\.github-private/\\.github/workflows/dev-lead-reusable\\.yml@dev-lead/(stable|next|ring[0-9]+)([[:space:]]|$)"; then
     add_finding "$repo" "ci-workflows" "dev-lead-stub-pin" "error" \
-      "The \`dev-lead.yml\` caller stub must pin \`petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable\`. Re-sync from \`standards/workflows/dev-lead.yml\`." \
+      "The \`dev-lead.yml\` caller stub must pin a \`dev-lead\` channel tag — \`petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/<channel>\` where <channel> is \`stable\` (default), \`next\`, or \`ring<N>\`. Re-sync from \`standards/workflows/dev-lead.yml\`." \
       "standards/ci-standards.md#dev-lead-agent"
   fi
 
   # 2) agent_ref must be threaded through to pin the same channel inside the
   #    reusable's own script/prompt checkout (prevents split-brain on promotion).
-  if ! printf '%s\n' "$decoded" | grep -qE "^[[:space:]]*agent_ref:[[:space:]]*dev-lead/stable([[:space:]]|$)"; then
+  #    Same channel set as the uses: pin above; should match the uses: channel.
+  if ! printf '%s\n' "$decoded" | grep -qE "^[[:space:]]*agent_ref:[[:space:]]*dev-lead/(stable|next|ring[0-9]+)([[:space:]]|$)"; then
     add_finding "$repo" "ci-workflows" "dev-lead-stub-agent-ref" "error" \
-      "The \`dev-lead.yml\` caller stub must pass \`with: agent_ref: dev-lead/stable\` so the reusable checks out its own scripts/prompts from the same channel. Re-sync from \`standards/workflows/dev-lead.yml\`." \
+      "The \`dev-lead.yml\` caller stub must pass \`with: agent_ref: dev-lead/<channel>\` (\`stable\`, \`next\`, or \`ring<N>\`) so the reusable checks out its own scripts/prompts from the same channel. Re-sync from \`standards/workflows/dev-lead.yml\`." \
       "standards/ci-standards.md#dev-lead-agent"
   fi
 

--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -1072,10 +1072,19 @@ check_dev_lead_stub() {
   # 2) agent_ref must be threaded through to pin the same channel inside the
   #    reusable's own script/prompt checkout (prevents split-brain on promotion).
   #    Same channel set as the uses: pin above; should match the uses: channel.
-  if ! printf '%s\n' "$decoded" | grep -qE "^[[:space:]]*agent_ref:[[:space:]]*dev-lead/(stable|next|ring[0-9]+)([[:space:]]|$)"; then
-    add_finding "$repo" "ci-workflows" "dev-lead-stub-agent-ref" "error" \
-      "The \`dev-lead.yml\` caller stub must pass \`with: agent_ref: dev-lead/<channel>\` (\`stable\`, \`next\`, or \`ring<N>\`) so the reusable checks out its own scripts/prompts from the same channel. Re-sync from \`standards/workflows/dev-lead.yml\`." \
-      "standards/ci-standards.md#dev-lead-agent"
+  uses_channel=$(printf '%s\n' "$decoded" | sed -nE 's#^[[:space:]]*uses:[[:space:]]*petry-projects/\.github-private/\.github/workflows/dev-lead-reusable\.yml@dev-lead/(stable|next|ring[0-9]+)([[:space:]]|$).*#\1#p')
+  if [ -n "$uses_channel" ]; then
+    if ! printf '%s\n' "$decoded" | grep -qE "^[[:space:]]*agent_ref:[[:space:]]*dev-lead/$uses_channel([[:space:]]|$)"; then
+      add_finding "$repo" "ci-workflows" "dev-lead-stub-agent-ref" "error" \
+        "The \`dev-lead.yml\` caller stub must pass \`with: agent_ref: dev-lead/$uses_channel\` to match the pinned channel \`$uses_channel\`. Re-sync from \`standards/workflows/dev-lead.yml\`." \
+        "standards/ci-standards.md#dev-lead-agent"
+    fi
+  else
+    if ! printf '%s\n' "$decoded" | grep -qE "^[[:space:]]*agent_ref:[[:space:]]*dev-lead/(stable|next|ring[0-9]+)([[:space:]]|$)"; then
+      add_finding "$repo" "ci-workflows" "dev-lead-stub-agent-ref" "error" \
+        "The \`dev-lead.yml\` caller stub must pass \`with: agent_ref: dev-lead/<channel>\` (\`stable\`, \`next\`, or \`ring<N>\`) so the reusable checks out its own scripts/prompts from the same channel. Re-sync from \`standards/workflows/dev-lead.yml\`." \
+        "standards/ci-standards.md#dev-lead-agent"
+    fi
   fi
 
   # 3) No per-stub concurrency block — concurrency is owned by the reusable.

--- a/test/scripts/compliance-audit/dev-lead-stub-channel-sync.bats
+++ b/test/scripts/compliance-audit/dev-lead-stub-channel-sync.bats
@@ -1,0 +1,185 @@
+#!/usr/bin/env bats
+# Tests for the agent_ref/uses-channel sync check in check_dev_lead_stub()
+# (scripts/compliance-audit.sh).
+#
+# The audit must enforce that agent_ref passes the *same* channel as the uses:
+# pin — not merely any valid channel — to prevent split-brain where the
+# reusable workflow and its own script/prompt checkout run on different releases.
+#
+# The helpers below mirror the extraction and matching logic in the script so
+# the check can be exercised without needing live gh API calls.
+
+bats_require_minimum_version 1.5.0
+
+# ---------------------------------------------------------------------------
+# Pure helpers that mirror the script's logic
+#
+# _extract_uses_channel: pulls the channel name out of the uses: pin line.
+#   Returns the channel string (e.g. "stable", "ring0") on stdout, or empty
+#   string when no matching pin is found.
+#
+# _agent_ref_matches_channel: returns 0 when agent_ref pins exactly $channel.
+# ---------------------------------------------------------------------------
+
+_extract_uses_channel() {
+  local decoded="$1"
+  printf '%s\n' "$decoded" | \
+    sed -nE 's#^[[:space:]]*uses:[[:space:]]*petry-projects/\.github-private/\.github/workflows/dev-lead-reusable\.yml@dev-lead/(stable|next|ring[0-9]+)([[:space:]]|$).*#\1#p'
+}
+
+_agent_ref_matches_channel() {
+  local decoded="$1" channel="$2"
+  printf '%s\n' "$decoded" | grep -qE "^[[:space:]]*agent_ref:[[:space:]]*dev-lead/$channel([[:space:]]|$)"
+}
+
+# ---------------------------------------------------------------------------
+# Channel extraction from uses: pin
+# ---------------------------------------------------------------------------
+
+@test "extracts 'stable' from a stable pin" {
+  decoded="    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable"
+  run _extract_uses_channel "$decoded"
+  [ "$status" -eq 0 ]
+  [ "$output" = "stable" ]
+}
+
+@test "extracts 'next' from a next pin" {
+  decoded="    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/next"
+  run _extract_uses_channel "$decoded"
+  [ "$status" -eq 0 ]
+  [ "$output" = "next" ]
+}
+
+@test "extracts 'ring0' from a ring0 pin" {
+  decoded="    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/ring0"
+  run _extract_uses_channel "$decoded"
+  [ "$status" -eq 0 ]
+  [ "$output" = "ring0" ]
+}
+
+@test "extracts 'ring1' from a ring1 pin" {
+  decoded="    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/ring1"
+  run _extract_uses_channel "$decoded"
+  [ "$status" -eq 0 ]
+  [ "$output" = "ring1" ]
+}
+
+@test "extraction ignores a commented-out uses line" {
+  decoded="    # uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable"
+  run _extract_uses_channel "$decoded"
+  [ "$output" = "" ]
+}
+
+@test "extraction returns empty for a SHA pin (not a channel)" {
+  decoded="    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@376a4fcb1117444595e3e702fa450873d0e54310"
+  run _extract_uses_channel "$decoded"
+  [ "$output" = "" ]
+}
+
+@test "extraction returns empty for a version-tag pin" {
+  decoded="    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@v1.2.3"
+  run _extract_uses_channel "$decoded"
+  [ "$output" = "" ]
+}
+
+# ---------------------------------------------------------------------------
+# agent_ref channel matching — happy path (no split-brain)
+# ---------------------------------------------------------------------------
+
+@test "agent_ref stable matches channel stable" {
+  decoded="      agent_ref: dev-lead/stable"
+  run _agent_ref_matches_channel "$decoded" "stable"
+  [ "$status" -eq 0 ]
+}
+
+@test "agent_ref next matches channel next" {
+  decoded="      agent_ref: dev-lead/next"
+  run _agent_ref_matches_channel "$decoded" "next"
+  [ "$status" -eq 0 ]
+}
+
+@test "agent_ref ring0 matches channel ring0" {
+  decoded="      agent_ref: dev-lead/ring0"
+  run _agent_ref_matches_channel "$decoded" "ring0"
+  [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Split-brain detection — uses: and agent_ref on different channels
+# ---------------------------------------------------------------------------
+
+@test "agent_ref stable does NOT match channel ring0 (split-brain)" {
+  decoded="      agent_ref: dev-lead/stable"
+  run _agent_ref_matches_channel "$decoded" "ring0"
+  [ "$status" -ne 0 ]
+}
+
+@test "agent_ref next does NOT match channel stable (split-brain)" {
+  decoded="      agent_ref: dev-lead/next"
+  run _agent_ref_matches_channel "$decoded" "stable"
+  [ "$status" -ne 0 ]
+}
+
+@test "agent_ref ring0 does NOT match channel ring1 (split-brain)" {
+  decoded="      agent_ref: dev-lead/ring0"
+  run _agent_ref_matches_channel "$decoded" "ring1"
+  [ "$status" -ne 0 ]
+}
+
+@test "agent_ref ring1 does NOT match channel ring0 (split-brain)" {
+  decoded="      agent_ref: dev-lead/ring1"
+  run _agent_ref_matches_channel "$decoded" "ring0"
+  [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Extraction from a full multi-line YAML stub (realistic fixture)
+# ---------------------------------------------------------------------------
+
+@test "extracts channel from multi-line YAML with uses: at the right indent level" {
+  decoded=$(cat <<'EOF'
+on:
+  push:
+    branches: [main]
+jobs:
+  dev-lead:
+    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/ring0
+    with:
+      agent_ref: dev-lead/ring0
+    secrets: inherit
+EOF
+)
+  run _extract_uses_channel "$decoded"
+  [ "$status" -eq 0 ]
+  [ "$output" = "ring0" ]
+}
+
+@test "matching agent_ref in a full stub passes when channels agree" {
+  decoded=$(cat <<'EOF'
+jobs:
+  dev-lead:
+    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/ring0
+    with:
+      agent_ref: dev-lead/ring0
+EOF
+)
+  channel=$(_extract_uses_channel "$decoded")
+  [ "$channel" = "ring0" ]
+  run _agent_ref_matches_channel "$decoded" "$channel"
+  [ "$status" -eq 0 ]
+}
+
+@test "mismatched agent_ref in a full stub fails when channels differ" {
+  decoded=$(cat <<'EOF'
+jobs:
+  dev-lead:
+    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/ring0
+    with:
+      agent_ref: dev-lead/stable
+EOF
+)
+  channel=$(_extract_uses_channel "$decoded")
+  [ "$channel" = "ring0" ]
+  run _agent_ref_matches_channel "$decoded" "$channel"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Part of the staged canary rollout of dev-lead **v1.4.0** (the #781 release + accumulated main), per [versioning.md](https://github.com/petry-projects/.github-private/blob/main/docs/release/versioning.md) Phase 2 (#499/#500).

**Two changes:**
1. **`.github/workflows/dev-lead.yml`** — pin the dev-lead caller to the new **`dev-lead/ring0`** channel (+ `agent_ref: dev-lead/ring0`). This repo previously pinned `@main` (bleeding edge); ring0 gives it a controlled canary slot advanced/rolled-back by a central tag move.
2. **`scripts/compliance-audit.sh`** (`check_dev_lead_stub`) — accept the staged-canary channels `dev-lead/{stable,next,ring<N>}` for the `uses:` pin and `agent_ref`, not just `stable`. Still rejects `@main` and frozen `@vX.Y.Z`/`@<sha>`. Required so ring-pinned consumers (TalkTerm→`ring1`) don't trip `dev-lead-stub-pin`.

**Ring plan** (all channels cut at `dev-lead/v1.4.0`; `stable` untouched): .github-private→`next` · **.github→`ring0`** · TalkTerm→`ring1` · everyone else→`stable`.

Companion PRs: petry-projects/.github-private#856 (next), petry-projects/TalkTerm#306 (ring1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for compliance validation rules.

* **Chores**
  * Updated development infrastructure configurations and validation scripts to support flexible channel-based versioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->