### PR TITLE
docs(ci-standards): feature-ideation backlog enhancement (backfill) + dry-run

### DIFF
--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -910,10 +910,10 @@ skips the bot's own creations; enhancement is a comment (which does not re-fire
 `created`), so there is no trigger loop.
 
 **Backlog enhancement (backfill) + dry-run.** Beyond enhancing *newly-created*
-ideas, the reusable can **backfill the existing Ideas backlog**: dispatch with
+Ideas, the reusable can **backfill the existing Ideas backlog**: dispatch with
 `enhance_backlog: true` to sweep this repo's open, **human-authored**,
 not-yet-enhanced Ideas and post **exactly one** enhancement comment on each
-(bots and already-enhanced ideas are skipped). Combine with `dry_run: true` to
+(bots and already-enhanced Ideas are skipped). Combine with `dry_run: true` to
 **preview** — the intended per-Discussion comments are logged to the JSONL
 artifact and nothing is posted:
 

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -916,12 +916,14 @@ not-yet-enhanced Ideas and post **exactly one** enhancement comment on each
 (bots and already-enhanced ideas are skipped). Combine with `dry_run: true` to
 **preview** — the intended per-Discussion comments are logged to the JSONL
 artifact and nothing is posted:
+
 ```bash
 # Preview the backfill (posts nothing):
 gh workflow run feature-ideation.yml -R <owner>/<repo> -f enhance_backlog=true -f dry_run=true
 # Run it for real:
 gh workflow run feature-ideation.yml -R <owner>/<repo> -f enhance_backlog=true
 ```
+
 Idempotency is **marker-continuous**: a Discussion is treated as already-enhanced
 if it carries **either** `<!-- feature-ideation:enhanced -->` **or** the legacy
 `<!-- idea-enhancer:enhanced -->`, so re-runs are no-ops and the cutover from the

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -909,6 +909,25 @@ job-level `if` restricts this to new Discussions in the **Ideas** category and
 skips the bot's own creations; enhancement is a comment (which does not re-fire
 `created`), so there is no trigger loop.
 
+**Backlog enhancement (backfill) + dry-run.** Beyond enhancing *newly-created*
+ideas, the reusable can **backfill the existing Ideas backlog**: dispatch with
+`enhance_backlog: true` to sweep this repo's open, **human-authored**,
+not-yet-enhanced Ideas and post **exactly one** enhancement comment on each
+(bots and already-enhanced ideas are skipped). Combine with `dry_run: true` to
+**preview** — the intended per-Discussion comments are logged to the JSONL
+artifact and nothing is posted:
+```bash
+# Preview the backfill (posts nothing):
+gh workflow run feature-ideation.yml -R <owner>/<repo> -f enhance_backlog=true -f dry_run=true
+# Run it for real:
+gh workflow run feature-ideation.yml -R <owner>/<repo> -f enhance_backlog=true
+```
+Idempotency is **marker-continuous**: a Discussion is treated as already-enhanced
+if it carries **either** `<!-- feature-ideation:enhanced -->` **or** the legacy
+`<!-- idea-enhancer:enhanced -->`, so re-runs are no-ops and the cutover from the
+former standalone `idea-enhancer` never double-enhances. `target_discussion`
+(single-idea mode) takes precedence over `enhance_backlog` when both are set.
+
 **The pipeline (the reason this workflow exists):**
 
 | Phase | Skill | Purpose |


### PR DESCRIPTION
Documents the new `enhance_backlog` sweep + `dry_run` preview + marker continuity in ci-standards §9 — the docs portion of the backfill epic `petry-projects/.github-private#936`. Refs #934, #872.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the feature ideation workflow guide with instructions for backfilling existing ideas.
  * Added a preview mode that generates intended comment output without posting changes.
  * Clarified how enhanced items are detected, including support for legacy markers.
  * Noted that single-item handling takes priority when both single-item and backlog modes are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->