### PR TITLE
feat(pr-limits): add the no-LLM success-metric report (#510)

### DIFF
--- a/.github/workflows/pr-limits-report-tests.yml
+++ b/.github/workflows/pr-limits-report-tests.yml
@@ -1,0 +1,68 @@
+# Quality gate for the no-LLM PR-limits success-metric report (#510) and its
+# validating bats tests.
+#
+# Triggered on any PR that touches:
+#   - scripts/pr-limits-report.sh
+#   - test/scripts/pr-limits/**
+#   - .github/workflows/pr-limits-report.yml
+#   - .github/workflows/pr-limits-report-tests.yml
+#
+# Gates (all must pass before merge):
+#   1. shellcheck — static analysis for the report script
+#   2. bats       — unit tests for the report's counting + status logic
+#
+# Context: ADR docs/initiatives/pull-request-limits-adr.md; the report reuses the
+# admission-gate counting semantics (scripts/lib/pr-limit-gate.sh, #561) so the
+# two agree. Modeled on .github/workflows/auto-rebase-tests.yml.
+
+name: PR-limits Report Tests
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/pr-limits-report.sh'
+      - 'test/scripts/pr-limits/**'
+      - '.github/workflows/pr-limits-report.yml'
+      - '.github/workflows/pr-limits-report-tests.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'scripts/pr-limits-report.sh'
+      - 'test/scripts/pr-limits/**'
+      - '.github/workflows/pr-limits-report.yml'
+      - '.github/workflows/pr-limits-report-tests.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-limits-report-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Lint and bats
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          # Read-only test job — never pushes; don't leave the token in git config.
+          persist-credentials: false
+
+      - name: Install bats, shellcheck, and jq
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends bats shellcheck jq
+
+      - name: shellcheck
+        run: |
+          set -euo pipefail
+          shellcheck --severity=warning -x scripts/pr-limits-report.sh
+
+      - name: Run bats suite
+        run: bats --print-output-on-failure test/scripts/pr-limits/pr-limits-report.bats

--- a/.github/workflows/pr-limits-report.yml
+++ b/.github/workflows/pr-limits-report.yml
@@ -1,0 +1,51 @@
+name: PR-limits Report
+
+# No-LLM PR-limits success-metric report (#510, epic #505 Story 5).
+#
+# Pure `gh` + `jq` (NO LLM / agent): enumerates open, non-draft, automation
+# PRs org-wide and compares the count against the signed-off cap in
+# standards/pr-limits.json, using the SAME counting semantics as the admission
+# gate (scripts/lib/pr-limit-gate.sh) so the report and the gate agree. Writes a
+# Markdown summary to the job summary. Runs at most once daily plus manual
+# dispatch. Modeled on daily-org-status.yml.
+
+on:
+  schedule:
+    - cron: '0 12 * * *'   # once daily, 07:00 CDT (UTC-5)
+  workflow_dispatch:         # allow manual trigger from the Actions tab
+
+permissions: {}              # no default permissions; the job grants only what it needs
+
+concurrency:
+  group: pr-limits-report-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  report:
+    name: Measure open automation PRs vs. cap
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read           # checkout + read standards/pr-limits.json
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          # Read-only job — never pushes; don't leave the token in git config.
+          persist-credentials: false
+
+      - name: Ensure jq is available
+        run: |
+          set -euo pipefail
+          if ! command -v jq >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends jq
+          fi
+
+      - name: Generate PR-limits report
+        env:
+          # `gh search prs` needs a token; github.token has the read scope it needs.
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/pr-limits-report.sh

--- a/scripts/pr-limits-report.sh
+++ b/scripts/pr-limits-report.sh
@@ -52,15 +52,30 @@ EXEMPT_ACTORS="$(jq -c '.exempt_actors // []' "$CONFIG" 2>/dev/null || echo '[]'
 EXEMPT_LABELS="$(jq -c '.exempt_labels // []' "$CONFIG" 2>/dev/null || echo '[]')"
 
 # ── Enumerate open, non-draft PRs org-wide (same idiom as the admission gate) ──
+# Distinguish a real `gh` failure from a genuinely-empty queue. Unlike the
+# admission gate (which fails OPEN so PR creation is never wedged), a scheduled
+# report must fail LOUDLY when it cannot measure — otherwise a transient API
+# error masquerades as a misleading "🟢 Under cap 0/cap" result.
+gh_rc=0
 PRS="$(gh search prs \
   --owner "$ORG" \
   --state open \
   --draft=false \
   --limit 1000 \
   --json author,labels,repository,title,url \
-  2>/dev/null || true)"
+  2>/dev/null)" || gh_rc=$?
 
