### PR TITLE
feat(standards): per-repo initiative-driver caller stub (#884)

### DIFF
--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -1047,6 +1047,7 @@ channel:
 | [`initiative-planner.yml`](workflows/initiative-planner.yml) | [`initiative-planner-reusable.yml`](../.github/workflows/initiative-planner-reusable.yml) | `discussion [labeled] idea:approved` (trusted actor) → central planner builds an **inert** epic + story DAG (`initiative`, **not** `initiative:auto`) in the host repo |
 | [`idea-triage.yml`](workflows/idea-triage.yml) | [`idea-triage-reusable.yml`](../.github/workflows/idea-triage-reusable.yml) | weekly + dispatch → refresh the host repo's "Idea Promotion Queue" issue |
 | [`idea-enhancer.yml`](workflows/idea-enhancer.yml) | [`idea-enhancer-reusable.yml`](../.github/workflows/idea-enhancer-reusable.yml) | new Ideas Discussion + weekly → enrich the host repo's un-enhanced ideas |
+| [`initiative-driver.yml`](workflows/initiative-driver.yml) | _(none — direct `gh workflow run`)_ | `issues [closed, labeled] initiative:auto` + off-peak `schedule` → dispatches the central `initiative-driver` with `target_repo=<host>`; the central driver releases ready sub-issues of the host's `initiative:auto` epics to dev-lead |
 
 Two human gates keep judgement with a maintainer: adding `idea:approved` to a
 Discussion fires the planner; adding `initiative:auto` to the resulting epic

--- a/standards/workflows/initiative-driver.yml
+++ b/standards/workflows/initiative-driver.yml
@@ -47,15 +47,17 @@ on:
     types: [closed, labeled]
   schedule:
     - cron: "41 3 * * *" # off-peak safety net for missed close events
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  # One lane per repo so a close burst + the schedule cannot fan out duplicate
-  # dispatches. cancel-in-progress=false so queued dispatches are not dropped.
+  # One lane per repo so a close burst + the schedule does not fan out duplicate
+  # dispatches. cancel-in-progress=true cancels any pending/running redundant dispatches
+  # since the central driver sweeps all epics anyway.
   group: initiative-driver-dispatch-${{ github.repository }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   dispatch:

--- a/standards/workflows/initiative-driver.yml
+++ b/standards/workflows/initiative-driver.yml
@@ -1,0 +1,87 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/initiative-driver.yml
+# Standard:        petry-projects/.github/standards/ci-standards.md
+# Central driver:  petry-projects/.github-private/.github/workflows/initiative-driver.yml
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. All dependency-aware release logic (the
+#     `initiative:auto` gate, the DAG / `blocked_by` resolution, max-in-flight,
+#     and the dev-lead label hand-off) lives in the CENTRAL driver above. This
+#     stub only DISPATCHES that central workflow with this repo as target_repo.
+#   • Unlike the initiative-planner stub there is NO reusable: the central driver
+#     is pure-bash (no claude-code-action), so this stub dispatches the central
+#     workflow_dispatch DIRECTLY with `gh workflow run`. No LLM runs here.
+#   • You MUST NOT change: the dispatch target
+#     (-R petry-projects/.github-private -f target_repo=${{ github.repository }}),
+#     the `initiative:auto` label filter, or the PAT guard.
+#   • If you need different release behaviour, open a PR against the central
+#     driver in petry-projects/.github-private — never by editing callers.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Initiative Driver — per-repo dispatcher, thin caller for the central driver.
+#
+# On this repo's issues:[closed, labeled] (plus a safety-net off-peak schedule),
+# this stub dispatches the CENTRAL initiative-driver in
+# petry-projects/.github-private with target_repo=<this repo>. The central
+# driver then sweeps this repo's `initiative:auto` epics and releases their ready
+# sub-issues to dev-lead — so the central driver does not have to watch every
+# enrolled repo's events.
+#
+# To adopt:
+#   1. Copy this file verbatim to .github/workflows/initiative-driver.yml in your repo.
+#   2. Ensure the `initiative:auto` label exists on the repo.
+#   3. Confirm the org-level secret GH_PAT_WORKFLOWS is accessible **and its
+#      owner has write access to petry-projects/.github-private** (to dispatch
+#      the central workflow) **and to this repo** (the central driver applies the
+#      `dev-lead` label cross-repo with that PAT; a label applied with
+#      GITHUB_TOKEN would not trigger dev-lead).
+#
+# Standard: https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md
+name: Initiative Driver — Dispatch Central
+
+on:
+  issues:
+    # closed:  a close may unblock successors — re-evaluate this repo's DAG.
+    # labeled: arming an epic with `initiative:auto` starts it immediately
+    #          (the job below filters to that label).
+    types: [closed, labeled]
+  schedule:
+    - cron: "41 3 * * *" # off-peak safety net for missed close events
+
+permissions:
+  contents: read
+
+concurrency:
+  # One lane per repo so a close burst + the schedule cannot fan out duplicate
+  # dispatches. cancel-in-progress=false so queued dispatches are not dropped.
+  group: initiative-driver-dispatch-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    # On a `labeled` event, only dispatch when the added label is the gate label
+    # (mirror the central driver) — otherwise every label change fans out a dispatch.
+    if: >-
+      github.event_name != 'issues' ||
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'initiative:auto'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Guard — PAT present
+        # PAT required: a workflow_dispatch fired with GITHUB_TOKEN never starts a run.
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::GH_PAT_WORKFLOWS is required — a workflow_dispatch fired with GITHUB_TOKEN never starts a run."
+            exit 1
+          fi
+
+      - name: Dispatch central initiative-driver
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
+        run: |
+          gh workflow run initiative-driver.yml \
+            -R petry-projects/.github-private \
+            -f target_repo=${{ github.repository }}


### PR DESCRIPTION
## Summary
Applies the cross-repo deliverable of **`petry-projects/.github-private#884`** (Phase 2 of the driver fleet-enablement epic **#882**). dev-lead correctly flagged #884 as `hands-off` — all its ACs target this **public** repo, which dev-lead (running in `.github-private`) can't write — and produced a verified spec; this PR applies it.

- **`standards/workflows/initiative-driver.yml`** — thin caller stub. Unlike the planner stub there is **no reusable**: the central driver is pure-bash (no `claude-code-action`), so the stub dispatches the central `workflow_dispatch` **directly** via `gh workflow run -R petry-projects/.github-private -f target_repo=<host>`. It mirrors the central driver's `initiative:auto` label filter and keeps the PAT guard (a `workflow_dispatch` fired with `GITHUB_TOKEN` never starts a run).
- **`ci-standards.md` §10** — adds the `initiative-driver` row (Reusable = _none — direct dispatch_).

## Effect
On an enrolled repo's `issues: [closed, labeled] initiative:auto` (+ off-peak schedule), this dispatches the central driver for that repo, which releases ready sub-issues of its `initiative:auto` epics to dev-lead — closing the manual-release gap the `.github` pilot exposed. Adoptable template (not force-deployed), like the other idea-pipeline stubs.

Unblocks **#886** (Fleet Monitor coverage) + **#887** (docs). Refs **#882**, **#817**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)