### PR TITLE
feat: implement issue #507 — [Phase 2a] Encode the PR-limit config as a machine-readable single source of truth

### DIFF
--- a/.github/workflows/pr-limits-tests.yml
+++ b/.github/workflows/pr-limits-tests.yml
@@ -47,6 +47,8 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
+          # Read-only test job — never pushes; don't leave the token in git config.
+          persist-credentials: false
 
       - name: Install bats, shellcheck, and jq
         run: |

--- a/.github/workflows/pr-limits-tests.yml
+++ b/.github/workflows/pr-limits-tests.yml
@@ -1,0 +1,58 @@
+# Quality gate for the PR-limit shared config (the single source of truth) and
+# its validating bats test.
+#
+# Triggered on any PR that touches:
+#   - standards/pr-limits.json
+#   - test/scripts/pr-limits/**
+#   - .github/workflows/pr-limits-tests.yml
+#
+# Gate: bats validates that standards/pr-limits.json parses as JSON, the
+# org-wide cap is a positive integer, all required keys exist, the numbers are
+# flagged provisional, and dependabot[bot] is on the exempt list.
+#
+# Context: ADR docs/initiatives/pull-request-limits-adr.md (#506). This story
+# (#507) delivers only the data; the admission gate is #507b and the apply path
+# is #508. Modeled on .github/workflows/auto-rebase-tests.yml.
+
+name: PR-limits Tests
+
+on:
+  pull_request:
+    paths:
+      - 'standards/pr-limits.json'
+      - 'test/scripts/pr-limits/**'
+      - '.github/workflows/pr-limits-tests.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'standards/pr-limits.json'
+      - 'test/scripts/pr-limits/**'
+      - '.github/workflows/pr-limits-tests.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-limits-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Validate config
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: Install bats, shellcheck, and jq
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends bats shellcheck jq
+
+      - name: Run bats suite
+        run: bats --print-output-on-failure test/scripts/pr-limits/

--- a/.github/workflows/pr-limits-tests.yml
+++ b/.github/workflows/pr-limits-tests.yml
@@ -50,11 +50,11 @@ jobs:
           # Read-only test job — never pushes; don't leave the token in git config.
           persist-credentials: false
 
-      - name: Install bats, shellcheck, and jq
+      - name: Install bats and jq
         run: |
           set -euo pipefail
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends bats shellcheck jq
+          sudo apt-get install -y --no-install-recommends bats jq
 
       - name: Run bats suite
         run: bats --print-output-on-failure test/scripts/pr-limits/

--- a/standards/pr-limits.json
+++ b/standards/pr-limits.json
@@ -1,0 +1,25 @@
+{
+  "status": "provisional",
+  "_note": "PROVISIONAL — pending human sign-off (ADR docs/initiatives/pull-request-limits-adr.md §6). Every numeric value below is a proposal anchored to the §5 baseline, NOT a GitHub-imposed maximum (none exists; see ADR §2-§3). The confirmed numbers can be set here later without a code change — consumers read values from this single file, never hardcoded. Consumers: Phase 2b admission gate (#507b) and Phase 3 apply path (#508).",
+  "_schema_version": 1,
+  "org_wide": {
+    "automation_open_pr_cap": 18,
+    "_note": "Soft cap on concurrent open, non-draft automation PRs org-wide, counting only non-Dependabot sources (ADR §6, §7.4). Range proposed in ADR §6 is ~15-20."
+  },
+  "_per_source_caps_note": "Optional per-source sub-caps (ADR §6). Complementary to the org-wide cap. Dependabot is intentionally absent — it stays governed solely by its own ecosystem open-pull-requests-limit (ADR §7.4). Kept as a clean name->integer map so consumers can read values directly.",
+  "per_source_caps": {
+    "dev-lead": 9,
+    "claude": 4,
+    "initiative-driver": 5
+  },
+  "exempt_actors": [
+    "dependabot[bot]",
+    "OrganizationAdmin",
+    "@petry-projects/org-leads",
+    "dependabot-automerge-petry"
+  ],
+  "exempt_labels": [
+    "security"
+  ],
+  "_exempt_note": "Actors/labels whose PRs must never be blocked by the cap (ADR §6, §7.4). dependabot[bot] is exempt because it is already bounded per-ecosystem and security PRs must never be starved; OrganizationAdmin / @petry-projects/org-leads are human break-glass and maintainer PRs; dependabot-automerge-petry operates on existing PRs (does not add to the queue); security-labeled PRs are urgent fixes that bypass any throttle."
+}

