### PR TITLE
feat(pr-limits): sign off cap at 50 as a single org-wide soft ceiling

### DIFF
--- a/standards/pr-limits.json
+++ b/standards/pr-limits.json
@@ -1,17 +1,13 @@
 {
-  "status": "provisional",
-  "_note": "PROVISIONAL — pending human sign-off (ADR docs/initiatives/pull-request-limits-adr.md §6). Every numeric value below is a proposal anchored to the §5 baseline, NOT a GitHub-imposed maximum (none exists; see ADR §2-§3). The confirmed numbers can be set here later without a code change — consumers read values from this single file, never hardcoded. Consumers: Phase 2b admission gate (#507b) and Phase 3 apply path (#508).",
+  "status": "signed-off",
+  "_note": "Human sign-off 2026-07-01 (epic #505 gate #566): the policy is a SINGLE org-wide soft ceiling of 50 concurrent open, non-draft automation PRs — no per-source sub-caps. 50 sits just above the ADR §5 baseline (~47 open, ~34 non-Dependabot automation), so it caps runaway growth without refusing any PR today. Counts only non-Dependabot automation (ADR §7.4). No native GitHub PR-count surface exists (ADR §2-§3); enforced source-side by scripts/lib/pr-limit-gate.sh. Consumers read values from this single file, never hardcoded.",
   "_schema_version": 1,
   "org_wide": {
-    "automation_open_pr_cap": 18,
-    "_note": "Soft cap on concurrent open, non-draft automation PRs org-wide, counting only non-Dependabot sources (ADR §6, §7.4). Range proposed in ADR §6 is ~15-20."
+    "automation_open_pr_cap": 50,
+    "_note": "Signed-off soft cap (2026-07-01) on concurrent open, non-draft automation PRs org-wide, counting only non-Dependabot sources (ADR §6, §7.4). Set above the ~47 baseline to bound runaway growth without blocking current traffic."
   },
-  "_per_source_caps_note": "Optional per-source sub-caps (ADR §6). Complementary to the org-wide cap. Dependabot is intentionally absent — it stays governed solely by its own ecosystem open-pull-requests-limit (ADR §7.4). Kept as a clean name->integer map so consumers can read values directly.",
-  "per_source_caps": {
-    "dev-lead": 9,
-    "claude": 4,
-    "initiative-driver": 5
-  },
+  "_per_source_caps_note": "Per-source sub-caps are intentionally UNUSED under the signed-off policy (2026-07-01): a single org-wide ceiling of 50, not per-source throttles (a dev-lead sub-cap below its current ~30 open PRs would have blocked it immediately). Left as an empty map; ADR §6 made per-source caps optional/complementary, and a consumer applies a sub-cap only when one is present here.",
+  "per_source_caps": {},
   "exempt_actors": [
     "dependabot[bot]",
     "OrganizationAdmin",

--- a/test/scripts/pr-limits/pr-limits-config.bats
+++ b/test/scripts/pr-limits/pr-limits-config.bats
@@ -29,12 +29,11 @@ CONFIG="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)/standards/pr-limits.json"
 }
 
 @test "status field records the human sign-off state" {
-  # After the epic #505 gate #566 sign-off (2026-07-01) the numbers are
-  # human-confirmed. Accept either state so the test is stable across the
-  # provisional -> signed-off transition.
+  # The epic #505 gate #566 sign-off (2026-07-01) is complete, so strictly
+  # assert signed-off — a regression back to provisional must fail CI.
   run jq -er '.status' "$CONFIG"
   [ "$status" -eq 0 ]
-  [[ "$output" = "signed-off" || "$output" = "provisional" ]]
+  [ "$output" = "signed-off" ]
 }
 
 @test "an inline _note documents that the numbers are not yet confirmed" {

--- a/test/scripts/pr-limits/pr-limits-config.bats
+++ b/test/scripts/pr-limits/pr-limits-config.bats
@@ -28,10 +28,13 @@ CONFIG="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)/standards/pr-limits.json"
   [ "$status" -eq 0 ]
 }
 
-@test "status field marks the values provisional (pending human sign-off)" {
+@test "status field records the human sign-off state" {
+  # After the epic #505 gate #566 sign-off (2026-07-01) the numbers are
+  # human-confirmed. Accept either state so the test is stable across the
+  # provisional -> signed-off transition.
   run jq -er '.status' "$CONFIG"
   [ "$status" -eq 0 ]
-  [ "$output" = "provisional" ]
+  [[ "$output" = "signed-off" || "$output" = "provisional" ]]
 }
 
 @test "an inline _note documents that the numbers are not yet confirmed" {
@@ -56,21 +59,21 @@ CONFIG="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)/standards/pr-limits.json"
   done
 }
 
-@test "per-source sub-caps cover dev-lead, claude, and initiative-driver" {
-  for src in dev-lead claude initiative-driver; do
-    run jq -e ".per_source_caps | has(\"$src\")" "$CONFIG"
-    [ "$status" -eq 0 ]
-    [ "$output" = "true" ]
-  done
+@test "per_source_caps is an object (single org-wide ceiling — may be empty)" {
+  # The signed-off policy (2026-07-01) is a single org-wide soft ceiling, so
+  # per-source sub-caps are optional and currently empty. The key must still
+  # exist and be an object so consumers can read it uniformly.
+  run jq -er '.per_source_caps | type' "$CONFIG"
+  [ "$status" -eq 0 ]
+  [ "$output" = "object" ]
 }
 
-@test "each per-source sub-cap is a positive integer" {
-  run jq -er '.per_source_caps | to_entries[] | .value' "$CONFIG"
+@test "any configured per-source sub-cap is a positive integer" {
+  # Per-source caps are optional; validate only those present. `all` over an
+  # empty map is vacuously true, so this passes when none are configured.
+  run jq -e '(.per_source_caps // {}) | to_entries | all(.value | (type == "number") and (. > 0) and (. == floor))' "$CONFIG"
   [ "$status" -eq 0 ]
-  while read -r v; do
-    [[ "$v" =~ ^[0-9]+$ ]]
-    [ "$v" -gt 0 ]
-  done <<< "$output"
+  [ "$output" = "true" ]
 }
 
 @test "exempt_actors is a non-empty array" {


### PR DESCRIPTION
Implements the epic #505 human sign-off (gate #566): org-wide automation open-PR cap = **50**, single soft ceiling, per-source sub-caps dropped.

## What changed
- `standards/pr-limits.json`: `automation_open_pr_cap` 18 → **50**; `per_source_caps` → `{}`; `status` → `signed-off`.
- Tests: status marker accepts `signed-off`; per-source-cap assertions treat sub-caps as optional (empty is valid).

## Why 50 / why drop per-source
50 sits just above the ADR §5 baseline (~47 open, ~34 non-Dependabot automation), so it caps runaway growth **without refusing any PR today**. A per-source dev-lead cap of 9 would have immediately blocked dev-lead (currently ~30 open PRs) — the opposite of raising the cap — so the signed-off policy is a single org-wide ceiling.

## Still inert
Nothing calls `plg_admission_gate` yet. Enforcement wiring (the Phase 3 apply path) is tracked separately in `.github-private` per the sign-off decision. This PR only updates the signed-off config value.

Closes part of the #566 sign-off (caps + exempt list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)