### PR TITLE
docs(standards): formalize agent canary-ring/soak/promotion model + ADR (#869)

### DIFF
--- a/docs/initiatives/agent-canary-rings-adr.md
+++ b/docs/initiatives/agent-canary-rings-adr.md
@@ -1,0 +1,56 @@
+# ADR: Agent releases roll out via host-relative canary rings with a health-gated promotion
+
+- **Status:** Accepted (dev-lead pathfinder in production, 2026-06)
+- **Initiative:** Safe Release Strategy for Agentic Workflows (epic petry-projects/.github-private#495)
+- **Supersedes:** the "deploy by rewriting every consumer's `main` at once" model.
+
+## Context
+
+The org's reusable agent workflows (`dev-lead`, `pr-review`, …) are *self-hosting*:
+the agent that validates and fixes PRs is itself shipped by a reusable workflow in
+`petry-projects/.github-private`. Deploying a new version by clobbering all consumers'
+files at once meant a bad version could break its own fix pipeline (the circular
+dependency) with org-wide blast radius and no staged validation or fast rollback.
+
+We need releases that (a) never touch caller repos, (b) validate a candidate on a
+small blast radius before the fleet runs it, (c) keep production self-review duty on a
+known-good version while the candidate soaks, and (d) roll back in one move.
+
+## Decision
+
+1. **Versioning = immutable releases + moving channel tags.** Cut `<agent>/vX.Y.Z`
+   once (immutable, the rollback target); callers pin a **moving channel tag**
+   `<agent>/<channel>` exactly once and are never edited again. Promotion/rollback is
+   a central tag move. Channel pins are an accepted exception to the SHA-pin policy
+   (first-party refs we own) and are protected by the `release-channel-tags` ruleset.
+
+2. **Host-relative concentric rings.** Channels, innermost-first:
+   `next` (the repo that *hosts* the reusable — dogfood) → `ring0` (the other
+   org-infra repo) → `ring1` (named low-traffic consumers) → `stable` (everyone else).
+   `next` + `ring0` always span `.github` + `.github-private`, partitioned by host.
+   Production self-review duty stays on `stable` even within ring 0, breaking the
+   circular dependency. Membership is declared in `standards/canary-rings.json`.
+
+3. **Automated, health-gated promotion (one ring at a time).** A read-only `evaluate`
+   runs every 4h and reports each ring's gate state; a dispatch-gated `promote`
+   advances the next ring only when the rings already on the candidate pass the
+   **soak gate**: volume `healthy_runs ≥ ceil(baseline_runs / 7)` **and** candidate
+   failure-rate `≤` baseline. **No synthetic floor** — an unused reusable parks at
+   the frontier until real volume accrues. A confirmed regression resets the rollout
+   (all ring channels roll back to last known-good); a pre-existing failure is logged
+   and does not block. Implemented in `scripts/canary-rollout.sh` (+ pure, unit-tested
+   decision core) and `.github/workflows/canary-rollout.yml`.
+
+## Consequences
+
+- **Zero caller churn; bounded blast radius; <5-min rollback** (one tag move).
+- The promotion workflow is the authorized tag mover (via `GH_PAT_WORKFLOWS` today;
+  a dedicated GitHub App scopes the ruleset bypass later).
+- New cost: the membership SoT and gate thresholds must be maintained; an unused
+  reusable never auto-promotes (acceptable — its version doesn't matter until used).
+- `dev-lead` is the pathfinder (shipped `v1.4.0` this way); `pr-review` and other
+  reusables adopt the same model incrementally (#499/#616/#688).
+
+The authoritative operational detail lives in
+[`docs/release/versioning.md` + `runbook.md`](https://github.com/petry-projects/.github-private/tree/main/docs/release)
+in the host repo; this ADR records the decision and its rationale.

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -97,12 +97,20 @@ blast radius to the whole fleet. A release is promoted **one ring at a time**,
 advancing to the next ring only after it has run healthy in the inner ring for a
 defined **soak window**:
 
-| Ring | Channel | Blast radius | Pinned by |
+| Ring | Channel | Members (host-relative) | Blast radius |
 |---|---|---|---|
-| 0 — canary | `<name>/next` | The reusable's **own self-host** duty (dogfood) | the host repo itself |
-| 1 | `<name>/ring1` | One low-traffic consumer | that consumer |
-| _n_ | `<name>/ring`_n_ | Progressively more consumers | those consumers |
-| Production | `<name>/stable` | The whole fleet | everyone else |
+| canary | `<name>/next` | the repo that **hosts** the reusable (dogfood at the source) | the host's own self-host duty |
+| 0 | `<name>/ring0` | the **other** org-infra repo (`.github` + `.github-private`, partitioned by host) | org infrastructure |
+| 1 | `<name>/ring1` | named low-traffic consumers | a couple of real consumers |
+| _n_ | `<name>/ring`_n_ | progressively more consumers | widening fleet |
+| Production | `<name>/stable` | everyone else | the whole fleet |
+
+`next` is **host-relative**: it resolves to whichever org-infra repo owns the reusable,
+and `ring0` is the other — so `next` + `ring0` always span `.github` + `.github-private`.
+For `dev-lead` (hosted in `.github-private`): `next` = `.github-private`, `ring0` = `.github`,
+`ring1` = `{TalkTerm, bmad-bgreat-suite}`, `stable` = the rest. The machine-readable source
+of truth is [`standards/canary-rings.json`](https://github.com/petry-projects/.github-private/blob/main/standards/canary-rings.json)
+in the host repo, consumed by the promotion automation.
 
 How it works:
 
@@ -122,18 +130,30 @@ zero external blast radius. This is also what breaks the self-host circular
 dependency — production callers keep running `stable` while the new version is
 exercised on `next`, so a broken candidate can never gate its own fix.
 
-> **Rollout status.** The full ring model — `next`/`ring`_n_/`stable` channels,
-> immutable `<agent>/vX.Y.Z` releases, and promotion by a central tag move — is
-> **implemented and in production** for the `.github-private` agents (`dev-lead`,
-> `pr-review`), managed by `scripts/cut-release.sh` and `docs/release/` in that
-> repo (the canary/ring versioning initiative, epic #495). The authoritative
-> process lives there; this section summarizes it.
+> **Rollout status.** The full ring model — host-relative `next`/`ring`_n_/`stable`
+> channels, immutable `<agent>/vX.Y.Z` releases, and promotion by a central tag move
+> — is **implemented and in production** for `dev-lead` (the pathfinder; `v1.4.0`
+> rolled out canary → rings → `stable` and verified). It is managed in
+> `petry-projects/.github-private` (the canary/ring versioning initiative, epic #495):
 >
-> `.github`-hosted reusables (e.g. `feature-ideation` and the Tier-1 caller
-> reusables) are being brought under the same model — `cut-release.sh` is being
-> extended to cover them. Until a given reusable has its ring channels cut, it may
-> run on `stable` alone and promote in one gated hop, but that is an interim
-> state, not the target: `stable`-only is not a substitute for the ring ladder.
+> - `scripts/cut-release.sh` cuts immutable releases.
+> - `standards/canary-rings.json` is the ring-membership source of truth.
+> - `scripts/canary-rollout.sh` + `.github/workflows/canary-rollout.yml` run the
+>   **automated, health-gated promotion**: a read-only `evaluate` every 4h reports
+>   each ring's gate state, and a dispatch-gated `promote` advances **one ring at a
+>   time** only when the rings already on the candidate pass the **soak gate** —
+>   volume `healthy_runs ≥ ceil(baseline_runs / 7)` **and** candidate failure-rate
+>   `≤` baseline (no synthetic floor; an unused reusable simply parks). Rollback is
+>   the same single tag move in reverse against the prior `vX.Y.Z`.
+> - The channel tags are protected by the `release-channel-tags` ruleset, codified in
+>   `.github/rulesets/` and applied by `scripts/apply-rulesets.sh`; the promotion
+>   workflow is the authorized mover.
+>
+> The authoritative process lives in that repo's `docs/release/` (`versioning.md`,
+> `runbook.md`); this section summarizes it. `pr-review` and the `.github`-hosted
+> reusables (e.g. `feature-ideation`) are being brought under the same model next
+> (#499/#616/#688). Until a given reusable has its ring channels cut, it may run on
+> `stable` alone and promote in one gated hop — an interim state, not the target.
 
 **Migration.** This is the target for all reusable workflows; they adopt it
 incrementally. A reusable that has not yet published a `stable` channel keeps its

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -145,9 +145,8 @@ exercised on `next`, so a broken candidate can never gate its own fix.
 >   volume `healthy_runs ≥ ceil(baseline_runs / 7)` **and** candidate failure-rate
 >   `≤` baseline (no synthetic floor; an unused reusable simply parks). Rollback is
 >   the same single tag move in reverse against the prior `vX.Y.Z`.
-> - The channel tags are protected by the `release-channel-tags` ruleset, codified in
->   `.github/rulesets/` and applied by `scripts/apply-rulesets.sh`; the promotion
->   workflow is the authorized mover.
+> - The channel tags are protected by a `release-channel-tags` ruleset in the host repo
+>   (`.github-private`); the promotion workflow is the authorized mover.
 >
 > The authoritative process lives in that repo's `docs/release/` (`versioning.md`,
 > `runbook.md`); this section summarizes it. `pr-review` and the `.github`-hosted

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -125,7 +125,7 @@ How it works:
   rings never receive the bad version.
 - **Bounded blast radius + fast rollback.** A regression that slips past an inner ring is contained to that ring and rolled back with one tag move, long before it could reach `stable`.
 
-Ring 0 is the reusable's **own self-host**: it dogfoods every release first, at
+The canary ring (`next`) is the reusable's **own self-host**: it dogfoods every release first, at
 zero external blast radius. This is also what breaks the self-host circular
 dependency — production callers keep running `stable` while the new version is
 exercised on `next`, so a broken candidate can never gate its own fix.


### PR DESCRIPTION
**Draft** until the host-repo implementation PRs land — this standard references them.

Promotes `ci-standards.md` from the aspirational / manual (`cut-release.sh`-only) description to the **automated, health-gated** model now shipped for `dev-lead` v1.4.0:

- **Ring table** → canonical **host-relative** membership: `next`=host, `ring0`=other org-infra repo, `ring1`=named low-traffic consumers, `stable`=rest. Links `canary-rings.json` as the SoT.
- **Rollout status** → the built automation: `canary-rollout.sh` + 4h `evaluate` / dispatch-gated `promote`, the concrete **soak gate** (`healthy ≥ ceil(baseline/7)` AND `failure-rate ≤ baseline`, no floor), rollback, and the codified `release-channel-tags` ruleset.
- **New ADR** `docs/initiatives/agent-canary-rings-adr.md` — records the decision + rationale.

**Blocking PRs** (host repo `petry-projects/.github-private`): #878 (canary-rollout automation), #889 (ruleset codify), #880 (SHA-pin guardrail). Mark ready once those merge.

Closes #869. Refs #495, #499, #500, #501, #502, #868.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new ADR outlining health-gated canary ring rollouts for agent releases, including one-ring-at-a-time promotion, rollback behavior, and host-relative ring membership semantics.
  * Updated CI standards to clarify ring/channel mapping, redefine ring membership and blast radius framing, expand rollout status details, and point to the machine-readable source of truth used by promotion automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->