--- a/test/scripts/pr-limits/pr-limits-config.bats
+++ b/test/scripts/pr-limits/pr-limits-config.bats
@@ -49,7 +49,7 @@ CONFIG="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)/standards/pr-limits.json"
 }
 
 @test "all required top-level keys exist" {
-  for key in status _note org_wide per_source_caps exempt_actors; do
+  for key in status _note _schema_version org_wide per_source_caps exempt_actors exempt_labels; do
     run jq -e "has(\"$key\")" "$CONFIG"
     [ "$status" -eq 0 ]
     [ "$output" = "true" ]
@@ -86,4 +86,19 @@ CONFIG="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)/standards/pr-limits.json"
   run jq -e '.exempt_actors | index("dependabot[bot]") != null' "$CONFIG"
   [ "$status" -eq 0 ]
   [ "$output" = "true" ]
+}
+
+@test "security is present in the exempt-label list (ADR §6/§7.4)" {
+  # Guards the ADR safety property that urgent security/hotfix PRs are never
+  # throttled by the cap; a regression dropping this label must fail CI.
+  run jq -e '.exempt_labels | index("security") != null' "$CONFIG"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+}
+
+@test "_schema_version is a positive integer" {
+  run jq -er '._schema_version' "$CONFIG"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^[0-9]+$ ]]
+  [ "$output" -gt 0 ]
 }

--- a/test/scripts/pr-limits/pr-limits-config.bats
+++ b/test/scripts/pr-limits/pr-limits-config.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+# Tests for standards/pr-limits.json — the machine-readable single source of
+# truth for the PR-limit caps and exempt-actor list (#507).
+#
+# Context (#507, ADR docs/initiatives/pull-request-limits-adr.md):
+# GitHub exposes no native "max open PRs" repo/org/ruleset surface (ADR §2–§3),
+# so the limit lives as source-side shared config consumed by the Phase 2b
+# admission gate (#507b) and the Phase 3 apply path (#508). This story delivers
+# only the data file. Per ADR §6 every number is provisional pending human
+# sign-off; per ADR §7.4 dependabot[bot] is exempt (it stays governed solely by
+# its own ecosystem open-pull-requests-limit, so the new cap counts only
+# non-Dependabot automation).
+#
+# These tests validate the contract every consumer relies on: the file parses
+# as JSON, the org-wide cap is a positive integer, all required keys exist, the
+# numbers are flagged provisional, and dependabot[bot] is on the exempt list.
+
+bats_require_minimum_version 1.5.0
+
+CONFIG="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)/standards/pr-limits.json"
+
+@test "config file exists" {
+  [ -f "$CONFIG" ]
+}
+
+@test "config parses as valid JSON" {
+  run jq -e . "$CONFIG"
+  [ "$status" -eq 0 ]
+}
+
+@test "status field marks the values provisional (pending human sign-off)" {
+  run jq -er '.status' "$CONFIG"
+  [ "$status" -eq 0 ]
+  [ "$output" = "provisional" ]
+}
+
+@test "an inline _note documents that the numbers are not yet confirmed" {
+  run jq -er '._note' "$CONFIG"
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+}
+
+@test "org-wide automation open-PR cap is a positive integer" {
+  run jq -er '.org_wide.automation_open_pr_cap' "$CONFIG"
+  [ "$status" -eq 0 ]
+  # integer (no decimal point) and strictly greater than zero
+  [[ "$output" =~ ^[0-9]+$ ]]
+  [ "$output" -gt 0 ]
+}
+
+@test "all required top-level keys exist" {
+  for key in status _note org_wide per_source_caps exempt_actors; do
+    run jq -e "has(\"$key\")" "$CONFIG"
+    [ "$status" -eq 0 ]
+    [ "$output" = "true" ]
+  done
+}
+
+@test "per-source sub-caps cover dev-lead, claude, and initiative-driver" {
+  for src in dev-lead claude initiative-driver; do
+    run jq -e ".per_source_caps | has(\"$src\")" "$CONFIG"
+    [ "$status" -eq 0 ]
+    [ "$output" = "true" ]
+  done
+}
+
+@test "each per-source sub-cap is a positive integer" {
+  run jq -er '.per_source_caps | to_entries[] | .value' "$CONFIG"
+  [ "$status" -eq 0 ]
+  while read -r v; do
+    [[ "$v" =~ ^[0-9]+$ ]]
+    [ "$v" -gt 0 ]
+  done <<< "$output"
+}
+
+@test "exempt_actors is a non-empty array" {
+  run jq -er '.exempt_actors | type' "$CONFIG"
+  [ "$status" -eq 0 ]
+  [ "$output" = "array" ]
+  run jq -er '.exempt_actors | length' "$CONFIG"
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
+}
+
+@test "dependabot[bot] is present in the exempt-actor list (ADR §7.4)" {
+  run jq -e '.exempt_actors | index("dependabot[bot]") != null' "$CONFIG"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+}


### PR DESCRIPTION
Closes #507

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared configuration for pull-request limit rules, including overall caps, per-source limits, and exemption settings.
  * Introduced automated checks to validate that the configuration stays well-formed and complete.
* **Chores**
  * Added a GitHub Actions workflow to run the PR-limits validation tests on relevant changes and on updates to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->