### PR TITLE
chore: cut .github ring0 dogfood callers to local refs (#541)

### DIFF
--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   agent-shield:
-    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v2
+    uses: ./.github/workflows/agent-shield-reusable.yml  # local ref — always current (ring0 dogfood, #541)

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -35,5 +35,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@v2
+    uses: ./.github/workflows/dependabot-automerge-reusable.yml  # local ref — always current (ring0 dogfood, #541)
     secrets: inherit


### PR DESCRIPTION
## Summary

`.github` is the **ring0** dogfood tier (epic #495) — its own callers should run the **latest** reusable code so regressions surface at the source. Two were frozen on a stale `@v2` cross-repo tag and silently weren't dogfooding. Cut them over to the local-ref form already used by `auto-rebase.yml` / `dependabot-rebase.yml` / `pr-review-mention.yml`:

| Caller | Before | After |
|---|---|---|
| `agent-shield.yml` | `…/agent-shield-reusable.yml@v2` | `./.github/workflows/agent-shield-reusable.yml` |
| `dependabot-automerge.yml` | `…/dependabot-automerge-reusable.yml@v2` | `./.github/workflows/dependabot-automerge-reusable.yml` |

## Compatibility (checked against HEAD reusables)
- `agent-shield-reusable.yml` — all `workflow_call` inputs optional; stub passes none. ✓
- `dependabot-automerge-reusable.yml` — required secrets `APP_ID`/`APP_PRIVATE_KEY` already supplied by the stub's unchanged `secrets: inherit`. ✓

`.github` is in `SKIP_REPOS` and exempt from the centralized-stub audit, so these local refs won't be reverted. Only affects `.github`'s own repo automation — the safest place to dogfood.

Closes #541. Refs #870, #495.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation workflows to use repository-local reusable logic instead of an external shared version.
  * This keeps the workflow behavior aligned with the current project configuration and simplifies maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->