-# Robust to an empty / failed enumeration: treat as an empty array, report 0.
+if [ "$gh_rc" -ne 0 ]; then
+  UNAVAILABLE="$(printf '## PR-limits report — %s\n\n> ⚠️ **Metric unavailable** — `gh search prs` failed (rc=%s); the open-PR queue could not be enumerated. No cap comparison was produced.\n' "$ORG" "$gh_rc")"
+  printf '%s\n' "$UNAVAILABLE"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    printf '%s\n' "$UNAVAILABLE" >>"$GITHUB_STEP_SUMMARY"
+  fi
+  exit 1
+fi
+
+# rc 0: a genuinely empty result is a real "0 open PRs". Keep the unparseable-JSON
+# guard as a secondary safety net (rc 0 but garbage stdout).
 if [ -z "$PRS" ]; then
   PRS='[]'
 fi

--- a/scripts/pr-limits-report.sh
+++ b/scripts/pr-limits-report.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# scripts/pr-limits-report.sh — No-LLM PR-limits success-metric report (#510).
+#
+# Measures the epic #505 success metric for the source-side PR-limit: how the
+# count of open, non-draft, automation-authored PRs org-wide compares to the
+# signed-off cap in standards/pr-limits.json. This is a pure `gh` + `jq` report
+# (NO LLM / agent): it enumerates the standing PR queue, applies the SAME
+# counting semantics as the admission gate (scripts/lib/pr-limit-gate.sh) so the
+# report and the gate always agree, and prints a Markdown summary.
+#
+# Counting semantics (must mirror scripts/lib/pr-limit-gate.sh §7.4):
+#   * enumerate open, non-draft PRs org-wide via `gh search prs`;
+#   * a PR counts toward the cap only when its author is NOT an exempt actor
+#     AND it carries NO exempt label;
+#   * exempt-actor and exempt-labeled PRs are shown in the total but excluded
+#     from the counted-toward-cap figure.
+#
+# Reads the cap + exempt lists from the single source of truth
+# (standards/pr-limits.json); nothing is hardcoded.
+#
+# Environment (all optional):
+#   ORG               — GitHub org slug to scope the search (default: petry-projects)
+#   PR_LIMITS_CONFIG  — path to pr-limits.json (default: <repo>/standards/pr-limits.json,
+#                       resolved relative to this script so it works from any CWD)
+#   GH_TOKEN / GITHUB_TOKEN — token for `gh search prs` (github.token in CI)
+#   GITHUB_STEP_SUMMARY — when set, the Markdown summary is ALSO appended there.
+#
+# Exit status: 0 on success (including an empty PR queue, reported as 0). A
+# non-zero exit only indicates a hard error (missing config, unparseable cap).
+
+set -euo pipefail
+
+# Resolve the config relative to this script so the report finds the org single
+# source of truth regardless of the caller's CWD.
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_CONFIG="${SCRIPT_DIR}/../standards/pr-limits.json"
+CONFIG="${PR_LIMITS_CONFIG:-$DEFAULT_CONFIG}"
+ORG="${ORG:-petry-projects}"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "pr-limits-report: error: config not found at $CONFIG" >&2
+  exit 1
+fi
+
+# ── Read the cap + exempt lists from the single source of truth ───────────────
+CAP="$(jq -er '.org_wide.automation_open_pr_cap' "$CONFIG" 2>/dev/null || printf '')"
+if ! [[ "$CAP" =~ ^[0-9]+$ ]]; then
+  echo "pr-limits-report: error: org_wide.automation_open_pr_cap missing or not an integer in $CONFIG" >&2
+  exit 1
+fi
+EXEMPT_ACTORS="$(jq -c '.exempt_actors // []' "$CONFIG" 2>/dev/null || echo '[]')"
+EXEMPT_LABELS="$(jq -c '.exempt_labels // []' "$CONFIG" 2>/dev/null || echo '[]')"
+
+# ── Enumerate open, non-draft PRs org-wide (same idiom as the admission gate) ──
+PRS="$(gh search prs \
+  --owner "$ORG" \
+  --state open \
+  --draft=false \
+  --limit 1000 \
+  --json author,labels,repository,title,url \
+  2>/dev/null || true)"
+
+# Robust to an empty / failed enumeration: treat as an empty array, report 0.
+if [ -z "$PRS" ]; then
+  PRS='[]'
+fi
+if ! jq -e . >/dev/null 2>&1 <<<"$PRS"; then
+  echo "pr-limits-report: warning: PR enumeration returned unparseable data — treating as empty" >&2
+  PRS='[]'
+fi
+
+# ── Compute the metrics with a single jq pass ─────────────────────────────────
+# `counted` uses exactly the gate's predicate: non-exempt author AND no exempt
+# label. `by_source` groups the counted PRs by author login for the breakdown.
+METRICS="$(jq -c \
+  --argjson exempt_actors "$EXEMPT_ACTORS" \
+  --argjson exempt_labels "$EXEMPT_LABELS" '
+  def is_exempt_actor: ((.author.login // "") as $a | ($exempt_actors | index($a)) != null);
+  def has_exempt_label: ([.labels[]?.name] | map(. as $n | $exempt_labels | index($n)) | any);
+  def counts_toward_cap: ((is_exempt_actor | not) and (has_exempt_label | not));
+  {
+    total: length,
+    counted: ([ .[] | select(counts_toward_cap) ] | length),
+    exempt: ([ .[] | select(counts_toward_cap | not) ] | length),
+    by_source: (
+      [ .[] | select(counts_toward_cap) | (.author.login // "unknown") ]
+      | group_by(.)
+      | map({ source: .[0], count: length })
+      | sort_by(-.count)
+    )
+  }
+' <<<"$PRS")"
+
+TOTAL="$(jq -r '.total' <<<"$METRICS")"
+COUNTED="$(jq -r '.counted' <<<"$METRICS")"
+EXEMPT="$(jq -r '.exempt' <<<"$METRICS")"
+HEADROOM=$(( CAP - COUNTED ))
+
+if [ "$COUNTED" -ge "$CAP" ]; then
+  STATUS_ICON="🔴"
+  STATUS_LINE="**AT OR OVER CAP** — ${COUNTED}/${CAP} counted automation PRs (headroom ${HEADROOM})."
+else
+  STATUS_ICON="🟢"
+  STATUS_LINE="**Under cap** — ${COUNTED}/${CAP} counted automation PRs (headroom ${HEADROOM})."
+fi
+
+# ── Render the Markdown summary ───────────────────────────────────────────────
+render_summary() {
+  printf '## PR-limits report — %s\n\n' "$ORG"
+  printf 'Success metric for epic #505: open non-draft automation PRs org-wide vs. the signed-off cap.\n'
+  printf 'Counting mirrors the admission gate (`scripts/lib/pr-limit-gate.sh`): a PR counts only when its author is not exempt and it carries no exempt label.\n\n'
+
+  printf '| Metric | Value |\n'
+  printf '| --- | --- |\n'
+  printf '| Open non-draft PRs (total) | %s |\n' "$TOTAL"
+  printf '| Counted toward cap | %s |\n' "$COUNTED"
+  printf '| Exempt (actor or label) | %s |\n' "$EXEMPT"
+  printf '| Cap | %s |\n' "$CAP"
+  printf '| Headroom (cap − counted) | %s |\n' "$HEADROOM"
+  printf '\n'
+
+  printf '%s %s\n\n' "$STATUS_ICON" "$STATUS_LINE"
+
+  printf '### Breakdown by source (counted PRs by author)\n\n'
+  if [ "$COUNTED" -eq 0 ]; then
+    printf '_No counted automation PRs._\n'
+  else
+    printf '| Source (author login) | Counted PRs |\n'
+    printf '| --- | --- |\n'
+    jq -r '.by_source[] | "| \(.source) | \(.count) |"' <<<"$METRICS"
+  fi
+  printf '\n'
+}
+
+SUMMARY="$(render_summary)"
+printf '%s\n' "$SUMMARY"
+
+# Mirror the daily-org-status pattern: also append to the job summary when set.
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  printf '%s\n' "$SUMMARY" >>"$GITHUB_STEP_SUMMARY"
+fi
+
+exit 0

--- a/test/scripts/pr-limits/pr-limits-report.bats
+++ b/test/scripts/pr-limits/pr-limits-report.bats
@@ -1,0 +1,189 @@
+#!/usr/bin/env bats
+# Tests for scripts/pr-limits-report.sh — the no-LLM PR-limits success-metric
+# report that measures open, non-draft, automation-authored PRs org-wide against
+# the signed-off cap in standards/pr-limits.json (#510, epic #505 Story 5).
+#
+# Context (ADR docs/initiatives/pull-request-limits-adr.md): the report reuses
+# the admission gate's counting semantics (scripts/lib/pr-limit-gate.sh §7.4) so
+# the two always agree — a PR counts toward the cap only when its author is not
+# an exempt actor AND it carries no exempt label. This report is pure gh + jq
+# (no LLM).
+#
+# `gh` is stubbed via the env-driven fake under
+# test/scripts/compliance-remediate/stubs/gh (no live API), so the metrics depend
+# only on the stubbed search payload + the config cap/exempt lists.
+
+bats_require_minimum_version 1.5.0
+
+SCRIPT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)/scripts/pr-limits-report.sh"
+GH_STUB_SRC="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)/scripts/compliance-remediate/stubs/gh"
+
+setup() {
+  TMP="$(mktemp -d)"
+  export TMP
+
+  # Put the env-driven gh stub on PATH and log every invocation so we can assert
+  # the report never issues a mutating gh subcommand (read-only search only).
+  mkdir -p "$TMP/bin"
+  cp "$GH_STUB_SRC" "$TMP/bin/gh"
+  chmod +x "$TMP/bin/gh"
+  PATH="$TMP/bin:$PATH"
+  export PATH
+  export GH_STUB_LOG="$TMP/gh.log"
+  : >"$GH_STUB_LOG"
+
+  export ORG="petry-projects"
+}
+
+teardown() {
+  if [ -n "${TMP:-}" ] && [ -d "$TMP" ]; then
+    rm -rf "$TMP"
+  fi
+}
+
+# Write a pr-limits config with the given org-wide cap and point
+# PR_LIMITS_CONFIG at it. Exempt lists mirror the real config.
+write_config() {
+  local org_cap="$1"
+  export PR_LIMITS_CONFIG="$TMP/pr-limits.json"
+  jq -n --argjson org_cap "$org_cap" '{
+    status: "provisional",
+    _schema_version: 1,
+    org_wide: { automation_open_pr_cap: $org_cap },
+    per_source_caps: {},
+    exempt_actors: ["dependabot[bot]"],
+    exempt_labels: ["security"]
+  }' >"$PR_LIMITS_CONFIG"
+}
+
+# Make the gh stub return a search payload of N open non-draft PRs, all authored
+# by a non-exempt actor with no exempt labels.
+stub_open_prs() {
+  local count="$1"
+  export GH_STUB_STDOUT
+  GH_STUB_STDOUT="$(jq -nc --argjson n "$count" \
+    '[range(0; $n) | { author: { login: "dev-lead-bot" }, labels: [], repository: { name: "r" }, title: "t", url: "u" }]')"
+}
+
+run_report() {
+  run bash "$SCRIPT"
+}
+
+# --------------------------------------------------------------------------
+# Under the cap -> "Under cap" with positive headroom
+# --------------------------------------------------------------------------
+@test "under the cap reports Under cap with positive headroom" {
+  write_config 10
+  stub_open_prs 4
+  run_report
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Under cap"* ]]
+  [[ "$output" == *"Counted toward cap | 4"* ]]
+  [[ "$output" == *"Headroom (cap − counted) | 6"* ]]
+}
+
+# --------------------------------------------------------------------------
+# At the cap -> "AT OR OVER CAP" with zero headroom
+# --------------------------------------------------------------------------
+@test "at the cap reports AT OR OVER CAP with zero headroom" {
+  write_config 5
+  stub_open_prs 5
+  run_report
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"AT OR OVER CAP"* ]]
+  [[ "$output" == *"Headroom (cap − counted) | 0"* ]]
+}
+
+# --------------------------------------------------------------------------
+# Over the cap -> "AT OR OVER CAP" with negative headroom
+# --------------------------------------------------------------------------
+@test "over the cap reports AT OR OVER CAP with negative headroom" {
+  write_config 3
+  stub_open_prs 7
+  run_report
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"AT OR OVER CAP"* ]]
+  [[ "$output" == *"Counted toward cap | 7"* ]]
+  [[ "$output" == *"Headroom (cap − counted) | -4"* ]]
+}
+
+# --------------------------------------------------------------------------
+# Exempt-actor and exempt-labeled PRs are excluded from the counted figure
+# but shown in the total (mirrors the admission gate, ADR §7.4).
+# --------------------------------------------------------------------------
+@test "exempt-actor and exempt-labeled PRs are excluded from the count" {
+  write_config 3
+  # 2 countable + 3 non-countable (1 exempt actor, 2 security-labeled) = 5 total,
+  # only 2 count -> under the cap of 3.
+  export GH_STUB_STDOUT
+  GH_STUB_STDOUT="$(jq -nc '[
+    { author: { login: "dev-lead-bot" },   labels: [],                    repository: { name: "a" }, title: "t", url: "u" },
+    { author: { login: "claude-bot" },     labels: [],                    repository: { name: "b" }, title: "t", url: "u" },
+    { author: { login: "dependabot[bot]" },labels: [],                    repository: { name: "c" }, title: "t", url: "u" },
+    { author: { login: "claude-bot" },     labels: [{ name: "security" }],repository: { name: "d" }, title: "t", url: "u" },
+    { author: { login: "claude-bot" },     labels: [{ name: "security" }],repository: { name: "e" }, title: "t", url: "u" }
+  ]')"
+  run_report
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Open non-draft PRs (total) | 5"* ]]
+  [[ "$output" == *"Counted toward cap | 2"* ]]
+  [[ "$output" == *"Exempt (actor or label) | 3"* ]]
+  [[ "$output" == *"Under cap"* ]]
+}
+
+# --------------------------------------------------------------------------
+# The by-source breakdown groups counted PRs by author login.
+# --------------------------------------------------------------------------
+@test "breakdown groups counted PRs by source author" {
+  write_config 10
+  export GH_STUB_STDOUT
+  GH_STUB_STDOUT="$(jq -nc '[
+    { author: { login: "dev-lead-bot" }, labels: [], repository: { name: "a" }, title: "t", url: "u" },
+    { author: { login: "dev-lead-bot" }, labels: [], repository: { name: "b" }, title: "t", url: "u" },
+    { author: { login: "claude-bot" },   labels: [], repository: { name: "c" }, title: "t", url: "u" }
+  ]')"
+  run_report
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"| dev-lead-bot | 2 |"* ]]
+  [[ "$output" == *"| claude-bot | 1 |"* ]]
+}
+
+# --------------------------------------------------------------------------
+# Robust to an empty PR queue: report 0, not an error.
+# --------------------------------------------------------------------------
+@test "empty PR queue reports zero under cap without error" {
+  write_config 50
+  export GH_STUB_STDOUT="[]"
+  run_report
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Open non-draft PRs (total) | 0"* ]]
+  [[ "$output" == *"Counted toward cap | 0"* ]]
+  [[ "$output" == *"Under cap"* ]]
+  [[ "$output" == *"No counted automation PRs"* ]]
+}
+
+# --------------------------------------------------------------------------
+# The report is read-only: never issues a mutating gh subcommand.
+# --------------------------------------------------------------------------
+@test "report issues only a read-only gh search" {
+  write_config 10
+  stub_open_prs 2
+  run_report
+  [ "$status" -eq 0 ]
+  grep -q 'search prs' "$GH_STUB_LOG"
+  ! grep -qE 'pr create|pr edit|api -X (POST|PATCH|PUT|DELETE)' "$GH_STUB_LOG"
+}
+
+# --------------------------------------------------------------------------
+# Cap + exempt lists come from the config, not hardcoded: a different cap
+# flips the status.
+# --------------------------------------------------------------------------
+@test "cap is read from the config (not hardcoded)" {
+  write_config 4
+  stub_open_prs 4
+  run_report
+  [ "$status" -eq 0 ]
+  # 4 counted vs cap 4 -> at cap
+  [[ "$output" == *"AT OR OVER CAP"* ]]
+  [[ "$output" == *"| Cap | 4 |"* ]]
+}

