### PR TITLE
fix(auto-rebase): source predicate from reusable's own commit, not @v1 (restores review-ready gate)

### DIFF
--- a/.github/scripts/auto-rebase/README.md
+++ b/.github/scripts/auto-rebase/README.md
@@ -5,8 +5,11 @@ Supporting logic for the org-level **auto-rebase** reusable workflow
 lives here so it can be unit-tested with bats
 (`test/workflows/auto-rebase/`) instead of being trapped inline in YAML.
 
-The reusable workflow checks this repo out at `inputs.tooling_ref` (default
-`v1`) and sources `lib/eligibility.sh` to decide which behind PRs to update.
+The reusable workflow checks this repo out at `inputs.tooling_ref` and sources
+`lib/eligibility.sh` to decide which behind PRs to update. `tooling_ref`
+defaults to empty, which resolves to the reusable's own commit
+(`github.job_workflow_sha`) so the predicate always matches the pinned
+workflow version. Set `tooling_ref` only to test a branch end-to-end.
 
 ## `lib/eligibility.sh`
 

--- a/.github/scripts/auto-rebase/README.md
+++ b/.github/scripts/auto-rebase/README.md
@@ -6,7 +6,7 @@ lives here so it can be unit-tested with bats
 (`test/workflows/auto-rebase/`) instead of being trapped inline in YAML.
 
 The reusable workflow checks this repo out at `inputs.tooling_ref` and sources
-`lib/eligibility.sh` to decide which behind PRs to update. `tooling_ref`
+`lib/eligibility.sh` to decide which out-of-date PRs to update. `tooling_ref`
 defaults to empty, which resolves to the reusable's own commit
 (`github.job_workflow_sha`) so the predicate always matches the pinned
 workflow version. Set `tooling_ref` only to test a branch end-to-end.

--- a/.github/workflows/auto-rebase-reusable.yml
+++ b/.github/workflows/auto-rebase-reusable.yml
@@ -65,11 +65,15 @@ on:
       tooling_ref:
         description: |
           Ref of petry-projects/.github to source the auto-rebase scripts from.
-          Defaults to `v1` to match the @v1 pin used by caller stubs. Override
-          only to test a fork/PR branch (`tooling_ref: my-branch`) or main
-          (`tooling_ref: main`) end-to-end.
+          Leave empty (the default) to source them from THIS reusable's own
+          commit (`github.job_workflow_sha`) — that guarantees the predicate in
+          lib/eligibility.sh always matches the version of this workflow the
+          caller pinned, with no skew. (Previously defaulted to `v1`, which
+          predates eligibility.sh and made every run fail with "No such file
+          or directory" — see issue #465.) Override only to test a fork/PR
+          branch (`tooling_ref: my-branch`) end-to-end.
         required: false
-        default: 'v1'
+        default: ''
         type: string
     secrets:
       GH_PAT_WORKFLOWS:
@@ -87,7 +91,11 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: petry-projects/.github
-          ref: ${{ inputs.tooling_ref }}
+          # Source the scripts from this reusable's own commit so the predicate
+          # always matches the pinned workflow version. `job_workflow_sha` is the
+          # commit SHA of THIS reusable file for the run; `tooling_ref` overrides
+          # it only for end-to-end testing of a branch.
+          ref: ${{ inputs.tooling_ref || github.job_workflow_sha }}
           path: .auto-rebase-tooling
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,8 @@ jobs:
           chmod +x actionlint
           rm actionlint.tar.gz
           # Lint our own workflow files (fail on errors, ignore shellcheck style hints)
-          ./actionlint -ignore 'SC2129' .github/workflows/*.yml
+          # `job_workflow_sha` is a valid reusable-workflow context property; actionlint 1.7.7 schema omits it
+          ./actionlint -ignore 'SC2129' -ignore '"job_workflow_sha" is not defined' .github/workflows/*.yml
           # Template workflows use placeholder expressions — informational only
           ./actionlint -ignore 'context' standards/workflows/*.yml || true
 


### PR DESCRIPTION
## Problem

The auto-rebase review-ready gate (#465 / #468) is live **nowhere** — and #468 introduced a **regression** in `petry-projects/.github` itself.

The reusable defaulted `tooling_ref` to `v1` and checked out `petry-projects/.github@v1` to source `lib/eligibility.sh`. But `eligibility.sh` only landed in #468, *after* the `v1` tag (d3d768da, 2026-05-13). So every run fails:

```
.auto-rebase-tooling/.github/scripts/auto-rebase/lib/eligibility.sh: No such file or directory
##[error]Process completed with exit code 1.
```

**Evidence:** `petry-projects/.github`'s own auto-rebase is failing **5/5 recent runs** (e.g. run 28103191068) while it has 8 open non-Dependabot PRs to act on. The 7 consumer repos still pin the pre-#468 reusable (`v1`/`v2`/`@auto-rebase/stable`/SHA), so they run the **original unrestricted fan-out** (verified: `.github-private` PR#744 — no approval, no `auto-rebase:ready` label — still auto-updated on the 3 most recent runs).

## Fix

- Default `tooling_ref` to empty and resolve the tooling checkout to `${{ inputs.tooling_ref || github.job_workflow_sha }}` — the commit SHA of **this reusable file** for the run.
- The predicate (`lib/eligibility.sh`) is now always sourced from the **exact same commit** as the workflow version the caller pinned → no skew, ever.
- `tooling_ref` stays as an explicit override for end-to-end branch testing.
- README updated to match.

## Why `job_workflow_sha`

A separately-pinned `tooling_ref` can drift from the reusable version (too old → missing file; too new → predicate/workflow mismatch). `github.job_workflow_sha` binds tooling to the reusable's own commit, so a consumer pinning `@auto-rebase/stable` gets the predicate from whatever commit `stable` points at — automatically consistent.

## Rollout (after this merges)

1. **This PR** fixes `petry-projects/.github`'s own auto-rebase immediately on merge.
2. Move the `auto-rebase/stable` channel tag to this commit → deploys the review-ready gate to the 5 on-channel repos (TalkTerm, broodly, google-app-scripts, bmad-bgreat-suite, markets).
3. Caller-bump PRs return the 2 drifted repos (`ContentTwin` @SHA, `.github-private` @v2) to `@auto-rebase/stable`.

## Note (out of scope)

`feature-ideation-reusable.yml` carries the **same `tooling_ref: v1` default pattern** — likely the same latent bug. Flagged for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the auto-rebase workflow to use the reusable workflow’s pinned commit when no tooling version is provided, keeping execution consistent with the intended workflow version.
* **Documentation**
  * Clarified in the reusable workflow documentation how the tooling version default behaves, and when to set it for branch end-to-end testing.
* **Chores**
  * Adjusted CI GitHub Actions linting to ignore the additional reusable-workflow context warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->