### PR TITLE
feat(feature-ideation): backlog enhancement sweep + dry-run + marker continuity (E1/E2/E3)

### DIFF
--- a/.github/workflows/feature-ideation-reusable.yml
+++ b/.github/workflows/feature-ideation-reusable.yml
@@ -319,12 +319,38 @@ jobs:
                `comment_on_discussion "$DISCUSSION_ID" "$BODY"` (the Phase-8 helper).
                Do **NOT** create new Discussions, run the matcher, or comment on anything
                else. If the Discussion is not in the `ideas` category, exit without posting.
-            5. Idempotency: if a prior comment already carries the marker
-               `<!-- feature-ideation:enhanced -->`, do nothing. Otherwise begin your comment
-               with that exact HTML marker so re-runs are safe.
+            5. Idempotency (marker continuity): treat the Discussion as ALREADY ENHANCED —
+               and do nothing — if any existing comment carries EITHER
+               `<!-- feature-ideation:enhanced -->` OR the legacy
+               `<!-- idea-enhancer:enhanced -->` marker. Otherwise begin your comment with
+               the canonical `<!-- feature-ideation:enhanced -->` marker so re-runs (and the
+               cutover from the old idea-enhancer) are safe.
 
-            **If `$TARGET_DISCUSSION` is empty**, ignore this section and run the normal
-            scheduled ideation below.
+            **Else, if `$ENHANCE_BACKLOG` is "1"** (and `$TARGET_DISCUSSION` is empty), run in
+            **backlog enhancement mode** and SKIP the broad scheduled scan — this backfills
+            existing ideas and never generates new ones:
+
+            1. Enumerate this repo's open Discussions in the `ideas` category via GraphQL with
+               `$GH_TOKEN` (derive OWNER/REPO from `${{ github.repository }}`), paging through
+               all of them:
+               ```bash
+               gh api graphql -f query='{repository(owner:"OWNER",name:"REPO"){discussions(first:50,after:CURSOR){pageInfo{hasNextPage endCursor} nodes{number id title body category{slug} author{login __typename} comments(first:50){nodes{author{login} body}}}}}}'
+               ```
+            2. Build the **candidate** set: `category.slug == "ideas"` AND the author is a real
+               human (author `__typename` is `User`, not `Bot`/`Organization`) AND no existing
+               comment carries EITHER marker from step 5. Skip everything else (bot-authored
+               ideas, and anything already enhanced under either marker). If there are no
+               candidates, print a short summary and exit cleanly.
+            3. For EACH candidate, perform the SAME focused per-idea research + ONE additive
+               enhancement comment as single-idea steps 2–4 above, beginning the comment with
+               the canonical `<!-- feature-ideation:enhanced -->` marker. Post **exactly one**
+               comment per candidate via `comment_on_discussion "$DISCUSSION_ID" "$BODY"` (the
+               Phase-8 helper, which honors `$DRY_RUN`: when `$DRY_RUN` is "1" it logs the
+               intended comment to `$DRY_RUN_LOG` and posts NOTHING). Do **NOT** create
+               Discussions, run the matcher, or comment on non-candidates.
+
+            **If `$TARGET_DISCUSSION` is empty AND `$ENHANCE_BACKLOG` is not "1"**, ignore the
+            enhancement sections above and run the normal scheduled ideation below.
 
             ## Phase 1: Load Context
 

--- a/.github/workflows/feature-ideation-reusable.yml
+++ b/.github/workflows/feature-ideation-reusable.yml
@@ -334,7 +334,10 @@ jobs:
                `$GH_TOKEN` (derive OWNER/REPO from `${{ github.repository }}`), paging through
                all of them:
                ```bash
-               gh api graphql -f query='{repository(owner:"OWNER",name:"REPO"){discussions(first:50,after:CURSOR){pageInfo{hasNextPage endCursor} nodes{number id title body category{slug} author{login __typename} comments(first:50){nodes{author{login} body}}}}}}'
+               QUERY='{repository(owner:"OWNER",name:"REPO"){discussions(first:50,after:CURSOR){'
+               QUERY+='pageInfo{hasNextPage endCursor} nodes{number id title body category{slug}'
+               QUERY+=' author{login __typename} comments(first:50){nodes{author{login} body}}}}}}'
+               gh api graphql -f query="$QUERY"
                ```
             2. Build the **candidate** set: `category.slug == "ideas"` AND the author is a real
                human (author `__typename` is `User`, not `Bot`/`Organization`) AND no existing

--- a/.github/workflows/feature-ideation-reusable.yml
+++ b/.github/workflows/feature-ideation-reusable.yml
@@ -74,6 +74,18 @@ on:
         required: false
         default: ''
         type: string
+      enhance_backlog:
+        description: |
+          When true, run in BACKLOG ENHANCEMENT mode: sweep this repo's open,
+          human-authored, not-yet-enhanced Ideas Discussions and post one
+          enhancement comment on each (idempotent via the marker — see E1). Ignored
+          when `target_discussion` is set (single-idea mode wins). With
+          `dry_run: true`, the intended comments are logged to the JSONL artifact
+          rather than posted. This restores the existing-backlog sweep that the
+          standalone idea-enhancer provided before consolidation.
+        required: false
+        default: false
+        type: boolean
       tooling_ref:
         description: |
           Ref of petry-projects/.github to source the feature-ideation scripts from.
