### PR TITLE
feat: implement issue #546 — bug(ci-standards): dev-lead.yml caller stub missing SonarCloud S7637 exemption — blocks ring-pinned consumers (bmad #334)

### DIFF
--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -1610,6 +1610,26 @@ The cron's three `repository_dispatch` retry types — `dev-lead-ci-failure`,
 3. Set `GH_PAT_WORKFLOWS` — a PAT with read access to `petry-projects/.github-private` — as an org or repo secret (required for cross-repo script access).
 4. Optionally set `vars.DEV_LEAD_ENGINE` to `claude` (default), `gemini`, or `copilot`.
 5. Optionally set `vars.DEV_LEAD_DRY_RUN=true` during the initial rollout period.
+6. **If the repo is SonarCloud-gated, add the `s7637_devlead` exemption to
+   `sonar-project.properties`** (required). `dev-lead.yml` is a first-party
+   reusable-ref caller stub pinned to a moving channel tag — `@dev-lead/stable`,
+   or a canary-ring tag (`@dev-lead/ring0` | `@dev-lead/ring1` | `@dev-lead/next`)
+   under the [canary-rings rollout](#reusable-workflow-versioning--the-stable-channel).
+   That mutable ref is intentionally **not** SHA-pinned, so SonarCloud's
+   `githubactions:S7637` flags it at HIGH severity, drives `new_security_rating`
+   to **C**, and fails the Quality Gate — blocking the required `SonarCloud`
+   check. Add the per-file criterion (keyed to `**/dev-lead.yml`, **never** a
+   blanket `resourceKey`) exactly as for every other caller stub:
+
+   ```properties
+   sonar.issue.ignore.multicriteria.s7637_devlead.ruleKey=githubactions:S7637
+   sonar.issue.ignore.multicriteria.s7637_devlead.resourceKey=**/dev-lead.yml
+   ```
+
+   and add `s7637_devlead` to the `sonar.issue.ignore.multicriteria` list. See
+   [SonarCloud Exemption: First-Party Reusable-Ref S7637](#sonarcloud-exemption-first-party-reusable-ref-s7637)
+   for the canonical block; `check_sonar_s7637_exemption` files
+   `sonar-s7637-exemption-missing` against repos that omit it.
 
 ### Required secrets
 

--- a/standards/workflows/dev-lead.yml
+++ b/standards/workflows/dev-lead.yml
@@ -12,7 +12,7 @@
 #      sonar-project.properties (resourceKey **/dev-lead.yml, NEVER a blanket
 #      glob). The `uses:` ref below is a first-party reusable pinned to a moving
 #      channel/ring tag, so SonarCloud's githubactions:S7637 would otherwise
-#      fail the Quality Gate. See ci-standards.md#sonarcloud-exemption-first-party-reusable-ref-s7637.
+#      fail the Quality Gate. See ../ci-standards.md#sonarcloud-exemption-first-party-reusable-ref-s7637.
 #
 # UNLIKE claude.yml, this file has NO OIDC byte-for-byte constraint and may be
 # freely modified on PR branches to adjust triggers for repo-specific needs.
@@ -52,7 +52,7 @@ jobs:
     # change to dev-lead can no longer gate its own fix (the self-host circular
     # dependency). Promotion is done by moving the dev-lead/stable tag centrally; this
     # caller is never edited on release. agent_ref threads the same channel into
-    # dev-lead's own scripts/prompts checkout. See ci-standards.md#dev-lead-agent.
+    # dev-lead's own scripts/prompts checkout. See ../ci-standards.md#dev-lead-agent.
     uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable
     with:
       agent_ref: dev-lead/stable

--- a/standards/workflows/dev-lead.yml
+++ b/standards/workflows/dev-lead.yml
@@ -8,6 +8,11 @@
 #   2. Ensure CLAUDE_CODE_OAUTH_TOKEN is set as an org or repo secret.
 #   3. Optionally set GH_PAT_WORKFLOWS (required if Claude pushes workflow files).
 #   4. Optionally set vars.DEV_LEAD_ENGINE = "claude" | "gemini" | "copilot".
+#   5. SonarCloud-gated repo? Add the s7637_devlead exemption to
+#      sonar-project.properties (resourceKey **/dev-lead.yml, NEVER a blanket
+#      glob). The `uses:` ref below is a first-party reusable pinned to a moving
+#      channel/ring tag, so SonarCloud's githubactions:S7637 would otherwise
+#      fail the Quality Gate. See ci-standards.md#sonarcloud-exemption-first-party-reusable-ref-s7637.
 #
 # UNLIKE claude.yml, this file has NO OIDC byte-for-byte constraint and may be
 # freely modified on PR branches to adjust triggers for repo-specific needs.


### PR DESCRIPTION
Closes #546

Implemented by dev-lead agent. Please review.