--- a/test/scripts/pr-limits/pr-limits-report.bats
+++ b/test/scripts/pr-limits/pr-limits-report.bats
@@ -187,3 +187,65 @@ run_report() {
   [[ "$output" == *"AT OR OVER CAP"* ]]
   [[ "$output" == *"| Cap | 4 |"* ]]
 }
+
+# --------------------------------------------------------------------------
+# A null / missing author does not crash jq: it is counted as "unknown".
+# --------------------------------------------------------------------------
+@test "null or missing author is counted as unknown without a jq error" {
+  write_config 10
+  export GH_STUB_STDOUT
+  GH_STUB_STDOUT="$(jq -nc '[
+    { author: null,                       labels: [], repository: { name: "a" }, title: "t", url: "u" },
+    { author: { login: "dev-lead-bot" },  labels: [], repository: { name: "b" }, title: "t", url: "u" },
+    {                                     labels: [], repository: { name: "c" }, title: "t", url: "u" }
+  ]')"
+  run_report
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Open non-draft PRs (total) | 3"* ]]
+  [[ "$output" == *"Counted toward cap | 3"* ]]
+  # Both the null-author and the missing-author PR collapse to "unknown" (count 2).
+  [[ "$output" == *"| unknown | 2 |"* ]]
+  [[ "$output" == *"| dev-lead-bot | 1 |"* ]]
+  # No jq error text leaked into the output.
+  [[ "$output" != *"Cannot index"* ]]
+}
+
+# --------------------------------------------------------------------------
+# Interleaved authors: group_by yields correct per-author counts regardless of
+# input order (jq group_by sorts internally). Locks that invariant in.
+# --------------------------------------------------------------------------
+@test "interleaved authors are grouped correctly regardless of input order" {
+  write_config 10
+  export GH_STUB_STDOUT
+  GH_STUB_STDOUT="$(jq -nc '[
+    { author: { login: "a-bot" }, labels: [], repository: { name: "1" }, title: "t", url: "u" },
+    { author: { login: "b-bot" }, labels: [], repository: { name: "2" }, title: "t", url: "u" },
+    { author: { login: "a-bot" }, labels: [], repository: { name: "3" }, title: "t", url: "u" },
+    { author: { login: "b-bot" }, labels: [], repository: { name: "4" }, title: "t", url: "u" },
+    { author: { login: "a-bot" }, labels: [], repository: { name: "5" }, title: "t", url: "u" }
+  ]')"
+  run_report
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"| a-bot | 3 |"* ]]
+  [[ "$output" == *"| b-bot | 2 |"* ]]
+}
+
+# --------------------------------------------------------------------------
+# A `gh` failure (non-zero exit) fails loudly: the report exits non-zero and
+# prints "Metric unavailable" — NOT a fake "0/cap Under cap" table. Unlike the
+# admission gate (which fails open for PR creation), a scheduled measurement
+# report must not masquerade a query error as a real zero.
+# --------------------------------------------------------------------------
+@test "gh failure prints Metric unavailable and exits non-zero (no fake table)" {
+  write_config 50
+  export GH_STUB_EXIT=4
+  export GH_STUB_STDOUT=""
+  export GH_STUB_STDERR="simulated gh API error"
+  run_report
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Metric unavailable"* ]]
+  [[ "$output" == *"rc=4"* ]]
+  # Must NOT emit the normal metrics table or an "under cap" verdict.
+  [[ "$output" != *"Under cap"* ]]
+  [[ "$output" != *"Counted toward cap"* ]]
+}


