### PR TITLE
docs(ci-standards): correct stale 'ring model is the next phase' note

### DIFF
--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -122,11 +122,18 @@ zero external blast radius. This is also what breaks the self-host circular
 dependency — production callers keep running `stable` while the new version is
 exercised on `next`, so a broken candidate can never gate its own fix.
 
-> **Rollout status.** The `stable` channel and single-hop manual promotion are in
-> place today (Phase 1). The `next`/`ring`_n_ channels and automated,
-> soak-gated ring-by-ring promotion are the next phase — the model above is the
-> target the `stable` foundation is built for. A reusable with only `stable`
-> defined today promotes in one gated hop until its ring channels exist.
+> **Rollout status.** The full ring model — `next`/`ring`_n_/`stable` channels,
+> immutable `<agent>/vX.Y.Z` releases, and promotion by a central tag move — is
+> **implemented and in production** for the `.github-private` agents (`dev-lead`,
+> `pr-review`), managed by `scripts/cut-release.sh` and `docs/release/` in that
+> repo (the canary/ring versioning initiative, epic #495). The authoritative
+> process lives there; this section summarizes it.
+>
+> `.github`-hosted reusables (e.g. `feature-ideation` and the Tier‑1 caller
+> reusables) are being brought under the same model — `cut-release.sh` is being
+> extended to cover them. Until a given reusable has its ring channels cut it may
+> run on `stable` alone and promote in one gated hop, but that is an interim
+> state, not the target: `stable`-only is not a substitute for the ring ladder.
 
 **Migration.** This is the target for all reusable workflows; they adopt it
 incrementally. A reusable that has not yet published a `stable` channel keeps its

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -129,9 +129,9 @@ exercised on `next`, so a broken candidate can never gate its own fix.
 > repo (the canary/ring versioning initiative, epic #495). The authoritative
 > process lives there; this section summarizes it.
 >
-> `.github`-hosted reusables (e.g. `feature-ideation` and the Tier‑1 caller
+> `.github`-hosted reusables (e.g. `feature-ideation` and the Tier-1 caller
 > reusables) are being brought under the same model — `cut-release.sh` is being
-> extended to cover them. Until a given reusable has its ring channels cut it may
+> extended to cover them. Until a given reusable has its ring channels cut, it may
 > run on `stable` alone and promote in one gated hop, but that is an interim
 > state, not the target: `stable`-only is not a substitute for the ring ladder.
 


### PR DESCRIPTION
## Summary

`standards/ci-standards.md` → "Reusable workflow versioning" claimed the `next`/`ring`_n_ channels and soak-gated ring promotion were *"the next phase"* / not yet built. **They're implemented and in production** for the `.github-private` agents (`dev-lead` runs `next/ring0/ring1/stable` with releases v1.0.0→v1.4.0; `pr-review` through v1.8.0), managed by `scripts/cut-release.sh` + `docs/release/` (epic #495).

This corrects the Rollout-status note to:
- state the ring model is **live** and point at `.github-private/docs/release/{versioning,runbook}.md` + `agentic-release-strategy.md` as the authoritative process;
- note `.github`-hosted reusables (feature-ideation + the Tier-1 caller reusables) are being brought under the same model (`cut-release.sh` extension);
- mark `stable`-only as an explicit **interim**, not the target.

## Why

Surfaced via discussion `.github-private#866` + the #482 review: I (and anyone reading ci-standards) had treated rings as unbuilt and did the #482 reusable migration single-hop to `stable` only. The doc was the stale source. Reconciling the #482 reusables under the ring model is tracked in `.github-private#870`.

Refs `.github-private#870`, `.github-private#866`, #482.

🤖 Generated with [Claude Code](https://claude.com/claude-code)