### PR TITLE
docs(governance): codify repo boundary — org-wide rulesets belong in .github, not .github-private (#575)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,9 +35,9 @@ diverging silently.
 
 Org-wide **standards and compliance policy are owned by `petry-projects/.github`**
 (this repo): everything in the table above, **plus the codified compliance
-rulesets** — `code-quality` and `pr-quality` — that `apply-rulesets.sh` /
-`bootstrap-new-repo.sh` apply to every repo. The canonical home for those ruleset
-JSONs is `standards/rulesets/`.
+rulesets** — `code-quality` and `pr-quality` — that `scripts/apply-rulesets.sh`
+(and org automation consuming it) apply to every repo. The canonical home for those
+ruleset JSONs is `standards/rulesets/`.
 
 **`petry-projects/.github-private` is scoped to agents, skills, and their reusable
 workflows/assets.** It must **not** be the source of truth for org-wide policy.
@@ -47,7 +47,7 @@ protects `.github-private`'s own `pr-review/**` and `dev-lead/**` agent-release 
 **Rule of thumb:** if a standard or ruleset applies to the whole fleet, it belongs
 in `.github/standards/`. If it protects an agent's/skill's own assets, it stays in
 `.github-private`. When in doubt, put it in `.github` and have `.github-private`
-**consume** it — the way `seed-repo-template.sh` fetches `standards/workflows/` from
+**consume** it — the way repo-seeding tooling fetches `standards/workflows/` from
 `.github`. Do **not** add new org-wide standards or rulesets to `.github-private`.
 
 > **Known exception being remediated:** `code-quality.json` and `pr-quality.json`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,33 @@ is, by definition, drift from the standard. If a needed standard or template
 is missing, file an issue against `petry-projects/.github` rather than
 diverging silently.
 
+### What lives where — `.github` vs `.github-private`
+
+Org-wide **standards and compliance policy are owned by `petry-projects/.github`**
+(this repo): everything in the table above, **plus the codified compliance
+rulesets** — `code-quality` and `pr-quality` — that `apply-rulesets.sh` /
+`bootstrap-new-repo.sh` apply to every repo. The canonical home for those ruleset
+JSONs is `standards/rulesets/`.
+
+**`petry-projects/.github-private` is scoped to agents, skills, and their reusable
+workflows/assets.** It must **not** be the source of truth for org-wide policy.
+The only ruleset that legitimately lives there is `release-channel-tags` — it
+protects `.github-private`'s own `pr-review/**` and `dev-lead/**` agent-release tags.
+
+**Rule of thumb:** if a standard or ruleset applies to the whole fleet, it belongs
+in `.github/standards/`. If it protects an agent's/skill's own assets, it stays in
+`.github-private`. When in doubt, put it in `.github` and have `.github-private`
+**consume** it — the way `seed-repo-template.sh` fetches `standards/workflows/` from
+`.github`. Do **not** add new org-wide standards or rulesets to `.github-private`.
+
+> **Known exception being remediated:** `code-quality.json` and `pr-quality.json`
+> currently live in `.github-private/.github/rulesets/` (added ad-hoc under
+> compliance fix #60, before this boundary was documented) and are being relocated
+> to `standards/rulesets/` — see
+> [petry-projects/.github#575](https://github.com/petry-projects/.github/issues/575).
+> Treat `.github` as the intended canonical home; do not extend the `.github-private`
+> copies.
+
 ---
 
 ## Project Context

--- a/standards/github-settings.md
+++ b/standards/github-settings.md
@@ -126,7 +126,7 @@ rules are deprecated — migrate existing classic rules to rulesets.
 ### Source of truth & repo boundary
 
 The codified ruleset JSONs are the source of truth for the two sanctioned
-rulesets; `apply-rulesets.sh` and `bootstrap-new-repo.sh` apply them to each repo.
+rulesets; `scripts/apply-rulesets.sh` (and any org automation consuming it) applies them to each repo.
 As **org-wide compliance policy they are owned by `petry-projects/.github`**, and
 their canonical home is `standards/rulesets/`. Do **not** author them in
 `petry-projects/.github-private` — that repo is scoped to agents/skills and their

--- a/standards/github-settings.md
+++ b/standards/github-settings.md
@@ -123,6 +123,22 @@ Rulesets are the primary enforcement mechanism for branch policies. All
 repositories MUST use rulesets on the default branch. Classic branch protection
 rules are deprecated — migrate existing classic rules to rulesets.
 
+### Source of truth & repo boundary
+
+The codified ruleset JSONs are the source of truth for the two sanctioned
+rulesets; `apply-rulesets.sh` and `bootstrap-new-repo.sh` apply them to each repo.
+As **org-wide compliance policy they are owned by `petry-projects/.github`**, and
+their canonical home is `standards/rulesets/`. Do **not** author them in
+`petry-projects/.github-private` — that repo is scoped to agents/skills and their
+reusable assets. The only ruleset that belongs there is `release-channel-tags`
+(it protects `.github-private`'s own `pr-review/**` / `dev-lead/**` release tags).
+See the repo-boundary rule in [`AGENTS.md`](../AGENTS.md).
+
+> **In transit:** `code-quality.json` and `pr-quality.json` currently still live
+> in `.github-private/.github/rulesets/` and are being relocated to
+> `standards/rulesets/` here — see
+> [petry-projects/.github#575](https://github.com/petry-projects/.github/issues/575).
+
 **`pr-quality` and `code-quality` are the only sanctioned rulesets.** Legacy
 `protect-branches` rulesets and ad-hoc `main` rulesets are deprecated: they
 duplicate protections and, because GitHub evaluates bypass eligibility per


### PR DESCRIPTION
## What

Documents the **repo-boundary rule** so the recurring mistake — putting org-wide compliance policy in `.github-private` — can't happen silently again.

- **`AGENTS.md`** (imported by every repo): new subsection **"What lives where — `.github` vs `.github-private`"** under Organization Standards. States that org-wide standards/compliance policy (incl. the codified `code-quality` / `pr-quality` rulesets) are owned by `.github` with canonical home `standards/rulesets/`; `.github-private` is scoped to agents/skills/reusable assets and must not be the source of truth for fleet policy (only `release-channel-tags` — which protects its own agent-release tags — belongs there). Includes the rule-of-thumb and the known exception being remediated.
- **`standards/github-settings.md`** (Repository Rulesets §): "Source of truth & repo boundary" note pointing the codified ruleset JSONs at `.github/standards/rulesets/` with the same boundary.

## Why

During epic #964 (repo-template), a review surfaced that `code-quality.json` / `pr-quality.json` — org-wide compliance policy applied to the whole fleet — live in `.github-private/.github/rulesets/` (added ad-hoc under compliance fix #60, before this boundary was documented). The relocation itself is tracked in **#575**; this PR lands the **guidance now** so the boundary is explicit going forward.

Refs #575.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified where shared repository standards and rulesets should live versus where reusable agent assets belong.
  * Added guidance on the canonical location for approved ruleset files, including a noted temporary exception during an ongoing move.
  * Improved wording around repository boundaries and ownership to make setup and maintenance expectations clearer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->