### PR TITLE
chore: drop the transitional @v1/@v2 pin grace (#870)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "pr-540",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/scripts/lib/ring-pins.sh
+++ b/scripts/lib/ring-pins.sh
@@ -78,8 +78,9 @@ ring_canonical_ref() {
 # is now flagged — the migration is complete, so those are genuine drift.
 ring_accepted_refs() {
   local name="$1" repo="$2"
-  ring_canonical_ref "$name" "$repo"; printf '\n'
-  printf '%s/next\n%s/ring0\n%s/ring1\n%s/stable\n' "$name" "$name" "$name" "$name"
+  local canonical; canonical=$(ring_canonical_ref "$name" "$repo")
+  printf '%s\n' "$canonical"
+  printf '%s/next\n%s/ring0\n%s/ring1\n%s/stable\n' "$name" "$name" "$name" "$name" | grep -vFx "$canonical"
   return 0
 }
 

--- a/scripts/lib/ring-pins.sh
+++ b/scripts/lib/ring-pins.sh
@@ -67,15 +67,19 @@ ring_canonical_ref() {
 
 # ring_accepted_refs <channel-base> <repo> -> newline-separated list of refs that
 # a stub in <repo> may pin without being flagged/reverted. The FIRST line is the
-# canonical tier channel; the rest are the transitional legacy grace: every ring
-# channel (so a repo pinned to a higher tier — e.g. ring1 still on /stable, or a
-# promoted /next — is never flagged) plus the pre-ring @v1/@v2 pins (so a stub
-# mid-migration is left alone). The grace is dropped once the fleet is fully on
-# the rings (#870 follow-up); dropping it here tightens BOTH consumers at once.
+# canonical tier channel; the rest are every ring channel, so a repo pinned to a
+# HIGHER tier than its own (e.g. a ring1 repo still on /stable, or a /next pin
+# promoted toward /stable) is never flagged and cut-release.sh promotions roll
+# without the audit tripping mid-promotion.
+#
+# The pre-ring @v1/@v2 migration grace was DROPPED in #870 once the whole fleet
+# was confirmed on `<name>/<tier>` channels (only .github's own dogfood callers
+# still carry @v2, and both consumers skip .github). A stub on @v1/@v2/SHA/@main
+# is now flagged — the migration is complete, so those are genuine drift.
 ring_accepted_refs() {
   local name="$1" repo="$2"
   ring_canonical_ref "$name" "$repo"; printf '\n'
-  printf '%s/next\n%s/ring0\n%s/ring1\n%s/stable\nv1\nv2\n' "$name" "$name" "$name" "$name"
+  printf '%s/next\n%s/ring0\n%s/ring1\n%s/stable\n' "$name" "$name" "$name" "$name"
   return 0
 }
 

--- a/test/scripts/compliance-audit/centralized-stub-pins.bats
+++ b/test/scripts/compliance-audit/centralized-stub-pins.bats
@@ -21,8 +21,10 @@ accept() {
     _ "$SCRIPT" "$line" "$canonical" "$legacy"
 }
 
-C="agent-shield/stable"   # canonical channel for these tests
-L="v1,v2"                 # transitional legacy grace
+C="agent-shield/stable"   # canonical channel for these tests (a stable-tier repo)
+# Retained grace = the other ring channels (a repo pinned to a higher tier than
+# its own is never flagged). The pre-ring @v1/@v2 grace was dropped in #870.
+L="agent-shield/next,agent-shield/ring0,agent-shield/ring1"
 R="petry-projects/.github/.github/workflows/agent-shield-reusable.yml"
 
 @test "canonical channel pin is accepted" {
@@ -30,14 +32,19 @@ R="petry-projects/.github/.github/workflows/agent-shield-reusable.yml"
   [ "$status" -eq 0 ]
 }
 
-@test "transitional legacy @v1 is accepted" {
-  accept "    uses: $R@v1" "$C" "$L"
+@test "a higher-tier ring channel is accepted (promotion grace)" {
+  accept "    uses: $R@agent-shield/ring1" "$C" "$L"
   [ "$status" -eq 0 ]
 }
 
-@test "transitional legacy @v2 is accepted" {
+@test "a pre-ring @v1 pin is now rejected (grace dropped, #870)" {
+  accept "    uses: $R@v1" "$C" "$L"
+  [ "$status" -ne 0 ]
+}
+
+@test "a pre-ring @v2 pin is now rejected (grace dropped, #870)" {
   accept "    uses: $R@v2" "$C" "$L"
-  [ "$status" -eq 0 ]
+  [ "$status" -ne 0 ]
 }
 
 @test "a SHA pin is rejected (must move to the channel)" {

--- a/test/scripts/lib/ring-pins.bats
+++ b/test/scripts/lib/ring-pins.bats
@@ -33,17 +33,20 @@ setup() {
   [ "$(ring_canonical_ref dev-lead .github-private)" = "dev-lead/next" ]
 }
 
-@test "ring_accepted_refs: canonical first, then legacy grace" {
+@test "ring_accepted_refs: canonical first, then the ring-channel grace" {
   run ring_accepted_refs auto-rebase TalkTerm
   [ "${lines[0]}" = "auto-rebase/ring1" ]                 # canonical = tier channel
   printf '%s\n' "${lines[@]}" | grep -qx "auto-rebase/stable"  # higher tier accepted
-  printf '%s\n' "${lines[@]}" | grep -qx "v1"                  # pre-ring grace
-  printf '%s\n' "${lines[@]}" | grep -qx "v2"
+  # the pre-ring @v1/@v2 grace was dropped in #870 — migration complete
+  ! printf '%s\n' "${lines[@]}" | grep -qx "v1"
+  ! printf '%s\n' "${lines[@]}" | grep -qx "v2"
 }
 
-@test "ring_legacy_csv excludes the canonical and comma-joins the rest" {
+@test "ring_legacy_csv excludes the canonical and comma-joins the ring channels" {
   run ring_legacy_csv auto-rebase markets
-  # canonical (auto-rebase/stable) must not be duplicated in the legacy list head
-  [[ "$output" == *"v1,v2"* ]]
   [[ "$output" == *"auto-rebase/next"* ]]
+  [[ "$output" == *"auto-rebase/ring1"* ]]
+  # no pre-ring grace
+  [[ "$output" != *"v1"* ]]
+  [[ "$output" != *"v2"* ]]
 }

--- a/test/scripts/lib/ring-pins.bats
+++ b/test/scripts/lib/ring-pins.bats
@@ -46,6 +46,7 @@ setup() {
   run ring_legacy_csv auto-rebase markets
   [[ "$output" == *"auto-rebase/next"* ]]
   [[ "$output" == *"auto-rebase/ring1"* ]]
+  [[ "$output" != *"auto-rebase/stable"* ]]
   # no pre-ring grace
   [[ "$output" != *"v1"* ]]
   [[ "$output" != *"v2"* ]]


### PR DESCRIPTION
## Summary

Final cleanup from the #482/#870 canary-ring migration: drop the transitional `@v1`/`@v2` pin grace now that the fleet is fully on `<name>/<tier>` channels.

The grace was added so the ring-aware audit/deploy wouldn't flag a stub still on its pre-ring `@v1`/`@v2` pin mid-migration. A full-fleet scan now finds **no consumer repo** pinned `@v1`/`@v2` for any of the 7 ring reusables — the only two left (`@v2` on `.github`'s own `dependabot-automerge`/`agent-shield` dogfood callers) live in `.github`, which both consumers skip. So the grace is no longer protecting anything; it's only masking genuine drift.

## Change
- `scripts/lib/ring-pins.sh` — remove `v1`/`v2` from `ring_accepted_refs`. A stub on `@v1`/`@v2`/SHA/`@main` is now flagged.
- **Retained:** the higher-tier ring-channel grace (a repo pinned above its tier — e.g. a ring1 repo still on `/stable`, or a `/next` pin promoted toward `/stable` — stays compliant, so `cut-release.sh` promotions roll without the audit tripping mid-promotion).
- Centralized in the shared lib → tightens **both** `compliance-audit.sh` and `deploy-standard-workflows.sh` at once.

## Verification
- `shellcheck --severity=warning` clean.
- bats: ring-pins (5), centralized-stub-pins (12), deploy dry-run (4) — all pass; the `@v1`/`@v2` cases now assert rejection.
- Full-fleet `deploy --dry-run` = **0 non-compliant** (no repo flagged by the drop).

Refs #870

🤖 Generated with [Claude Code](https://claude.com/claude-code)