### PR TITLE
chore(standards): add canonical ci.yml + sonarcloud.yml inline workflow templates (#966)

### DIFF
--- a/standards/workflows/ci.yml
+++ b/standards/workflows/ci.yml
@@ -1,0 +1,53 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/ci.yml
+# Standard:        petry-projects/.github/standards/ci-standards.md#1-ci-pipeline-ciyml
+#
+# ADOPTING THIS WORKFLOW:
+#   1. This ships verbatim into repos created from petry-projects/repo-template.
+#   2. It is a CUSTOMIZE-PER-STACK stub: it passes out of the box so a fresh repo
+#      is green on day 0. Replace the placeholder step with your stack's
+#      lint / format / typecheck / unit-test / coverage steps (see the standard).
+#   3. The job name `build-and-test` is the required CI status check. Keep it — or,
+#      if you split into per-language jobs (e.g. TypeScript, Go, Python), update the
+#      repo's branch-protection required checks to match the new job names.
+#
+# CONVENTIONS (enforced by the standard):
+#   • permissions: {} at top, least-privilege per job (CI needs contents: read)
+#   • triggers: push + pull_request to main
+#   • concurrency keyed by ref+sha so a new push cancels the stale run
+#   • SHA-pin every third-party action (never a tag/branch)
+# ─────────────────────────────────────────────────────────────────────────────
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: build-and-test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # ── Replace the step below with your stack's checks ───────────────────────
+      # Standard CI stages: lint, format check, type check, unit tests, coverage
+      # (plus integration / e2e / build where applicable). For example, a Node repo:
+      #   - uses: actions/setup-node@<sha> # vX   (with node-version + cache)
+      #   - run: npm ci
+      #   - run: npm run lint && npm run typecheck && npm test
+      # See BOOTSTRAP.md and the CI standard. Until you add real steps, the
+      # placeholder below keeps the required `build-and-test` check green.
+      - name: Placeholder — replace with real build/test steps
+        run: echo "CI stub — add your stack's lint/format/typecheck/test/coverage steps; see BOOTSTRAP.md."

--- a/standards/workflows/sonarcloud.yml
+++ b/standards/workflows/sonarcloud.yml
@@ -43,9 +43,9 @@ jobs:
           fetch-depth: 0
       - name: SonarCloud Scan
         id: sonar
-        if: ${{ env.SONAR_TOKEN != '' }}
+        if: env.SONAR_TOKEN != ''
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
         continue-on-error: true
       - name: SonarCloud Scan (retry)
-        if: ${{ env.SONAR_TOKEN != '' && steps.sonar.outcome == 'failure' }}
+        if: env.SONAR_TOKEN != '' && steps.sonar.outcome == 'failure'
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0

--- a/standards/workflows/sonarcloud.yml
+++ b/standards/workflows/sonarcloud.yml
@@ -1,0 +1,51 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/sonarcloud.yml
+# Standard:        petry-projects/.github/standards/ci-standards.md#3-sonarcloud-analysis
+#
+# ADOPTING THIS WORKFLOW:
+#   1. This ships verbatim into repos created from petry-projects/repo-template.
+#   2. Set sonar.projectKey / sonar.organization in sonar-project.properties to
+#      match your repo (see BOOTSTRAP.md), and add the SONAR_TOKEN repo secret.
+#   3. The job name `SonarCloud` is the required status check — keep it.
+#   4. The scan is guarded on SONAR_TOKEN, so the job is a green no-op until the
+#      secret is set — a fresh repo is not blocked on day 0.
+#
+# CONVENTIONS (enforced by the standard):
+#   • permissions: {} at top, least-privilege per job (contents + pull-requests: read)
+#   • triggers: push + pull_request to main; checkout with fetch-depth: 0
+#   • first scan is continue-on-error with a single retry (SonarCloud's analysis
+#     endpoint is occasionally flaky)
+#   • SHA-pin every third-party action (never a tag/branch)
+# ─────────────────────────────────────────────────────────────────────────────
+name: SonarCloud Analysis
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: SonarCloud Scan
+        id: sonar
+        if: ${{ env.SONAR_TOKEN != '' }}
+        uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
+        continue-on-error: true
+      - name: SonarCloud Scan (retry)
+        if: ${{ env.SONAR_TOKEN != '' && steps.sonar.outcome == 'failure' }}
+        uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0


### PR DESCRIPTION
## What

Adds two canonical inline workflow templates to `standards/workflows/`:

- **`ci.yml`** — stack-agnostic, customize-per-stack CI stub (job `build-and-test`, passes out of the box so a fresh repo is green on day 0; documented placeholder to replace with the stack's lint/format/typecheck/test/coverage steps).
- **`sonarcloud.yml`** — standard SonarCloud Analysis workflow (job name `SonarCloud`, `continue-on-error` first attempt + single retry, guarded on `SONAR_TOKEN`).

Both follow the existing inline-standard conventions (the `copilot-setup-steps.yml` banner style), `permissions: {}` + least-privilege per job, triggers on push/PR to `main`, and **SHA-pinned actions verified via the API** (`actions/checkout@de0fac2e… # v6.0.2`, `SonarSource/sonarqube-scan-action@713881670… # v8.2.0`).

## Why

`scripts/seed-repo-template.sh` in `.github-private` (epic #964, story #966) classifies `ci`/`sonarcloud` as `kind=inline` and **fetches them from `standards/workflows/`** to ship verbatim into `repo-template`. Those two files never existed here, so a live seed run 404'd and could not populate the template. The seeder's bats tests mocked the fetch, so they missed it. This adds the missing canonical sources (the chosen fix: keep inline workflows in `standards/`, not embedded in the script).

A companion PR in `.github-private` fixes a second seeder defect (Dependabot stack path/default) and closes the test gap.

## Validation

- yamllint passes under the exact config this repo's CI uses (`line-length: 200`, `document-start: disable`, `truthy.check-keys: false`).
- End-to-end: the fixed seeder, pointed at a mirror of the live `standards/` + these two files, emits all 10 workflow stubs + 10 baseline files with zero fetch errors; inline files ship byte-identically.

Refs #966, epic #964.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated CI checks for pushes and pull requests to the main branch.
  * Added code quality analysis with a SonarCloud workflow, including a retry if the first scan fails.

* **Security**
  * Tightened workflow permissions to follow least-privilege access.
  * Improved supply-chain safety by using pinned action versions.

* **Chores**
  * Enabled cancellation of older in-progress workflow runs when newer changes are pushed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->