### PR TITLE
fix(pr-review-mention): break the ack self-comment recursion

### DIFF
--- a/.github/workflows/pr-review-mention-reusable.yml
+++ b/.github/workflows/pr-review-mention-reusable.yml
@@ -37,6 +37,13 @@ jobs:
     # team review requests; comment fields don't exist on pull_request events.
     # For comment events we also gate at the job level on author_association so
     # that the job (and its secrets) never start for external/untrusted actors.
+    #
+    # Recursion guard: the ack comment this job posts itself contains
+    # '@donpetry-bot' and is posted via a PAT (so it DOES re-trigger workflows,
+    # unlike GITHUB_TOKEN), which without this guard self-loops until GitHub's
+    # 2500-comment cap. Skip any comment carrying our own ack marker. We match on
+    # the marker (not the bot actor) because donpetry-bot is also a human account
+    # whose own @-mention review requests must still fire.
     if: |
       (github.event_name == 'pull_request' &&
        github.event.requested_reviewer != null &&
@@ -44,6 +51,7 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name != 'pull_request' &&
        contains(github.event.comment.body, '@donpetry-bot') &&
+       !contains(github.event.comment.body, 'pr-review-agent mention-ack') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
        (github.event_name == 'pull_request_review_comment' ||
         github.event.issue.pull_request != null))


### PR DESCRIPTION
## Summary

`pr-review-mention`'s `handle-mention` job posts an acknowledgement comment that **itself contains `@donpetry-bot`**, via a PAT (`DON_PETRY_BOT_GH_PAT`). PAT-authored comments **do** re-trigger workflows (unlike `GITHUB_TOKEN`), so with no guard each ack re-satisfies the comment trigger and posts another ack — looping every ~8s until GitHub's **2500-comment cap**.

Observed **live** on `petry-projects/.github-private#959` during the #870 soak: ~2500 self-replies, then a failed run when commenting got disabled. (It manifests where `donpetry-bot`'s comment `author_association` ∈ OWNER/MEMBER/COLLABORATOR — i.e. `.github-private`; on `.github` the acks don't re-trigger, which is why review-requests here never looped.)

## Fix

Add a recursion guard to the comment branch of the job `if:`:

```yaml
!contains(github.event.comment.body, 'pr-review-agent mention-ack') &&
```

The ack always carries the HTML marker `<!-- pr-review-agent mention-ack -->`, so this skips the bot's own acks. **Matched on the marker, not the bot actor**, because `donpetry-bot` is also a human account whose own `@donpetry-bot` review requests must still fire.

## Notes
- Pre-existing in **all** channel versions (the trigger logic is identical across releases); the #870 soak surfaced it when the candidate ran on `.github-private`. Not a regression introduced by the candidate — but it means **`pr-review-mention` v2.1.0 is not safe to promote as-is**; this fix will be re-cut as a fresh candidate and re-soaked, while the other five reusables continue.
- No template change needed — the recursion lives in the reusable; caller stubs are unaffected.

Refs petry-projects/.github-private#870.

🤖 Generated with [Claude Code](https://claude.com/claude-code)