@@ -224,6 +236,7 @@ jobs:
           TOOLING_DIR: ${{ github.workspace }}/.feature-ideation-tooling/.github/scripts/feature-ideation
           FOCUS_AREA: ${{ inputs.focus_area || '' }}
           TARGET_DISCUSSION: ${{ inputs.target_discussion || '' }}
+          ENHANCE_BACKLOG: ${{ inputs.enhance_backlog && '1' || '0' }}
           SOURCES_FILE_PATH: ${{ inputs.sources_file }}
           RESEARCH_DEPTH: ${{ inputs.research_depth }}
         uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
@@ -277,6 +290,7 @@ jobs:
             - `$DRY_RUN`          — "1" = mutations are logged to `$DRY_RUN_LOG`, not executed
             - `$FOCUS_AREA`       — optional focus area (empty = open exploration)
             - `$TARGET_DISCUSSION`— if non-empty, a Discussion number to enhance (single-idea mode)
+            - `$ENHANCE_BACKLOG`  — "1" = backlog enhancement sweep (used only when `$TARGET_DISCUSSION` is empty)
             - `$RESEARCH_DEPTH`   — quick | standard | deep
             - `$GH_TOKEN`         — workflow token with `discussions: write`
 

--- a/standards/workflows/feature-ideation.yml
+++ b/standards/workflows/feature-ideation.yml
@@ -105,7 +105,7 @@ jobs:
       discussions: write
       id-token: write
       actions: read
-    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@897e4dede3518cdd7273b9dc63e607d0d05cbdda # v1
+    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@e20a8fac1b6a10bd6ad0999258e88a423f890ba6 # v1
     with:
       # On the `discussion: created` trigger this carries the new Discussion's
       # number → the reusable runs single-idea enhancement mode. Empty on
@@ -129,6 +129,6 @@ jobs:
       research_depth: ${{ inputs.research_depth || 'standard' }}
       dry_run: ${{ inputs.dry_run || false }}
       # Backlog enhancement sweep of existing un-enhanced Ideas (workflow_dispatch).
-      enhance_backlog: ${{ inputs.enhance_backlog || false }}
+      enhance_backlog: ${{ inputs.enhance_backlog == true }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/standards/workflows/feature-ideation.yml
+++ b/standards/workflows/feature-ideation.yml
@@ -64,6 +64,11 @@ on:
         required: false
         default: false
         type: boolean
+      enhance_backlog:
+        description: 'Backlog enhancement sweep: enhance this repo''s open, human-authored, not-yet-enhanced Ideas (one comment each, idempotent). Combine with dry_run=true to preview.'
+        required: false
+        default: false
+        type: boolean
   # Auto-enhance a freshly-created idea: when a new Discussion is opened in the
   # Ideas category, the analyst researches and refines it in single-idea mode.
   discussion:
@@ -123,5 +128,7 @@ jobs:
       focus_area: ${{ inputs.focus_area || '' }}
       research_depth: ${{ inputs.research_depth || 'standard' }}
       dry_run: ${{ inputs.dry_run || false }}
+      # Backlog enhancement sweep of existing un-enhanced Ideas (workflow_dispatch).
+      enhance_backlog: ${{ inputs.enhance_backlog || false }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
The **cross-repo prerequisite** for the consolidation backfill epic (`petry-projects/.github-private#934`, dogfooded from Discussion #933). Restores the existing-backlog sweep that the standalone `idea-enhancer` provided before #872 folded it into feature-ideation — the planner flagged it as an untracked prerequisite that dev-lead in `.github-private` can't author.

### `feature-ideation-reusable.yml`
- **E1 — marker continuity:** the enhancement idempotency check treats a Discussion as already-enhanced if it carries **either** `<!-- feature-ideation:enhanced -->` **or** the legacy `<!-- idea-enhancer:enhanced -->`; new comments emit the canonical marker. **Prevents re-enhancing idea-enhancer's prior work on cutover** (the exact failure #875's Dev Notes warn against).
- **E2 — backlog sweep:** new `enhance_backlog` `workflow_call` input → a mode that enumerates open, human-authored, not-yet-enhanced Ideas and posts **exactly one** additive enhancement comment each (bots + already-enhanced skipped). `target_discussion` single-idea mode still wins when set.
- **E3 — dry-run:** the sweep honors `dry_run` — intended per-Discussion comments go to the JSONL artifact, nothing posted (makes #875/#937's enhancement dry-run real).

### `standards/workflows/feature-ideation.yml`
- Expose + forward `enhance_backlog` — the verbatim-sync target for `.github-private#935`.

## After merge
The `feature-ideation/next` channel needs to be moved to this commit so `.github-private`'s pinned stub picks up the input; then #934's stories (#935 sync, #936 docs, #937 validate) can proceed, and #876 (deprecate idea-enhancer) unblocks.

Refs `.github-private#934`, `#872`, `#817`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional backlog enhancement mode for the feature ideation workflow.
  * Introduced a new run-time option to sweep existing Ideas and add one enhancement comment to each eligible discussion.
  * Updated the workflow to recognize both current and legacy enhancement markers for better idempotency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->