### PR TITLE
feat(ci-template): add secret-scan + coverage jobs to template ci.yml (#575)

### DIFF
--- a/standards/workflows/ci.yml
+++ b/standards/workflows/ci.yml
@@ -12,7 +12,7 @@
 #      repo's branch-protection required checks to match the new job names.
 #   4. Two more jobs ship by default and are org required checks — `Secret scan
 #      (gitleaks)` (per push-protection.md; needs a .gitleaks.toml at root, seeded
-#      with this template) and `coverage` (green until your stack emits coverage).
+#      by repo-template tooling) and `coverage` (green until your stack emits coverage).
 #      Keep their job names stable so the required checks stay satisfied.
 #
 # CONVENTIONS (enforced by the standard):
@@ -82,7 +82,8 @@ jobs:
           url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${tarball}"
           wget -q "${url}" -O /tmp/gitleaks.tar.gz
           echo "${GITLEAKS_CHECKSUM}  /tmp/gitleaks.tar.gz" | sha256sum -c
-          tar -xzf /tmp/gitleaks.tar.gz -C /usr/local/bin gitleaks
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          sudo mv /tmp/gitleaks /usr/local/bin
 
       - name: Run gitleaks
         # Requires a .gitleaks.toml at repo root (seeded by seed-repo-template.sh).

--- a/standards/workflows/ci.yml
+++ b/standards/workflows/ci.yml
@@ -10,6 +10,10 @@
 #   3. The job name `build-and-test` is the required CI status check. Keep it — or,
 #      if you split into per-language jobs (e.g. TypeScript, Go, Python), update the
 #      repo's branch-protection required checks to match the new job names.
+#   4. Two more jobs ship by default and are org required checks — `Secret scan
+#      (gitleaks)` (per push-protection.md; needs a .gitleaks.toml at root, seeded
+#      with this template) and `coverage` (green until your stack emits coverage).
+#      Keep their job names stable so the required checks stay satisfied.
 #
 # CONVENTIONS (enforced by the standard):
 #   • permissions: {} at top, least-privilege per job (CI needs contents: read)
@@ -51,3 +55,70 @@ jobs:
       # placeholder below keeps the required `build-and-test` check green.
       - name: Placeholder — replace with real build/test steps
         run: echo "CI stub — add your stack's lint/format/typecheck/test/coverage steps; see BOOTSTRAP.md."
+
+  # Canonical secret-scan job — copied verbatim from push-protection.md#required-ci-job.
+  # Produces the `Secret scan (gitleaks)` required check. Uses the gitleaks CLI (not
+  # gitleaks/gitleaks-action, whose v2+ needs a paid org license); fully pinned +
+  # checksum-verified; no SARIF upload, so no `security-events: write` permission.
+  secret-scan:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: "8.30.1"
+          # Named GITLEAKS_CHECKSUM (not GITLEAKS_SHA256) — SonarCloud flags env var names
+          # matching *SHA256* containing hex strings as Security Hotspots (false positive).
+          GITLEAKS_CHECKSUM: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+        run: |
+          tarball="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${tarball}"
+          wget -q "${url}" -O /tmp/gitleaks.tar.gz
+          echo "${GITLEAKS_CHECKSUM}  /tmp/gitleaks.tar.gz" | sha256sum -c
+          tar -xzf /tmp/gitleaks.tar.gz -C /usr/local/bin gitleaks
+
+      - name: Run gitleaks
+        # Requires a .gitleaks.toml at repo root (seeded by seed-repo-template.sh).
+        run: gitleaks detect --source . --config .gitleaks.toml --redact --verbose --exit-code 1
+
+  # Stack-aware coverage — produces the `coverage` required check. Default stack is
+  # shell/bats via kcov. GREEN-UNTIL-TESTS: when a stack emits no coverage yet, the
+  # job succeeds without producing a report, so seeding it fleet-wide never bricks a
+  # repo that has no test suite. It begins enforcing once tests exist. Add a per-stack
+  # block below (keep the job id and `name:` as `coverage` so the required check is stable).
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Coverage (shell/bats via kcov)
+        run: |
+          shopt -s globstar nullglob
+          bats_files=(tests/**/*.bats)
+          if [ ${#bats_files[@]} -eq 0 ]; then
+            echo "No bats tests found — coverage is green until tests exist."
+            exit 0
+          fi
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq bats kcov
+          mkdir -p coverage
+          kcov --include-path=. --exclude-path=tests,coverage coverage bats "${bats_files[@]}"
+          echo "Coverage report written to ./coverage"
+
+      # ── Per-stack expansion — replace/augment the shell block above for your stack.
+      #    Keep the job id and `name:` as `coverage` so the required check is unchanged.
+      #    Node:   npx jest --coverage
+      #    Go:     go test ./... -coverprofile=coverage.out && go tool cover -func=coverage.out
+      #    Python: pytest --cov
+      #    Rust:   cargo llvm-cov --workspace


### PR DESCRIPTION
## Summary

Adds the two org **required-check producers** to the day-0 CI template `standards/workflows/ci.yml`, so repos created from `repo-template` are forward-compatible with the `code-quality` ruleset. Folded in from closed #569 (epic #964), with both review fixes applied.

## Jobs added (alongside the existing `build-and-test` stub)

**`secret-scan` → `Secret scan (gitleaks)`** — copied **verbatim** from [`push-protection.md#required-ci-job`](../blob/main/standards/push-protection.md):
- gitleaks **CLI** (not `gitleaks/gitleaks-action` — its v2+ needs a paid org license), fully pinned + checksum-verified via `GITLEAKS_CHECKSUM`.
- ✅ **Review fix (a):** `permissions: contents: read` only — no SARIF upload, so no `security-events: write`.
- ✅ **Review fix (b):** runs `gitleaks detect --source . --config .gitleaks.toml --redact --verbose --exit-code 1`. Requires a `.gitleaks.toml` at root — **seeded by the companion `.github-private` PR** (wires `seed-repo-template.sh`).

**`coverage` → `coverage`** — stack-aware, default shell/bats via **kcov**:
- **Green-until-tests** (per your call): no bats tests → job succeeds without a report. Seeding it fleet-wide never bricks a repo without a suite; it enforces once tests exist.
- Per-stack expansion (Node/Go/Python/Rust) documented inline; job id + `name:` kept `coverage` so the required check is stable.

## Pins & lint
- `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2` — verified via `gh api` (matches the existing template + push-protection.md).
- `yamllint` (repo rules: line-length 200, document-start disable) ✅ · pinned `actionlint 1.7.7` ✅.

## Sequencing / coupling
- The `code-quality` ruleset does **not** yet require `coverage`/`Secret scan (gitleaks)` fleet-wide — that's a **separate follow-up PR**, scoped to template/new repos. Existing fleet repos have no coverage job, so a fleet-wide required `coverage` would brick them (the original #575 finding).
- A repo seeded with this `ci.yml` needs the `.gitleaks.toml` from the companion `.github-private` seed PR, or its `secret-scan` fails on missing config. Land them together.

Part of #575. Epic #964.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated secret detection to catch exposed credentials before changes are merged.
  * Added a coverage validation check that reports test coverage when repository tests are present.
* **Bug Fixes**
  * Improved CI reliability by keeping required check names stable, even when optional checks have nothing to run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->