### PR TITLE
docs+ci: inline S7635 NOSONAR marker for idea-pipeline caller stubs

### DIFF
--- a/.github/workflows/initiative-planner.yml
+++ b/.github/workflows/initiative-planner.yml
@@ -50,4 +50,4 @@ jobs:
     # Mirrors add-to-project.yml / pr-review-mention.yml; local refs also avoid the
     # SHA-pin security finding a remote tag ref raises on the hosting repo.
     uses: ./.github/workflows/initiative-planner-reusable.yml
-    secrets: inherit
+    secrets: inherit  # NOSONAR(githubactions:S7635) first-party trusted reusable

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pr-565",
+  "name": "pr-567",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -1167,13 +1167,15 @@ Where a planner-created epic lands depends on the repo:
 #### Adopting in a new repo
 
 1. Copy [`standards/workflows/initiative-planner.yml`](workflows/initiative-planner.yml)
-   and [`initiative-driver.yml`](workflows/initiative-driver.yml) to
-   `.github/workflows/` (and, optionally, `idea-triage.yml`) in the target repo.
-   Copy **verbatim** — the templates carry the inline
+   and [`standards/workflows/initiative-driver.yml`](workflows/initiative-driver.yml)
+   to `.github/workflows/` (and, optionally,
+   [`standards/workflows/idea-triage.yml`](workflows/idea-triage.yml) and
+   [`standards/workflows/idea-enhancer.yml`](workflows/idea-enhancer.yml)) in the
+   target repo. Copy **verbatim** — the templates carry the inline
    `# NOSONAR(githubactions:S7637)` and `# NOSONAR(githubactions:S7635)` markers,
    so a SonarCloud-gated repo needs **no** `sonar-project.properties` edits (see
    [SonarCloud Exemption: First-Party Reusable-Ref S7637](#sonarcloud-exemption-first-party-reusable-ref-s7637)
-   and the `secrets: inherit` S7635 note that follows it).
+   and [First-Party `secrets: inherit` S7635](#sonarcloud-exemption-first-party-secrets-inherit-s7635)).
 2. Ensure Discussions is enabled with an "Ideas" category, and **create the gate
    labels** the pipeline relies on. The driver's `initiative:auto` gate **cannot be
    armed if its label is missing** (the driver pilot hit exactly this — see #888),

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -494,8 +494,7 @@ when the legacy exemption uses a blanket workflow-path `resourceKey`.
 SonarCloud's rule **`githubactions:S7635`** ("only pass required secrets to this
 workflow") fires on the **`secrets: inherit`** line of a first-party caller stub.
 Caller stubs pass `secrets: inherit` **by design** so the central reusable
-receives every secret it needs (e.g. `GH_PAT_WORKFLOWS` + `CLAUDE_CODE_OAUTH_TOKEN`
-+ more) without each caller enumerating — and re-enumerating on every reusable
+receives every secret it needs (e.g. `GH_PAT_WORKFLOWS` + `CLAUDE_CODE_OAUTH_TOKEN` + more) without each caller enumerating — and re-enumerating on every reusable
 change. The reusable is **first-party and fully trusted**, the same trust boundary
 that exempts the channel ref from S7637 above.
 

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -489,6 +489,43 @@ exemption is present. It files `sonar-s7637-exemption-missing` (warning) when a
 SonarCloud-gated repo has neither, and `sonar-s7637-exemption-too-broad` (error)
 when the legacy exemption uses a blanket workflow-path `resourceKey`.
 
+#### SonarCloud Exemption: First-Party `secrets: inherit` S7635
+
+SonarCloud's rule **`githubactions:S7635`** ("only pass required secrets to this
+workflow") fires on the **`secrets: inherit`** line of a first-party caller stub.
+Caller stubs pass `secrets: inherit` **by design** so the central reusable
+receives every secret it needs (e.g. `GH_PAT_WORKFLOWS` + `CLAUDE_CODE_OAUTH_TOKEN`
++ more) without each caller enumerating — and re-enumerating on every reusable
+change. The reusable is **first-party and fully trusted**, the same trust boundary
+that exempts the channel ref from S7637 above.
+
+**Standard (canonical — inline NOSONAR on the `secrets:` line):** every
+first-party caller stub that uses `secrets: inherit` MUST carry an inline
+`# NOSONAR(githubactions:S7635)` marker on that line, e.g.:
+
+```yaml
+jobs:
+  idea-triage:
+    uses: petry-projects/.github/.github/workflows/idea-triage-reusable.yml@idea-triage/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    secrets: inherit  # NOSONAR(githubactions:S7635) first-party trusted reusable
+```
+
+Like the S7637 marker, SonarCloud suppresses S7635 on exactly that line, so the
+exemption travels **with the stub file** — verbatim adopters inherit it with
+**zero** per-repo `sonar-project.properties` entries. The grandfathered existing
+deployments pass because they are not "new code"; the rule only bites a stub the
+first time it is **added** to a SonarCloud-gated repo. (The legacy per-file
+`sonar.issue.ignore.multicriteria` mechanism with `ruleKey=githubactions:S7635`
+also works and is accepted during transition, but the inline marker is canonical.)
+
+Caller-stub templates that use `secrets: inherit` and therefore carry the S7635
+marker: `initiative-planner.yml`, `idea-triage.yml`, `idea-enhancer.yml`.
+**Pending:** `dev-lead.yml`, `auto-rebase.yml`, `dependabot-automerge.yml`, and
+`pr-review-mention.yml` also use `secrets: inherit` but do not yet carry the
+marker; because they are already deployed fleet-wide (so re-syncing them fans out
+broadly) the marker is being added to them under a separate rollout — until then a
+**new** adoption of one of those four needs the legacy per-file S7635 exemption.
+
 ### 4. Secret Scanning (`ci.yml` — gitleaks job)
 
 Secret detection via the gitleaks action. This job **must be added to the CI pipeline**
@@ -1131,8 +1168,13 @@ Where a planner-created epic lands depends on the repo:
 #### Adopting in a new repo
 
 1. Copy [`standards/workflows/initiative-planner.yml`](workflows/initiative-planner.yml)
-   to `.github/workflows/initiative-planner.yml` (and, optionally,
-   `idea-triage.yml`) in the target repo.
+   and [`initiative-driver.yml`](workflows/initiative-driver.yml) to
+   `.github/workflows/` (and, optionally, `idea-triage.yml`) in the target repo.
+   Copy **verbatim** — the templates carry the inline
+   `# NOSONAR(githubactions:S7637)` and `# NOSONAR(githubactions:S7635)` markers,
+   so a SonarCloud-gated repo needs **no** `sonar-project.properties` edits (see
+   [SonarCloud Exemption: First-Party Reusable-Ref S7637](#sonarcloud-exemption-first-party-reusable-ref-s7637)
+   and the `secrets: inherit` S7635 note that follows it).
 2. Ensure Discussions is enabled with an "Ideas" category, and **create the gate
    labels** the pipeline relies on. The driver's `initiative:auto` gate **cannot be
    armed if its label is missing** (the driver pilot hit exactly this — see #888),

--- a/standards/workflows/idea-enhancer.yml
+++ b/standards/workflows/idea-enhancer.yml
@@ -46,4 +46,4 @@ permissions: {}
 jobs:
   idea-enhancer:
     uses: petry-projects/.github/.github/workflows/idea-enhancer-reusable.yml@idea-enhancer/stable  # NOSONAR(githubactions:S7637) first-party channel ref
-    secrets: inherit
+    secrets: inherit  # NOSONAR(githubactions:S7635) first-party trusted reusable

--- a/standards/workflows/idea-triage.yml
+++ b/standards/workflows/idea-triage.yml
@@ -43,4 +43,4 @@ permissions: {}
 jobs:
   idea-triage:
     uses: petry-projects/.github/.github/workflows/idea-triage-reusable.yml@idea-triage/stable  # NOSONAR(githubactions:S7637) first-party channel ref
-    secrets: inherit
+    secrets: inherit  # NOSONAR(githubactions:S7635) first-party trusted reusable

--- a/standards/workflows/initiative-planner.yml
+++ b/standards/workflows/initiative-planner.yml
@@ -45,4 +45,4 @@ permissions: {}
 jobs:
   initiative-planner:
     uses: petry-projects/.github/.github/workflows/initiative-planner-reusable.yml@initiative-planner/stable  # NOSONAR(githubactions:S7637) first-party channel ref
-    secrets: inherit
+    secrets: inherit  # NOSONAR(githubactions:S7635) first-party trusted reusable


### PR DESCRIPTION
Closes the SonarCloud **S7635** gap surfaced by the ring1 idea→initiative enrollment (petry-projects/.github-private#978, gate #515). Companion to the ring1 PRs (TalkTerm #331, bmad #342).

## Problem
`githubactions:S7635` ("only pass required secrets to this workflow") fires on the **`secrets: inherit`** line of first-party caller stubs. `secrets: inherit` is intentional — the central reusable is first-party/trusted and needs every inherited secret (`GH_PAT_WORKFLOWS`, `CLAUDE_CODE_OAUTH_TOKEN`, …); enumerating per-caller re-breaks on every reusable change. Existing deployments pass as non-"new code", so the rule only bites the **first time a stub is added** to a SonarCloud-gated repo — exactly what ring1 hit. The templates only carried the S7637 marker, so the auto-fix bot tried to "fix" S7635 by mangling the stubs.

## Fix (canonical mechanism)
Per the existing [S7637 exemption](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#sonarcloud-exemption-first-party-reusable-ref-s7637), the canonical suppression is an **inline `# NOSONAR` marker that travels with the verbatim stub** — zero per-repo `sonar-project.properties` entries. This adds that for S7635:

- `standards/workflows/initiative-planner.yml`, `idea-triage.yml`, `idea-enhancer.yml` — the three idea-pipeline templates that use `secrets: inherit` — get `secrets: inherit  # NOSONAR(githubactions:S7635) first-party trusted reusable`.
- This repo's own dogfooded `.github/workflows/initiative-planner.yml` stub gets the same.
- New **"First-Party `secrets: inherit` S7635"** subsection in ci-standards (S7637 anchor preserved so existing links keep working); §10 adoption step 1 points at it and notes verbatim copy needs no sonar edits.

## Blast radius
Deployed stub consumers of these 3 templates on `main`: only this repo's own `initiative-planner.yml` (updated here). `.github-private` uses the full host workflow (not a stub). So **no external stub-drift** — the open ring1 PRs will be re-synced to match.

## Deferred (tracked follow-up)
`dev-lead.yml`, `auto-rebase.yml`, `dependabot-automerge.yml`, `pr-review-mention.yml` also use `secrets: inherit` and share the latent gap, but are deployed fleet-wide — marking them fans out a broad re-sync. Until then a **new** adoption of one of those four needs the legacy per-file S7635 exemption (documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer guidance for setting up initiative-planning workflows, including which templates to copy and how compliance markers should appear.
  * Documented the approved inline exemption format for trusted reusable workflow calls.

* **Chores**
  * Updated several workflow templates to consistently include the required inline compliance marker while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->