### PR TITLE
feat(audit): make centralized-stub check ring-aware (#870)

### DIFF
--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -1057,6 +1057,7 @@ ring_tier_for_repo() {
     TalkTerm | bmad-bgreat-suite) printf 'ring1' ;;
     *)                          printf 'stable' ;;
   esac
+  return 0
 }
 
 check_centralized_workflow_stubs() {

--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -1042,6 +1042,23 @@ stub_pin_acceptable() {
   printf '%s\n' "$decoded" | grep -qE "^[[:space:]]*uses:[[:space:]]*${expected}([[:space:]]|$)"
 }
 
+# ring_tier_for_repo <repo>
+# Map a repo to its canary-ring tier for the #482 reusables (epic #495 topology):
+#   next   — .github-private  (candidate / first soak)
+#   ring0  — .github          (dogfood; but .github self-hosts via @main and is
+#                              skipped by the stub check, so this is informational)
+#   ring1  — TalkTerm, bmad-bgreat-suite  (early fleet canary)
+#   stable — everything else  (broad fleet)
+# Keep in sync with docs/release/ring topology and cut-release.sh channels.
+ring_tier_for_repo() {
+  case "$1" in
+    .github-private)            printf 'next' ;;
+    .github)                    printf 'ring0' ;;
+    TalkTerm | bmad-bgreat-suite) printf 'ring1' ;;
+    *)                          printf 'stable' ;;
+  esac
+}
+
 check_centralized_workflow_stubs() {
   local repo="$1"
 
@@ -1050,23 +1067,27 @@ check_centralized_workflow_stubs() {
   [ "$repo" = ".github" ] && return
 
   # workflow-filename:reusable-basename:canonical-pin:legacy-accepted-csv
-  #   canonical-pin       — the org-standard ref a stub should pin (the moving
-  #                         <name>/stable channel for migrated reusables).
-  #   legacy-accepted-csv — comma-separated refs still accepted *during the
-  #                         channel migration* so the audit neither flags nor
-  #                         reverts a stub still on its old @vN pin (#482). Empty
-  #                         once the fleet is fully migrated (then drop the grace).
+  #   canonical-pin       — the org-standard ref a stub should pin. The sentinel
+  #                         `RING` means "this reusable is on the canary-ring
+  #                         model": the expected channel is the repo's RING TIER
+  #                         (next/ring0/ring1/stable — see ring_tier_for_repo),
+  #                         e.g. `agent-shield/ring1` on a ring1 repo. Any other
+  #                         value is a fixed pin (e.g. feature-ideation → v1).
+  #   legacy-accepted-csv — additional refs still accepted *during* migration so
+  #                         the audit neither flags nor reverts a stub mid-move.
+  #                         For RING reusables the per-repo legacy set (the
+  #                         `<name>/stable` channel + v1,v2) is computed below.
   # NOTE: dev-lead.yml is intentionally NOT listed here — its reusable lives in
   # the private petry-projects/.github-private repo and is pinned to the
   # dev-lead/stable channel, validated by check_dev_lead_stub() below.
   local centralized=(
-    "auto-rebase.yml:auto-rebase-reusable:auto-rebase/stable:v1,v2"
-    "dependency-audit.yml:dependency-audit-reusable:dependency-audit/stable:v1,v2"
-    "dependabot-automerge.yml:dependabot-automerge-reusable:dependabot-automerge/stable:v1,v2"
-    "dependabot-rebase.yml:dependabot-rebase-reusable:dependabot-rebase/stable:v1,v2"
-    "agent-shield.yml:agent-shield-reusable:agent-shield/stable:v1,v2"
+    "auto-rebase.yml:auto-rebase-reusable:RING"
+    "dependency-audit.yml:dependency-audit-reusable:RING"
+    "dependabot-automerge.yml:dependabot-automerge-reusable:RING"
+    "dependabot-rebase.yml:dependabot-rebase-reusable:RING"
+    "agent-shield.yml:agent-shield-reusable:RING"
     "feature-ideation.yml:feature-ideation-reusable:v1:"
-    "pr-review-mention.yml:pr-review-mention-reusable:pr-review-mention/stable:v1,v2"
+    "pr-review-mention.yml:pr-review-mention-reusable:RING"
   )
 
   # List the repo's workflow directory once instead of probing each file.
@@ -1079,6 +1100,22 @@ check_centralized_workflow_stubs() {
   for entry in "${centralized[@]}"; do
     IFS=':' read -r wf reusable canonical legacy <<< "$entry"
     [ -z "$canonical" ] && { echo "::error::centralized entry '$entry' missing canonical pin — expected format 'wf:reusable:canonical:legacy-csv'" >&2; exit 1; }
+
+    # RING sentinel: this reusable is on the canary-ring model. The canonical
+    # ref is the channel for THIS repo's ring tier (next/ring0/ring1/stable),
+    # and the per-repo legacy grace accepts the `<name>/stable` channel plus the
+    # pre-ring @v1/@v2 pins so the audit neither flags nor reverts a stub while
+    # the fleet migrates onto the rings (#870, same revert-collision lesson as
+    # #482). Higher tiers are also acceptable so a repo pinned ahead of its tier
+    # (e.g. a ring1 repo still on /stable, or .github-private's /next promoted to
+    # /stable) is never flagged — only @main / inline / off-channel pins are.
+    if [ "$canonical" = "RING" ]; then
+      local chan tier
+      chan="${reusable%-reusable}"
+      tier="$(ring_tier_for_repo "$repo")"
+      canonical="${chan}/${tier}"
+      legacy="${chan}/next,${chan}/ring0,${chan}/ring1,${chan}/stable,v1,v2"
+    fi
 
     # Skip workflows that don't exist in this repo. Required workflows are
     # checked separately by check_required_workflows; conditional ones

--- a/test/scripts/compliance-audit/centralized-stub-pins.bats
+++ b/test/scripts/compliance-audit/centralized-stub-pins.bats
@@ -62,3 +62,35 @@ R="petry-projects/.github/.github/workflows/agent-shield-reusable.yml"
   accept "    uses: $R@v2" "v1" ""
   [ "$status" -ne 0 ]
 }
+
+# ---------------------------------------------------------------------------
+# ring_tier_for_repo() — maps a repo to its canary-ring tier (epic #495).
+# ---------------------------------------------------------------------------
+tier() {
+  run bash -c 'source "$1" >/dev/null 2>&1; ring_tier_for_repo "$2"' _ "$SCRIPT" "$1"
+}
+
+@test "ring tier: .github-private is next" {
+  tier ".github-private"
+  [ "$status" -eq 0 ]
+  [ "$output" = "next" ]
+}
+
+@test "ring tier: .github is ring0 (dogfood)" {
+  tier ".github"
+  [ "$output" = "ring0" ]
+}
+
+@test "ring tier: TalkTerm and bmad-bgreat-suite are ring1" {
+  tier "TalkTerm"
+  [ "$output" = "ring1" ]
+  tier "bmad-bgreat-suite"
+  [ "$output" = "ring1" ]
+}
+
+@test "ring tier: any other repo defaults to stable" {
+  tier "markets"
+  [ "$output" = "stable" ]
+  tier "broodly"
+  [ "$output" = "stable" ]
+}


### PR DESCRIPTION
## Summary

Makes `check_centralized_workflow_stubs` in `compliance-audit.sh` **ring-aware** so the audit accepts a repo's canary-ring channel pin (epic #495) for the 6 #482 reusables. This must land **before** any stub is repinned onto a ring channel — otherwise dev-lead remediation reverts the change (the #482 revert-collision lesson; audit-first ordering).

## What changed

- **`ring_tier_for_repo()`** — new helper mapping each repo to its ring tier:
  - `next` → `.github-private`
  - `ring0` → `.github` (dogfood; self-hosts via `@main`, skipped by the stub check — informational)
  - `ring1` → `TalkTerm`, `bmad-bgreat-suite`
  - `stable` → broad fleet
  - Mirrors the epic #495 topology and `.github-private/scripts/cut-release.sh` channels.
- **`RING` sentinel** — the 6 reusables (`auto-rebase`, `dependency-audit`, `dependabot-automerge`, `dependabot-rebase`, `agent-shield`, `pr-review-mention`) now use a `RING` canonical. At check time it resolves to the repo's tier channel (e.g. `agent-shield/ring1` on a ring1 repo). The transitional legacy grace accepts every ring channel **plus** the pre-ring `@v1`/`@v2` pins, so no stub is flagged or reverted mid-migration.
- **`feature-ideation`** stays a fixed `@v1` pin (not on the ring model).

## Tests

- 4 new bats cases for `ring_tier_for_repo`; existing `stub_pin_acceptable` cases unchanged (signature preserved). **11/11 pass.**
- `shellcheck --severity=warning` clean.

Refs #870

🤖 Generated with [Claude Code](https://claude.com/claude-code)