### PR TITLE
fix(pr-quality): require last push approval — align codified ruleset with org policy (#575)

### DIFF
--- a/standards/rulesets/pr-quality.json
+++ b/standards/rulesets/pr-quality.json
@@ -27,7 +27,7 @@
         "require_code_owner_review": true,
         "required_review_thread_resolution": true,
         "dismiss_stale_reviews_on_push": true,
-        "require_last_push_approval": false,
+        "require_last_push_approval": true,
         "automatic_copilot_code_review_enabled": false,
         "allowed_merge_methods": ["squash"]
       }


### PR DESCRIPTION
## Summary

Sets `require_last_push_approval: true` in the codified `standards/rulesets/pr-quality.json`. Answers the review question on petry-projects/.github-private#1013: **there is no good reason for it to be `false`** — it was baked in at authoring time (#972), and the org's actual policy is `true`.

## Evidence

Live `require_last_push_approval` across the fleet is **split** (drift):

| true | false |
|------|-------|
| `.github`, `.github-private`, `TalkTerm`, `google-app-scripts` | `ContentTwin`, `markets`, `broodly` |

- The **meta-repos and newer repos already enforce `true`** — that's the intended policy.
- **#895 verified** auto-rebase's `update-branch` is **exempt** from `require_last_push_approval` (and dismiss-stale), so enabling it does **not** fight the auto-rebase flow — the historical worry that would justify `false`.

## Blast radius

On the next `apply-rulesets.sh` run this **tightens the three drifted repos** still at `false` (ContentTwin, markets, broodly) and is a **no-op** on the four already at `true`. The applier is operator-invoked, so this takes effect deliberately, not automatically.

## Notes
- **Stacked on #577** (base = `chore/relocate-rulesets-575`) so the diff is the single line; retargets to `main` when #577 merges.
- Resolves the pre-existing `pr-quality` file-vs-live drift flagged in petry-projects/.github-private#1013.

Part of #575.

🤖 Generated with [Claude Code](https://claude.com/claude-code)