### PR DESCRIPTION
Phase 4 of the PR-limits initiative (epic #505): the success-metric report.

## What
A **pure gh + jq** (no LLM) report measuring open non-draft automation PRs org-wide vs. the signed-off cap.

- **`scripts/pr-limits-report.sh`** — reads cap + exempt actors/labels from `standards/pr-limits.json` (single source of truth) and applies the **same counting semantics as the admission gate** (`scripts/lib/pr-limit-gate.sh`) so report and gate agree. Emits a Markdown table (total / counted / exempt / cap / headroom) + by-source breakdown + status line, and appends to `$GITHUB_STEP_SUMMARY`. Robust to empty/failed enumeration.
- **`.github/workflows/pr-limits-report.yml`** — `schedule` (once daily) + `workflow_dispatch`; `permissions: {}` + `contents: read` job; `github.token`; pinned checkout, `persist-credentials: false`; `timeout-minutes: 10`. Modeled on `daily-org-status.yml`.
- Tests: `test/scripts/pr-limits/pr-limits-report.bats` (8 gh-stubbed cases) + a `pr-limits-report-tests.yml` shellcheck+bats gate.

## Validation
shellcheck clean; **8/8** new bats (28/28 in `test/scripts/pr-limits/`); actionlint clean. Current real numbers: 41/50 counted, headroom 9.

## Note
Hand-authored after the dev-lead engine hit its **600s timeout** on #510 (3 attempts). The story also referenced a phantom `auto_rebase_health.sh`; this uses the real `org_status.sh`/`daily-org-status.yml` models. Closes #510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated PR-limits report that runs on schedule or manually and summarizes open pull request counts against the configured cap.
  * Added a dedicated validation workflow to check the report script and its test suite on pull request changes.

* **Bug Fixes**
  * Improved counting and reporting for exempt authors and labels, with clearer breakdowns and headroom values.
  * Added safeguards so report failures show an unavailable status instead of misleading results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->