### PR TITLE
fix: share canary-ring pin model between audit and deploy sweep (#482)

### DIFF
--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -138,6 +138,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/dev-lead-retrigger.sh
 . "$SCRIPT_DIR/lib/dev-lead-retrigger.sh"
 
+# Canary-ring pin model — ring_tier_for_repo(), ring_canonical_ref(),
+# ring_legacy_csv(). Shared with deploy-standard-workflows.sh so the audit's
+# "non-compliant" and the deploy sweep's "drift" stay in lockstep (#482).
+# shellcheck source=lib/ring-pins.sh
+. "$SCRIPT_DIR/lib/ring-pins.sh"
+
 # ---------------------------------------------------------------------------
 # Ecosystem detection
 # ---------------------------------------------------------------------------
@@ -1042,23 +1048,9 @@ stub_pin_acceptable() {
   printf '%s\n' "$decoded" | grep -qE "^[[:space:]]*uses:[[:space:]]*${expected}([[:space:]]|$)"
 }
 
-# ring_tier_for_repo <repo>
-# Map a repo to its canary-ring tier for the #482 reusables (epic #495 topology):
-#   next   — .github-private  (candidate / first soak)
-#   ring0  — .github          (dogfood; but .github self-hosts via @main and is
-#                              skipped by the stub check, so this is informational)
-#   ring1  — TalkTerm, bmad-bgreat-suite  (early fleet canary)
-#   stable — everything else  (broad fleet)
-# Keep in sync with docs/release/ring topology and cut-release.sh channels.
-ring_tier_for_repo() {
-  case "$1" in
-    .github-private)            printf 'next' ;;
-    .github)                    printf 'ring0' ;;
-    TalkTerm | bmad-bgreat-suite) printf 'ring1' ;;
-    *)                          printf 'stable' ;;
-  esac
-  return 0
-}
+# ring_tier_for_repo(), ring_canonical_ref() and ring_legacy_csv() are provided by
+# lib/ring-pins.sh (sourced above) — the single source of truth shared with the
+# deploy sweep so the audit and the deploy never disagree on a stub's pin (#482).
 
 check_centralized_workflow_stubs() {
   local repo="$1"
@@ -1111,11 +1103,10 @@ check_centralized_workflow_stubs() {
     # (e.g. a ring1 repo still on /stable, or .github-private's /next promoted to
     # /stable) is never flagged — only @main / inline / off-channel pins are.
     if [ "$canonical" = "RING" ]; then
-      local chan tier
+      local chan
       chan="${reusable%-reusable}"
-      tier="$(ring_tier_for_repo "$repo")"
-      canonical="${chan}/${tier}"
-      legacy="${chan}/next,${chan}/ring0,${chan}/ring1,${chan}/stable,v1,v2"
+      canonical="$(ring_canonical_ref "$chan" "$repo")"
+      legacy="$(ring_legacy_csv "$chan" "$repo")"
     fi
 
     # Skip workflows that don't exist in this repo. Required workflows are

--- a/scripts/deploy-standard-workflows.sh
+++ b/scripts/deploy-standard-workflows.sh
@@ -33,6 +33,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib/standards-deploy.sh
 source "$SCRIPT_DIR/lib/standards-deploy.sh"
+# Canary-ring pin model — shared with compliance-audit.sh so this sweep's notion
+# of "drift" matches the audit's "non-compliant" and never reverts a repo's
+# intentional ring/next pin back to the template's stable channel (#482).
+# shellcheck source=scripts/lib/ring-pins.sh
+source "$SCRIPT_DIR/lib/ring-pins.sh"
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -149,12 +154,34 @@ fetch_existing() {
 
 # True if the existing decoded content already has the canonical uses: reference
 # for this workflow (extracted from the template itself, so it tracks version bumps).
+#
+# Ring-aware (#482): templates pin a moving channel tag `<base>/stable`, but a
+# repo on a non-stable ring tier legitimately pins `<base>/<tier>` (e.g.
+# `<base>/ring1`). For those reusables the stub is compliant when it pins ANY ref
+# the shared ring model accepts for THIS repo (its tier channel + the transitional
+# legacy grace) — so the sweep never reverts an intentional ring/next pin. Non-ring
+# templates (e.g. add-to-project, feature-ideation@v1) keep the exact-match rule.
 is_already_compliant() {
-  local existing_content="$1" template="$2"
+  local existing_content="$1" template="$2" repo="$3"
   local expected_uses
   expected_uses=$(grep -E '^[[:space:]]*uses:' "$template" | head -1 | sed 's/^[[:space:]]*uses:[[:space:]]*//' | tr -d '\r')
   [[ -z "$expected_uses" ]] && return 1
-  echo "$existing_content" | grep -qF "$expected_uses"
+
+  local prefix="${expected_uses%@*}" ref_after="${expected_uses##*@}" base
+  if [[ "$prefix" =~ /([a-z0-9-]+)-reusable\.yml$ ]]; then
+    base="${BASH_REMATCH[1]}"
+    # Only treat it as ring-managed if the reusable is on the ring model AND the
+    # template pins a channel tag (not a frozen @vX / SHA).
+    if ring_is_ring_reusable "$base" && [[ "$ref_after" =~ ^${base}/(stable|next|ring[0-9]+)$ ]]; then
+      local ref
+      while IFS= read -r ref; do
+        [[ -n "$ref" ]] && grep -qF "${prefix}@${ref}" <<< "$existing_content" && return 0
+      done < <(ring_accepted_refs "$base" "$repo")
+      return 1
+    fi
+  fi
+
+  grep -qF "$expected_uses" <<< "$existing_content"
 }
 
 # Build the PR body for a batched stub deployment (one PR per repo).
@@ -197,7 +224,7 @@ deploy_repo() {
     raw=$(fetch_existing "$repo" "$target_path")
     existing_sha="${raw%%$'\t'*}"
     existing_content="${raw#*$'\t'}"
-    if [[ -n "$existing_sha" ]] && [[ "$FORCE" == "false" ]] && is_already_compliant "$existing_content" "$template"; then
+    if [[ -n "$existing_sha" ]] && [[ "$FORCE" == "false" ]] && is_already_compliant "$existing_content" "$template" "$repo"; then
       skip "$repo/$target_path already compliant"
       continue
     fi

--- a/scripts/deploy-standard-workflows.sh
+++ b/scripts/deploy-standard-workflows.sh
@@ -181,7 +181,7 @@ is_already_compliant() {
     fi
   fi
 
-  grep -qF "$expected_uses" <<< "$existing_content"
+  grep -qF "$expected_uses" <<< "$existing_content" && return 0 || return 1
 }
 
 # Build the PR body for a batched stub deployment (one PR per repo).

--- a/scripts/lib/ring-pins.sh
+++ b/scripts/lib/ring-pins.sh
@@ -21,7 +21,7 @@
 # WITHOUT the `-reusable` suffix (e.g. `auto-rebase`, not `auto-rebase-reusable`)
 # and WITHOUT the `.yml` extension. dev-lead is included: it is ring-released too
 # (its reusable lives in .github-private but the same tier topology applies).
-RING_REUSABLES=(
+readonly RING_REUSABLES=(
   auto-rebase
   dependency-audit
   dependabot-automerge
@@ -62,6 +62,7 @@ ring_is_ring_reusable() {
 # `agent-shield/ring1` on a ring1 repo.
 ring_canonical_ref() {
   printf '%s/%s' "$1" "$(ring_tier_for_repo "$2")"
+  return 0
 }
 
 # ring_accepted_refs <channel-base> <repo> -> newline-separated list of refs that
@@ -75,6 +76,7 @@ ring_accepted_refs() {
   local name="$1" repo="$2"
   ring_canonical_ref "$name" "$repo"; printf '\n'
   printf '%s/next\n%s/ring0\n%s/ring1\n%s/stable\nv1\nv2\n' "$name" "$name" "$name" "$name"
+  return 0
 }
 
 # ring_legacy_csv <channel-base> <repo> -> the accepted refs EXCEPT the canonical
@@ -82,4 +84,5 @@ ring_accepted_refs() {
 # legacy separately.
 ring_legacy_csv() {
   ring_accepted_refs "$1" "$2" | tail -n +2 | paste -sd, -
+  return 0
 }

--- a/scripts/lib/ring-pins.sh
+++ b/scripts/lib/ring-pins.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# ring-pins.sh — single source of truth for the canary-ring pin model.
+#
+# The #482 `.github`-hosted reusables (and dev-lead) are released through the
+# concentric-ring channels of epic #495: next → ring0 → ring1 → stable. Both
+# the compliance audit (`check_centralized_workflow_stubs` in
+# compliance-audit.sh) and the deploy sweep (`is_already_compliant` in
+# deploy-standard-workflows.sh) must agree on
+#   (a) which repo sits in which ring tier, and
+#   (b) which `@<channel>` refs are acceptable for a stub in that repo,
+# otherwise "drift" (deploy) and "non-compliant" (audit) diverge — the exact
+# three-way inconsistency #482 exists to close. This file is sourced by both so
+# they can never drift again.
+#
+# Keep the topology in sync with petry-projects/.github-private's
+# scripts/cut-release.sh channels and docs/release/.
+# ---------------------------------------------------------------------------
+
+# Reusable channel base-names on the canary-ring model. These are the basenames
+# WITHOUT the `-reusable` suffix (e.g. `auto-rebase`, not `auto-rebase-reusable`)
+# and WITHOUT the `.yml` extension. dev-lead is included: it is ring-released too
+# (its reusable lives in .github-private but the same tier topology applies).
+RING_REUSABLES=(
+  auto-rebase
+  dependency-audit
+  dependabot-automerge
+  dependabot-rebase
+  agent-shield
+  pr-review-mention
+  dev-lead
+)
+
+# ring_tier_for_repo <repo> -> next|ring0|ring1|stable
+# Map a repo to its canary-ring tier (epic #495 topology):
+#   next   — .github-private  (candidate / first soak)
+#   ring0  — .github          (dogfood; self-hosts via @main, so the stub check
+#                              skips it — this mapping is informational there)
+#   ring1  — TalkTerm, bmad-bgreat-suite  (early fleet canary)
+#   stable — everything else  (broad fleet)
+ring_tier_for_repo() {
+  case "$1" in
+    .github-private)              printf 'next' ;;
+    .github)                      printf 'ring0' ;;
+    TalkTerm | bmad-bgreat-suite) printf 'ring1' ;;
+    *)                            printf 'stable' ;;
+  esac
+  return 0
+}
+
+# ring_is_ring_reusable <channel-base> -> 0 if the reusable is on the ring model
+ring_is_ring_reusable() {
+  local name="$1" r
+  for r in "${RING_REUSABLES[@]}"; do
+    [ "$r" = "$name" ] && return 0
+  done
+  return 1
+}
+
+# ring_canonical_ref <channel-base> <repo> -> the org-standard ref a stub in
+# <repo> should pin: the channel tag for the repo's ring tier, e.g.
+# `agent-shield/ring1` on a ring1 repo.
+ring_canonical_ref() {
+  printf '%s/%s' "$1" "$(ring_tier_for_repo "$2")"
+}
+
+# ring_accepted_refs <channel-base> <repo> -> newline-separated list of refs that
+# a stub in <repo> may pin without being flagged/reverted. The FIRST line is the
+# canonical tier channel; the rest are the transitional legacy grace: every ring
+# channel (so a repo pinned to a higher tier — e.g. ring1 still on /stable, or a
+# promoted /next — is never flagged) plus the pre-ring @v1/@v2 pins (so a stub
+# mid-migration is left alone). The grace is dropped once the fleet is fully on
+# the rings (#870 follow-up); dropping it here tightens BOTH consumers at once.
+ring_accepted_refs() {
+  local name="$1" repo="$2"
+  ring_canonical_ref "$name" "$repo"; printf '\n'
+  printf '%s/next\n%s/ring0\n%s/ring1\n%s/stable\nv1\nv2\n' "$name" "$name" "$name" "$name"
+}
+
+# ring_legacy_csv <channel-base> <repo> -> the accepted refs EXCEPT the canonical
+# one, comma-joined. Convenience for callers (the audit) that pass canonical and
+# legacy separately.
+ring_legacy_csv() {
+  ring_accepted_refs "$1" "$2" | tail -n +2 | paste -sd, -
+}

--- a/test/scripts/deploy-standard-workflows/dry-run.bats
+++ b/test/scripts/deploy-standard-workflows/dry-run.bats
@@ -62,3 +62,32 @@ STUB
   echo "$output" | grep -q 'already compliant'
   echo "$output" | grep -vq 'Would open PR'
 }
+
+# Ring-awareness (#482): the auto-rebase template pins @auto-rebase/stable, but a
+# ring1 repo legitimately pins @auto-rebase/ring1. The sweep must treat that as
+# compliant and NOT plan a PR reverting it to stable.
+stub_pinning() {  # <ref> → base64 of a minimal stub pinning the reusable at <ref>
+  local body="jobs:
+  auto-rebase:
+    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@$1
+    secrets: inherit"
+  base64 -w 0 <<<"$body" 2>/dev/null || base64 -b 0 <<<"$body"
+}
+
+@test "dry-run treats a ring1 tier-channel pin as compliant on a ring1 repo" {
+  GH_CONTENT_B64="$(stub_pinning auto-rebase/ring1)"; export GH_CONTENT_B64
+  install_gh_stub
+  run env GH_TOKEN=x bash "$SCRIPT" --dry-run --repo TalkTerm --workflow auto-rebase.yml
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'already compliant'
+  echo "$output" | grep -vq 'Would open PR'
+}
+
+@test "dry-run still flags an off-channel (SHA) pin on a ring1 repo" {
+  GH_CONTENT_B64="$(stub_pinning '376a4fcb1117444595e3e702fa450873d0e54310 # auto-rebase/stable')"
+  export GH_CONTENT_B64
+  install_gh_stub
+  run env GH_TOKEN=x bash "$SCRIPT" --dry-run --repo TalkTerm --workflow auto-rebase.yml
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qE 'Would open PR for TalkTerm .* auto-rebase.yml'
+}

--- a/test/scripts/lib/ring-pins.bats
+++ b/test/scripts/lib/ring-pins.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# Unit tests for scripts/lib/ring-pins.sh — the canary-ring pin model shared by
+# compliance-audit.sh (check_centralized_workflow_stubs) and
+# deploy-standard-workflows.sh (is_already_compliant). The lib has no `main`, so
+# it is sourced directly and its pure helpers are exercised in-process.
+
+setup() {
+  REPO_ROOT="$(cd -- "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  # shellcheck source=/dev/null
+  source "${REPO_ROOT}/scripts/lib/ring-pins.sh"
+}
+
+@test "ring_tier_for_repo maps each tier" {
+  [ "$(ring_tier_for_repo .github-private)" = "next" ]
+  [ "$(ring_tier_for_repo .github)" = "ring0" ]
+  [ "$(ring_tier_for_repo TalkTerm)" = "ring1" ]
+  [ "$(ring_tier_for_repo bmad-bgreat-suite)" = "ring1" ]
+  [ "$(ring_tier_for_repo markets)" = "stable" ]
+  [ "$(ring_tier_for_repo anything-else)" = "stable" ]
+}
+
+@test "ring_is_ring_reusable recognises the ring set (incl. dev-lead)" {
+  ring_is_ring_reusable auto-rebase
+  ring_is_ring_reusable pr-review-mention
+  ring_is_ring_reusable dev-lead
+  ! ring_is_ring_reusable feature-ideation
+  ! ring_is_ring_reusable add-to-project
+}
+
+@test "ring_canonical_ref is the repo's tier channel" {
+  [ "$(ring_canonical_ref agent-shield TalkTerm)" = "agent-shield/ring1" ]
+  [ "$(ring_canonical_ref agent-shield markets)" = "agent-shield/stable" ]
+  [ "$(ring_canonical_ref dev-lead .github-private)" = "dev-lead/next" ]
+}
+
+@test "ring_accepted_refs: canonical first, then legacy grace" {
+  run ring_accepted_refs auto-rebase TalkTerm
+  [ "${lines[0]}" = "auto-rebase/ring1" ]                 # canonical = tier channel
+  printf '%s\n' "${lines[@]}" | grep -qx "auto-rebase/stable"  # higher tier accepted
+  printf '%s\n' "${lines[@]}" | grep -qx "v1"                  # pre-ring grace
+  printf '%s\n' "${lines[@]}" | grep -qx "v2"
+}
+
+@test "ring_legacy_csv excludes the canonical and comma-joins the rest" {
+  run ring_legacy_csv auto-rebase markets
+  # canonical (auto-rebase/stable) must not be duplicated in the legacy list head
+  [[ "$output" == *"v1,v2"* ]]
+  [[ "$output" == *"auto-rebase/next"* ]]
+}


### PR DESCRIPTION
## Summary

Closes the core of #482 — the **three-way pin inconsistency** (template ↔ compliance audit ↔ deploy sweep). The audit became ring-aware in #529/#870, but `deploy-standard-workflows.sh`'s `is_already_compliant` was still a literal substring match on the template's `@<name>/stable` pin, so a fleet sweep flagged **every ring1/next repo as drifted** and would have reverted their intentional ring pins back to `stable`.

## What changed

- **New `scripts/lib/ring-pins.sh`** — single source of truth for the canary-ring model: `ring_tier_for_repo`, `ring_canonical_ref`, `ring_accepted_refs`, `ring_legacy_csv`, and the `RING_REUSABLES` set (now incl. `dev-lead`, which is ring-released too).
- **`compliance-audit.sh`** — drops its duplicate `ring_tier_for_repo`; the RING canonical/legacy is computed via the lib. Behaviour-identical (11/11 existing stub bats pass).
- **`deploy-standard-workflows.sh`** — `is_already_compliant` accepts a repo's **tier channel** (+ transitional grace) for ring reusables, so the sweep never reverts a ring/next pin. Non-ring templates (add-to-project, feature-ideation@v1) keep the exact-match rule.

"Drift" and "non-compliant" are now computed from the **same code** and can't diverge again.

## Verification

Full-fleet `--dry-run` before → noisy (TalkTerm, bmad, `.github-private` all falsely drifted). After → only the **two genuine off-channel SHA pins** remain:
```
TalkTerm — dev-lead.yml
ContentTwin — pr-review-mention, agent-shield, auto-rebase, dependabot-automerge, dependabot-rebase, dependency-audit
```
Those are repinned to their channel tags in separate PRs; once merged the fleet dry-run is fully clean (criterion 3) and #482 closes.

## Tests
- `test/scripts/lib/ring-pins.bats` — 5 new unit tests for the lib.
- `test/scripts/deploy-standard-workflows/dry-run.bats` — 2 new cases (ring1 tier-channel pin = compliant; SHA pin = still flagged).
- `shellcheck --severity=warning` clean.

Refs #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)