### PR TITLE
feat(rulesets): retire detection-based apply-rulesets.sh; codified applier canonical in .github (#580)

### DIFF
--- a/.github/workflows/apply-rulesets-tests.yml
+++ b/.github/workflows/apply-rulesets-tests.yml
@@ -1,0 +1,49 @@
+# Tests for the codified ruleset applier (scripts/apply-rulesets.sh), the canonical
+# org tooling that replaced the retired detection-based builder (#580 / #575).
+# Gates: shellcheck (applier) + bats (behavior + the anti-divergence guard on the
+# codified standards/rulesets/*.json).
+name: Apply Rulesets Tests
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/apply-rulesets.sh'
+      - 'standards/rulesets/**'
+      - 'test/scripts/apply-rulesets/**'
+      - '.github/workflows/apply-rulesets-tests.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/apply-rulesets.sh'
+      - 'standards/rulesets/**'
+      - 'test/scripts/apply-rulesets/**'
+      - '.github/workflows/apply-rulesets-tests.yml'
+
+permissions: {}
+
+concurrency:
+  group: apply-rulesets-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Lint and bats
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install bats, shellcheck, jq
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends bats shellcheck jq
+
+      - name: shellcheck
+        run: shellcheck --severity=warning -x scripts/apply-rulesets.sh
+
+      - name: bats
+        run: bats --print-output-on-failure test/scripts/apply-rulesets/

--- a/docs/initiatives/pull-request-limits-adr.md
+++ b/docs/initiatives/pull-request-limits-adr.md
@@ -170,6 +170,13 @@ neither of which is invoked by any in-repo workflow (verified by grep over
 > the ruleset / settings" gap the planner flagged is real and confirmed: both
 > scripts are run by hand (or referenced as manual remediation steps in
 > [`scripts/compliance-remediate.sh`](../../scripts/compliance-remediate.sh)).
+>
+> **Update (2026-07, #575 / #580):** the premise above no longer holds. The codified
+> [`standards/rulesets/{code-quality,pr-quality}.json`](../../standards/rulesets/) now
+> exist and ARE the source of truth, and the detection-based in-code generation was
+> retired — `apply-rulesets.sh` now reads those JSON files and PUTs them. The §7.2 /
+> §7.3 conclusion is unaffected: PR limits remain a source-side admission gate, not an
+> `apply-rulesets.sh` field.
 
 ### 7.2 Where PR limits land
 

--- a/scripts/apply-rulesets.sh
+++ b/scripts/apply-rulesets.sh
@@ -1,406 +1,142 @@
 #!/usr/bin/env bash
-# apply-rulesets.sh — Apply standard repository rulesets to petry-projects repos
+set -euo pipefail
+# apply-rulesets.sh — codified, idempotent application of the org compliance rulesets.
 #
-# Companion script to compliance-audit.sh. Creates or updates the rulesets defined in:
-#   standards/github-settings.md#repository-rulesets
+# CANONICAL org tooling (petry-projects/.github#580 / #575). Reads the codified source
+# of truth in standards/rulesets/*.json (code-quality.json, pr-quality.json) and
+# creates/updates the named ruleset on the target repo(s). Re-running converges to the
+# file's desired state (a no-op when already in sync).
 #
-# Rulesets managed:
-#   pr-quality    — pull request review requirements and merge policy
-#   code-quality  — required status checks (CI, SonarCloud, CodeQL default setup, Dev-Lead Agent)
+# This REPLACES the retired detection-based builder, which dynamically probed each
+# repo's workflow files and *generated* the ruleset in-code. That approach DIVERGED
+# from the codified set — e.g. it injected `Dev-Lead Agent / dev-lead` as a required
+# context, which standards/github-settings.md#code-quality deliberately excludes
+# (per-PR review, not a merge gate). The codified JSON is now the single source of
+# truth; there is no in-code generation.
+#
+# Detection items → codified mapping (nothing org-wide is lost by the retirement):
+#   SonarCloud, CodeQL, agent-shield/AgentShield, dependency-audit/Detect ecosystems
+#     → carried statically in standards/rulesets/code-quality.json.
+#   Dev-Lead Agent → intentionally NOT required (the divergence this retires).
+#   CI Pipeline (build-and-test) → repo-specific job name → required per-repo via
+#     branch protection, not a fixed org context (see github-settings.md §code-quality).
+#   Secret scan (gitleaks) + coverage → produced by the template ci.yml; added to the
+#     ruleset fleet-wide only after the coverage backfill (#581), not here.
+#
+# Rulesets live ON each repo: editing a JSON here changes the desired state, not any
+# live ruleset, until this applier runs.
 #
 # Usage:
-#   # Apply to a specific repo:
-#   GH_TOKEN=<admin-token> ./scripts/apply-rulesets.sh <repo-name>
+#   GH_TOKEN=<admin> ./scripts/apply-rulesets.sh --repo owner/repo [--dry-run] [<name>...]
+#   GH_TOKEN=<admin> ./scripts/apply-rulesets.sh <repo-name>       [--dry-run]   # bare name → $ORG/<name>
+#   GH_TOKEN=<admin> ./scripts/apply-rulesets.sh --all             [--dry-run]   # every non-archived org repo
 #
-#   # Apply to all non-archived org repos:
-#   GH_TOKEN=<admin-token> ./scripts/apply-rulesets.sh --all
-#
-#   # Dry run (show what would be changed):
-#   GH_TOKEN=<admin-token> ./scripts/apply-rulesets.sh <repo-name> --dry-run
-#
-# Requirements:
-#   - GH_TOKEN must have administration:write scope on the target repo(s)
-#   - gh CLI must be installed
-#   - jq must be installed
+# Env:
+#   GH_TOKEN       token with administration:write on the target repo(s) (required for writes)
+#   ORG            org for --all and bare repo names (default: petry-projects)
+#   RULESETS_DIR   directory of ruleset JSONs (default: <repo-root>/standards/rulesets)
+#   DRY_RUN        "true" → print intent, make no write calls
 
-set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+ORG="${ORG:-petry-projects}"
+RULESETS_DIR="${RULESETS_DIR:-$(cd "${SCRIPT_DIR}/.." && pwd)/standards/rulesets}"
+DRY_RUN="${DRY_RUN:-false}"
 
-ORG="petry-projects"
-DRY_RUN=false
-
-info()  { echo "[INFO]  $*"; }
-ok()    { echo "[OK]    $*"; }
-err()   { echo "[ERROR] $*" >&2; }
-skip()  { echo "[SKIP]  $*"; }
-
-usage() {
-  echo "Usage: $0 <repo-name> [--dry-run]"
-  echo "       $0 --all [--dry-run]"
-  echo ""
-  echo "Environment variables:"
-  echo "  GH_TOKEN   GitHub token with administration:write scope (required)"
-  exit 1
+# ruleset_id_by_name <repo> <name> — echo the id of an existing ruleset, or empty.
+ruleset_id_by_name() {
+  local repo="$1" name="$2"
+  gh api --paginate "repos/${repo}/rulesets" \
+    | jq -r --arg n "$name" 'if type=="array" then .[] else . end | select(.name==$n) | .id'
 }
 
-# ---------------------------------------------------------------------------
-# Detect required status checks from a repo's workflow files
-# ---------------------------------------------------------------------------
-detect_required_checks() {
-  local repo="$1"
-  local checks=()
+# apply_one <repo> <json_file> — create or update the ruleset described by json_file.
+apply_one() {
+  local repo="$1" file="$2"
+  local name id
+  name="$(jq -r '.name' "$file")"
+  [ -n "$name" ] && [ "$name" != "null" ] || { echo "::error::$file has no .name" >&2; return 1; }
+  id="$(ruleset_id_by_name "$repo" "$name")"
 
-  # Fetch list of workflow files present in the repo
-  local workflows
-  workflows=$(gh api "repos/$ORG/$repo/contents/.github/workflows" \
-    --jq '.[].name' 2>/dev/null || echo "")
-
-  # Helper: fetch workflow file content and extract the top-level `name:` field
-  workflow_name() {
-    local file="$1"
-    gh api "repos/$ORG/$repo/contents/.github/workflows/$file" \
-      --jq '.content' 2>/dev/null \
-      | base64 -d 2>/dev/null \
-      | grep -m1 '^name:' \
-      | sed 's/^name:[[:space:]]*//' \
-      | tr -d '"'"'" \
-      | sed "s/'//g" \
-      || echo ""
-  }
-
-  # --- SonarCloud ---
-  if echo "$workflows" | grep -qx "sonarcloud.yml"; then
-    local sc_wf_name
-    sc_wf_name=$(workflow_name "sonarcloud.yml")
-    if [ -n "$sc_wf_name" ]; then
-      checks+=("$sc_wf_name / SonarCloud")
-    else
-      checks+=("SonarCloud")
-    fi
-  fi
-
-  # --- CodeQL (GitHub-managed default setup) ---
-  # CodeQL is no longer driven by a per-repo workflow file. We probe the
-  # default-setup API: if the state is "configured", GitHub publishes results
-  # under the required-status-check context name `CodeQL` (single context,
-  # regardless of how many languages are detected). See
-  # standards/ci-standards.md#2-codeql-analysis-github-managed-default-setup.
-  #
-  # Note: a stray .github/workflows/codeql.yml is drift and will be flagged
-  # by compliance-audit.sh#check_codeql_default_setup. We do NOT fall back
-  # to a workflow-derived check name here, because doing so would let drift
-  # silently satisfy the rule and bypass remediation.
-  local codeql_state codeql_err
-  if codeql_err=$(gh api "repos/$ORG/$repo/code-scanning/default-setup" --jq '.state' 2>&1); then
-    codeql_state="$codeql_err"  # on success, stdout holds the state value
-    if [ "$codeql_state" = "configured" ]; then
-      checks+=("CodeQL")
-    else
-      info "  CodeQL default setup not configured for $repo (state: $codeql_state) — skipping CodeQL required check. Run apply-repo-settings.sh first."
-    fi
+  if [ -n "$id" ]; then
+    echo "  update ruleset '${name}' (id ${id}) on ${repo}"
+    if [ "$DRY_RUN" = "true" ]; then echo "    [dry-run] PUT repos/${repo}/rulesets/${id}"; return 0; fi
+    gh api --method PUT "repos/${repo}/rulesets/${id}" --input "$file" >/dev/null
   else
-    err "  Failed to probe CodeQL default-setup state for $repo. API error: $codeql_err"
-    err "  Check that GH_TOKEN has code-scanning scope and the repo exists."
-    return 1
+    echo "  create ruleset '${name}' on ${repo}"
+    if [ "$DRY_RUN" = "true" ]; then echo "    [dry-run] POST repos/${repo}/rulesets"; return 0; fi
+    gh api --method POST "repos/${repo}/rulesets" --input "$file" >/dev/null
   fi
-
-  # --- Tier 1 centralized workflows ---
-  # Caller-job-ids are fixed by the canonical stubs in
-  # standards/workflows/, so the resulting reusable check names
-  # (<caller-job-id> / <reusable-job-id-or-name>) are known constants.
-  # See standards/ci-standards.md#centralization-tiers
-  #
-  # NOTE: claude-code / claude is intentionally NOT added as a required
-  # check. claude-code-action's GitHub App refuses to mint a token for
-  # any PR that touches workflow files, which would deadlock every
-  # workflow-modifying PR. The check is still useful for review feedback
-  # on normal PRs, but it must not be a merge gate.
-  if echo "$workflows" | grep -qx "agent-shield.yml"; then
-    checks+=("agent-shield / AgentShield")
-  fi
-  if echo "$workflows" | grep -qx "dependency-audit.yml"; then
-    # Only the detect job runs unconditionally; per-ecosystem audit jobs
-    # (npm audit, govulncheck, cargo audit, pip-audit, pnpm audit) are
-    # gated on lockfile presence and report SKIPPED when absent. A
-    # required-but-skipped check fails the gate, so we cannot require
-    # the per-ecosystem jobs.
-    checks+=("dependency-audit / Detect ecosystems")
-  fi
-  if echo "$workflows" | grep -qx "dev-lead.yml"; then
-    checks+=("Dev-Lead Agent / dev-lead")
-  fi
-  # dependabot-automerge / dependabot-rebase are intentionally NOT
-  # required: dependabot-automerge runs only on dependabot[bot] PRs and
-  # dependabot-rebase runs only on push to main, neither of which are
-  # regular contributor PRs.
-  # feature-ideation runs on a schedule, never on PRs, so also not required.
-
-  # --- CI Pipeline ---
-  if echo "$workflows" | grep -qx "ci.yml"; then
-    local ci_wf_name
-    ci_wf_name=$(workflow_name "ci.yml")
-    # Fetch ci.yml content once; used for first-job detection and secret-scan check below
-    local ci_content ci_decoded
-    ci_content=$(gh api "repos/$ORG/$repo/contents/.github/workflows/ci.yml" \
-      --jq '.content' 2>/dev/null || echo "")
-    ci_decoded=$(echo "$ci_content" | base64 -d 2>/dev/null || echo "")
-    # Fetch the first job name from ci.yml
-    local ci_job_name
-    ci_job_name=$(echo "$ci_decoded" \
-      | awk '
-          /^jobs:/ { in_jobs=1; found=0; next }
-          in_jobs && /^  [a-zA-Z0-9_-]+:/ && !found {
-            job_id=substr($0, 3); gsub(/:.*/, "", job_id); current_job=job_id; next
-          }
-          in_jobs && /^    name:/ && !found {
-            name=substr($0, 11); gsub(/^[ \t]+|[ \t]+$/, "", name); gsub(/["\x27]/, "", name)
-            print name; found=1; exit
-          }
-        ' 2>/dev/null || echo "")
-    if [ -z "$ci_job_name" ]; then
-      ci_job_name="build"
-    fi
-    if [ -n "$ci_wf_name" ]; then
-      checks+=("$ci_wf_name / $ci_job_name")
-    else
-      checks+=("$ci_job_name")
-    fi
-
-    # --- Secret scan (gitleaks) — included when ci.yml contains the gitleaks action ---
-    if echo "$ci_decoded" | grep -qE 'uses:[[:space:]]*(gitleaks/gitleaks-action|zricethezav/gitleaks-action)@'; then
-      checks+=("Secret scan (gitleaks)")
-    fi
-  fi
-
-  # Output as newline-separated list (guard against empty array with set -u)
-  [ "${#checks[@]}" -gt 0 ] && printf '%s\n' "${checks[@]}" || true
 }
 
-# ---------------------------------------------------------------------------
-# Build the pr-quality ruleset JSON payload
-# ---------------------------------------------------------------------------
-build_pr_quality_ruleset_json() {
-  jq -n '{
-    name: "pr-quality",
-    target: "branch",
-    enforcement: "active",
-    conditions: {
-      ref_name: {
-        include: ["~DEFAULT_BRANCH"],
-        exclude: []
-      }
-    },
-    rules: [
-      {
-        type: "pull_request",
-        parameters: {
-          required_approving_review_count: 1,
-          dismiss_stale_reviews_on_push: true,
-          require_code_owner_review: true,
-          require_last_push_approval: true,
-          required_review_thread_resolution: true
-        }
-      },
-      { type: "required_linear_history" },
-      { type: "non_fast_forward" },
-      { type: "deletion" }
-    ],
-    bypass_actors: [
-      {
-        actor_id: 0,
-        actor_type: "OrganizationAdmin",
-        bypass_mode: "always"
-      },
-      {
-        actor_id: 3167543,
-        actor_type: "Integration",
-        bypass_mode: "always"
-      }
-    ]
-  }'
+# apply_repo <repo> <file...> — apply each ruleset file to one repo.
+apply_repo() {
+  local repo="$1"; shift
+  echo "[apply-rulesets] repo=${repo} dir=${RULESETS_DIR} dry_run=${DRY_RUN}"
+  local file
+  for file in "$@"; do apply_one "$repo" "$file"; done
 }
 
-# ---------------------------------------------------------------------------
-# Build the code-quality ruleset JSON payload
-# ---------------------------------------------------------------------------
-build_ruleset_json() {
-  local name="$1"
-  shift
-  local checks=("$@")
-
-  # Build the required_status_checks array
-  local checks_json
-  checks_json=$(printf '%s\n' "${checks[@]}" | jq -R '{"context": .}' | jq -s '.')
-
-  jq -n \
-    --arg name "$name" \
-    --argjson checks "$checks_json" \
-    '{
-      name: $name,
-      target: "branch",
-      enforcement: "active",
-      conditions: {
-        ref_name: {
-          include: ["~DEFAULT_BRANCH"],
-          exclude: []
-        }
-      },
-      rules: [
-        {
-          type: "required_status_checks",
-          parameters: {
-            strict_required_status_checks_policy: true,
-            do_not_enforce_on_create: false,
-            required_status_checks: $checks
-          }
-        }
-      ],
-      bypass_actors: [
-        {
-          actor_id: 0,
-          actor_type: "OrganizationAdmin",
-          bypass_mode: "always"
-        },
-        {
-          actor_id: 3167543,
-          actor_type: "Integration",
-          bypass_mode: "always"
-        }
-      ]
-    }'
+# resolve_repo <arg> — echo owner/repo: pass through an owner/repo, else prefix $ORG.
+resolve_repo() {
+  case "$1" in */*) printf '%s' "$1" ;; *) printf '%s/%s' "$ORG" "$1" ;; esac
 }
 
-# ---------------------------------------------------------------------------
-# Apply rulesets to a single repo
-# ---------------------------------------------------------------------------
-apply_rulesets() {
-  local repo="$1"
-  info "Processing $ORG/$repo ..."
-
-  # Fetch existing rulesets
-  local existing_rulesets
-  existing_rulesets=$(gh api "repos/$ORG/$repo/rulesets" 2>/dev/null || echo "[]")
-
-  # --- pr-quality ruleset ---
-  local pr_quality_id
-  pr_quality_id=$(echo "$existing_rulesets" | jq -r '.[] | select(.name == "pr-quality") | .id' 2>/dev/null || echo "")
-
-  local pr_quality_payload
-  pr_quality_payload=$(build_pr_quality_ruleset_json)
-
-  if [ "$DRY_RUN" = true ]; then
-    if [ -n "$pr_quality_id" ]; then
-      skip "  DRY_RUN — would UPDATE pr-quality ruleset (id=$pr_quality_id) for $ORG/$repo"
-    else
-      skip "  DRY_RUN — would CREATE pr-quality ruleset for $ORG/$repo"
-    fi
-    echo "$pr_quality_payload" | jq '.'
-  elif [ -n "$pr_quality_id" ]; then
-    info "  Updating existing pr-quality ruleset (id=$pr_quality_id) ..."
-    gh api -X PUT "repos/$ORG/$repo/rulesets/$pr_quality_id" \
-      --input <(echo "$pr_quality_payload") > /dev/null
-    ok "  pr-quality ruleset updated for $ORG/$repo"
-  else
-    info "  Creating pr-quality ruleset ..."
-    gh api -X POST "repos/$ORG/$repo/rulesets" \
-      --input <(echo "$pr_quality_payload") > /dev/null
-    ok "  pr-quality ruleset created for $ORG/$repo"
-  fi
-
-  # --- code-quality ruleset ---
-  local existing_id
-  existing_id=$(echo "$existing_rulesets" | jq -r '.[] | select(.name == "code-quality") | .id' 2>/dev/null || echo "")
-
-  # Detect required checks for this repo
-  local checks=()
-  mapfile -t checks < <(detect_required_checks "$repo")
-
-  if [ "${#checks[@]}" -eq 0 ]; then
-    err "  No required checks detected for $ORG/$repo — skipping code-quality ruleset"
-    return 1
-  fi
-
-  info "  Detected required checks:"
-  for c in "${checks[@]}"; do
-    info "    - $c"
+main() {
+  local target="" all=false
+  local names=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --repo)
+        [ "$#" -ge 2 ] || { echo "::error::--repo requires a value" >&2; return 2; }
+        target="$2"; shift 2 ;;
+      --all)     all=true; shift ;;
+      --dry-run) DRY_RUN=true; shift ;;
+      --*)       echo "::error::unknown flag: $1" >&2; return 2 ;;
+      *)
+        # A bare token is the target repo (back-compat with the retired applier's
+        # positional <repo-name>) unless --repo/--all already set it, in which case
+        # remaining bare tokens filter which ruleset names to apply.
+        if [ -z "$target" ] && [ "$all" = false ]; then target="$1"; else names+=("$1"); fi
+        shift ;;
+    esac
   done
 
-  local payload
-  payload=$(build_ruleset_json "code-quality" "${checks[@]}")
+  [ -d "$RULESETS_DIR" ] || { echo "::error::rulesets dir not found: $RULESETS_DIR" >&2; return 1; }
 
-  if [ "$DRY_RUN" = true ]; then
-    if [ -n "$existing_id" ]; then
-      skip "  DRY_RUN — would UPDATE code-quality ruleset (id=$existing_id) for $ORG/$repo"
-    else
-      skip "  DRY_RUN — would CREATE code-quality ruleset for $ORG/$repo"
-    fi
-    echo "$payload" | jq '.'
+  # Select the ruleset files (all *.json, or only the named ones).
+  local files=()
+  if [ "${#names[@]}" -gt 0 ]; then
+    local n
+    for n in "${names[@]}"; do
+      [ -f "${RULESETS_DIR}/${n}.json" ] && files+=("${RULESETS_DIR}/${n}.json") \
+        || { echo "::error::no ruleset file ${n}.json in ${RULESETS_DIR}" >&2; return 1; }
+    done
+  else
+    local f
+    for f in "${RULESETS_DIR}"/*.json; do [ -e "$f" ] && files+=("$f"); done
+  fi
+  [ "${#files[@]}" -gt 0 ] || { echo "  no ruleset files to apply"; return 0; }
+
+  if [ "$all" = true ]; then
+    [ -z "$target" ] || { echo "::error::--all and a repo argument are mutually exclusive" >&2; return 2; }
+    echo "[apply-rulesets] fetching non-archived repos in ${ORG} ..."
+    local repos repo failed=0
+    repos="$(gh repo list "$ORG" --no-archived --json name -q '.[].name' --limit 500)"
+    [ -n "$repos" ] || { echo "::error::no repositories found in ${ORG} — check GH_TOKEN" >&2; return 1; }
+    for repo in $repos; do
+      apply_repo "${ORG}/${repo}" "${files[@]}" || { failed=$((failed + 1)); echo "::warning::failed on ${ORG}/${repo}"; }
+    done
+    [ "$failed" -eq 0 ] || { echo "::error::${failed} repo(s) failed" >&2; return 1; }
+    echo "[apply-rulesets] done (${#files[@]} ruleset(s) across the fleet)"
     return 0
   fi
 
-  if [ -n "$existing_id" ]; then
-    info "  Updating existing code-quality ruleset (id=$existing_id) ..."
-    gh api -X PUT "repos/$ORG/$repo/rulesets/$existing_id" \
-      --input <(echo "$payload") > /dev/null
-    ok "  code-quality ruleset updated for $ORG/$repo"
-  else
-    info "  Creating code-quality ruleset ..."
-    gh api -X POST "repos/$ORG/$repo/rulesets" \
-      --input <(echo "$payload") > /dev/null
-    ok "  code-quality ruleset created for $ORG/$repo"
-  fi
+  [ -n "$target" ] || { echo "::error::usage: $0 --repo owner/repo | <repo-name> | --all  [--dry-run] [<name>...]" >&2; return 2; }
+  apply_repo "$(resolve_repo "$target")" "${files[@]}"
+  echo "[apply-rulesets] done (${#files[@]} ruleset(s))"
 }
 
-# ---------------------------------------------------------------------------
-# Parse arguments
-# ---------------------------------------------------------------------------
-if [ $# -eq 0 ]; then
-  usage
-fi
-
-if [ -z "${GH_TOKEN:-}" ]; then
-  err "GH_TOKEN is required — provide a token with administration:write scope"
-  exit 1
-fi
-
-export GH_TOKEN
-
-TARGET=""
-for arg in "$@"; do
-  case "$arg" in
-    --dry-run) DRY_RUN=true ;;
-    --all)     TARGET="--all" ;;
-    -*)        err "Unknown flag: $arg"; usage ;;
-    *)         TARGET="$arg" ;;
-  esac
-done
-
-if [ -z "$TARGET" ]; then
-  usage
-fi
-
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
-if [ "$TARGET" = "--all" ]; then
-  info "Fetching all non-archived repos in $ORG ..."
-  repos=$(gh repo list "$ORG" --no-archived --json name -q '.[].name' --limit 500)
-
-  if [ -z "$repos" ]; then
-    err "No repositories found in $ORG — check GH_TOKEN permissions"
-    exit 1
-  fi
-
-  failed=0
-  for repo in $repos; do
-    apply_rulesets "$repo" || failed=$((failed + 1))
-  done
-
-  if [ "$failed" -gt 0 ]; then
-    err "$failed repo(s) failed — check output above for details"
-    exit 1
-  fi
-
-  ok "All repos processed successfully"
-else
-  apply_rulesets "$TARGET"
+# Source-guard: tests source this to exercise ruleset_id_by_name / apply_one.
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+  main "$@"
 fi

--- a/scripts/apply-rulesets.sh
+++ b/scripts/apply-rulesets.sh
@@ -45,35 +45,54 @@ DRY_RUN="${DRY_RUN:-false}"
 # ruleset_id_by_name <repo> <name> — echo the id of an existing ruleset, or empty.
 ruleset_id_by_name() {
   local repo="$1" name="$2"
-  gh api --paginate "repos/${repo}/rulesets" \
-    | jq -r --arg n "$name" 'if type=="array" then .[] else . end | select(.name==$n) | .id'
+  local output rc=0
+  output=$(gh api --paginate "repos/${repo}/rulesets" 2>/dev/null) && rc=0 || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "::error::failed to fetch rulesets for ${repo} (exit code ${rc})" >&2
+    return "$rc"
+  fi
+  echo "$output" | jq -r --arg n "$name" 'if type=="array" then .[] else . end | select(.name==$n) | .id'
 }
 
 # apply_one <repo> <json_file> — create or update the ruleset described by json_file.
 apply_one() {
   local repo="$1" file="$2"
-  local name id
+  local name id id_rc=0
   name="$(jq -r '.name' "$file")"
   [ -n "$name" ] && [ "$name" != "null" ] || { echo "::error::$file has no .name" >&2; return 1; }
-  id="$(ruleset_id_by_name "$repo" "$name")"
+  id="$(ruleset_id_by_name "$repo" "$name")" && id_rc=0 || id_rc=$?
+  if [ "$id_rc" -ne 0 ]; then
+    echo "::error::failed to resolve ruleset ID for '${name}' on ${repo}" >&2
+    return "$id_rc"
+  fi
 
   if [ -n "$id" ]; then
     echo "  update ruleset '${name}' (id ${id}) on ${repo}"
     if [ "$DRY_RUN" = "true" ]; then echo "    [dry-run] PUT repos/${repo}/rulesets/${id}"; return 0; fi
-    gh api --method PUT "repos/${repo}/rulesets/${id}" --input "$file" >/dev/null
+    gh api --method PUT "repos/${repo}/rulesets/${id}" --input "$file" >/dev/null || {
+      echo "::error::failed to update ruleset '${name}' on ${repo}" >&2
+      return 1
+    }
   else
     echo "  create ruleset '${name}' on ${repo}"
     if [ "$DRY_RUN" = "true" ]; then echo "    [dry-run] POST repos/${repo}/rulesets"; return 0; fi
-    gh api --method POST "repos/${repo}/rulesets" --input "$file" >/dev/null
+    gh api --method POST "repos/${repo}/rulesets" --input "$file" >/dev/null || {
+      echo "::error::failed to create ruleset '${name}' on ${repo}" >&2
+      return 1
+    }
   fi
+  return 0
 }
 
 # apply_repo <repo> <file...> — apply each ruleset file to one repo.
 apply_repo() {
   local repo="$1"; shift
   echo "[apply-rulesets] repo=${repo} dir=${RULESETS_DIR} dry_run=${DRY_RUN}"
-  local file
-  for file in "$@"; do apply_one "$repo" "$file"; done
+  local file rc=0
+  for file in "$@"; do
+    apply_one "$repo" "$file" || rc=$?
+  done
+  return "$rc"
 }
 
 # resolve_repo <arg> — echo owner/repo: pass through an owner/repo, else prefix $ORG.
@@ -101,6 +120,7 @@ main() {
     esac
   done
 
+  gh auth status >/dev/null 2>&1 || { echo "::error::GitHub authentication failed — set GH_TOKEN or run 'gh auth login'" >&2; return 1; }
   [ -d "$RULESETS_DIR" ] || { echo "::error::rulesets dir not found: $RULESETS_DIR" >&2; return 1; }
 
   # Select the ruleset files (all *.json, or only the named ones).
@@ -120,8 +140,12 @@ main() {
   if [ "$all" = true ]; then
     [ -z "$target" ] || { echo "::error::--all and a repo argument are mutually exclusive" >&2; return 2; }
     echo "[apply-rulesets] fetching non-archived repos in ${ORG} ..."
-    local repos repo failed=0
-    repos="$(gh repo list "$ORG" --no-archived --json name -q '.[].name' --limit 500)"
+    local repos repo failed=0 repos_rc=0
+    repos="$(gh repo list "$ORG" --no-archived --json name -q '.[].name' --limit 500)" && repos_rc=0 || repos_rc=$?
+    if [ "$repos_rc" -ne 0 ]; then
+      echo "::error::failed to list repositories for organization ${ORG} (exit code ${repos_rc})" >&2
+      return "$repos_rc"
+    fi
     [ -n "$repos" ] || { echo "::error::no repositories found in ${ORG} — check GH_TOKEN" >&2; return 1; }
     for repo in $repos; do
       apply_repo "${ORG}/${repo}" "${files[@]}" || { failed=$((failed + 1)); echo "::warning::failed on ${ORG}/${repo}"; }

--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -1433,7 +1433,7 @@ check_centralized_check_names() {
     fi
 
     add_finding "$repo" "rulesets" "$check_id" "error" \
-      "Required-status-check ruleset includes \`$context\`, which is incompatible with workflow-modifying PRs. claude-code-action's GitHub App refuses to mint an OAuth token for any PR whose diff includes a workflow file, so the check fails on every workflow PR and the merge gate becomes a deadlock. **Remove \`$context\` from required status checks** — do NOT rename it. The Claude review check still runs on normal PRs and surfaces feedback without being a merge gate. See \`scripts/apply-rulesets.sh\` (post petry-projects/.github#94) for the canonical required-checks list." \
+      "Required-status-check ruleset includes \`$context\`, which is incompatible with workflow-modifying PRs. claude-code-action's GitHub App refuses to mint an OAuth token for any PR whose diff includes a workflow file, so the check fails on every workflow PR and the merge gate becomes a deadlock. **Remove \`$context\` from required status checks** — do NOT rename it. The Claude review check still runs on normal PRs and surfaces feedback without being a merge gate. See the codified \`standards/rulesets/code-quality.json\` for the canonical required-checks list." \
       "standards/ci-standards.md#centralization-tiers"
   done <<< "$contexts"
 }

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -350,9 +350,9 @@ flipping default setup on causes both to run and double-bills CI minutes.
 
 **Status check name:** GitHub publishes default setup results under the
 required-status-check context name **`CodeQL`** (single context, regardless
-of how many languages are detected). The org `apply-rulesets.sh` script
-adds this context to the `code-quality` ruleset for any repo where default
-setup is configured.
+of how many languages are detected). The codified `code-quality` ruleset
+([`standards/rulesets/code-quality.json`](rulesets/code-quality.json)) carries
+the `CodeQL` context, applied to each repo by `apply-rulesets.sh`.
 
 **Escape hatch — when advanced setup is justified:** A repo MAY revert to
 an inline `codeql.yml` workflow only when it has a concrete need that

--- a/standards/github-settings.md
+++ b/standards/github-settings.md
@@ -261,22 +261,25 @@ a fresh approval under the current CODEOWNERS.
 
 ### `code-quality` — Required Checks Ruleset (All Repositories)
 
-`apply-rulesets.sh` **dynamically constructs** the `code-quality` ruleset for each
-repo by probing its workflow files via `detect_required_checks()` — it does not apply
-a static JSON file. The table below is the canonical reference for the required-check
-set; keep it in sync with the detection logic in `scripts/apply-rulesets.sh`. Note:
-`apply-rulesets.sh` manages only the `pr-quality` and `code-quality` branch rulesets —
-the `release-channel-tags` ruleset is managed in `.github-private` (see
+The **codified** [`standards/rulesets/code-quality.json`](rulesets/code-quality.json)
+is the source of truth for the required-check set; `apply-rulesets.sh` reads it and
+PUTs it to each repo. (The detection-based in-code builder that dynamically probed
+workflow files was **retired** in #580 — it diverged from this file.) The table below
+reconciles to `code-quality.json`; keep the two in sync. Note: `apply-rulesets.sh`
+manages only the `pr-quality` and `code-quality` branch rulesets — the
+`release-channel-tags` ruleset is managed in `.github-private` (see
 [§Source of truth & repo boundary](#source-of-truth--repo-boundary)).
 
 #### Required Check Categories
 
-The table below covers the **unconditional fleet-wide required check contexts** — the base set `detect_required_checks()` applies when each org-standard workflow file is present.
-The script also conditionally adds **Dev-Lead Agent** (when `dev-lead.yml` exists) and **Secret scan** (when `ci.yml` contains the gitleaks action), but those are in staged rollout; see below.
+The four contexts below are the **unconditional fleet-wide required checks** codified
+in `code-quality.json`. `Dev-Lead Agent` is intentionally excluded, and
+`Secret scan (gitleaks)` + `coverage` are staged (template / new repos first) — see
+the reclassification table and sequencing note that follow.
 
 | Check | Status | Check Name(s) | Notes |
 |-------|--------|---------------|-------|
-| **SonarCloud** | ✅ Required (codified) | `SonarCloud Analysis / SonarCloud` | Code quality, maintainability, security hotspots. `apply-rulesets.sh` derives the check name as `<sonarcloud.yml name> / SonarCloud`; the standard template sets `name: SonarCloud Analysis`, producing this context. Verify with `gh pr checks <PR>` if the workflow name differs |
+| **SonarCloud** | ✅ Required (codified) | `SonarCloud` | Code quality, maintainability, security hotspots. The context is exactly as codified in `code-quality.json`; verify with `gh pr checks <PR>` if a repo's SonarCloud workflow reports under a different name |
 | **CodeQL** | ✅ Required (codified) | `CodeQL` | SAST via GitHub-managed default setup — auto-detects all supported languages (see [ci-standards.md §2](ci-standards.md#2-codeql-analysis-github-managed-default-setup)) |
 | **AgentShield** | ✅ Required (codified) | `agent-shield / AgentShield` | Deep agent-config security scan on every PR |
 | **Dependency Audit** | ✅ Required (codified) | `dependency-audit / Detect ecosystems` | Only the unconditional `Detect ecosystems` job is required; per-ecosystem audit jobs are gated on lockfile presence and would fail as required-but-skipped |

--- a/standards/push-protection.md
+++ b/standards/push-protection.md
@@ -428,12 +428,13 @@ When onboarding a repository to this standard:
 2. **Verify gitignore** contains the standard entries listed in
    [Required gitignore entries](#required-gitignore-entries).
 3. **Add the `secret-scan` job** to `ci.yml` per [Layer 3](#layer-3--ci-secret-scanning-secondary-defense).
-4. **Add `secret-scan` as a required check** in the `code-quality` ruleset.
-   If provisioning is done via `scripts/apply-rulesets.sh`, first update
-   `detect_required_checks()` in that script to recognize and insert the
-   `secret-scan` check, then re-apply rulesets org-wide. Update
+4. **Add `secret-scan` as a required check** in the `code-quality` ruleset —
+   add the `Secret scan (gitleaks)` context to the codified
+   [`standards/rulesets/code-quality.json`](rulesets/code-quality.json), then
+   re-apply org-wide with `scripts/apply-rulesets.sh`. Do this **only after** the
+   fleet backfill (every repo must produce the check first — see #581), and update
    [`github-settings.md`](github-settings.md#code-quality--required-checks-ruleset-all-repositories)
-   if the ruleset template needs a new entry.
+   to move the row from staged to required.
 5. **Scan existing history** one time with `gitleaks git --redact --exit-code 1`
    before enabling enforcement, to surface any pre-existing secrets across all
    commits (not just the current working tree).

--- a/standards/ruleset-remediation-runbook.md
+++ b/standards/ruleset-remediation-runbook.md
@@ -63,9 +63,10 @@ preserving any existing actors. Already-compliant rulesets are skipped.
 ./scripts/fix-ruleset-bypass.sh <repo>
 ```
 
-> `apply-rulesets.sh` full-replaces `pr-quality` / `code-quality` with the two
-> canonical bypass actors; `fix-ruleset-bypass.sh` is the least-destructive,
-> any-ruleset complement used to remediate audit findings.
+> `apply-rulesets.sh` full-replaces `pr-quality` / `code-quality` from the codified
+> `standards/rulesets/*.json` (which carry the two canonical bypass actors);
+> `fix-ruleset-bypass.sh` is the least-destructive, any-ruleset complement used to
+> remediate audit findings.
 
 ## 3. Legacy rulesets — migrate checks first, THEN delete
 

--- a/test/scripts/apply-rulesets/apply-rulesets.bats
+++ b/test/scripts/apply-rulesets/apply-rulesets.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+# Unit tests for scripts/apply-rulesets.sh — the codified, file-driven applier that
+# replaced the retired detection-based builder (petry-projects/.github#580 / #575).
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+APPLY="$SCRIPT_DIR/scripts/apply-rulesets.sh"
+RULESETS_DIR="$SCRIPT_DIR/standards/rulesets"
+
+setup() {
+  STUB_BIN="$(mktemp -d)"; export PATH="$STUB_BIN:$PATH"
+  CALLS="$STUB_BIN/calls.log"; export CALLS
+}
+teardown() { [ -n "${STUB_BIN:-}" ] && rm -rf "$STUB_BIN"; return 0; }
+
+# gh stub: records writes (POST/PUT) to $CALLS; returns $RULESETS_LIST for the
+# rulesets LIST (default [] → create path); returns $REPO_LIST for `repo list`.
+_stub_gh() {
+  cat > "$STUB_BIN/gh" <<EOF
+#!/usr/bin/env bash
+args="\$*"
+case "\$args" in
+  *"--method POST"*|*"--method PUT"*) echo "\$args" >> "$CALLS"; echo '{}' ;;
+  *"repo list"*) printf '%s' "\${REPO_LIST:-}" ;;
+  *"rulesets"*)  printf '%s' "\${RULESETS_LIST:-[]}" ;;
+  *) echo '{}' ;;
+esac
+EOF
+  chmod +x "$STUB_BIN/gh"
+}
+
+# ── codified source of truth: shape + the anti-divergence guard (#580) ────────
+@test "code-quality.json: requires exactly the 4 codified contexts" {
+  run jq -r '[.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context] | sort | join(",")' "$RULESETS_DIR/code-quality.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "CodeQL,SonarCloud,agent-shield / AgentShield,dependency-audit / Detect ecosystems" ]
+}
+
+@test "code-quality.json: does NOT require 'Dev-Lead Agent' (the retired divergence)" {
+  run jq -e '[.rules[]?.parameters?.required_status_checks?[]?.context] | any(. // "" | test("Dev-Lead"))' "$RULESETS_DIR/code-quality.json"
+  # jq `any` over no match exits 1 (false) — that is the pass condition.
+  [ "$status" -ne 0 ]
+}
+
+@test "pr-quality.json + code-quality.json carry both bypass actors (OrgAdmin + Integration)" {
+  local f
+  for f in pr-quality code-quality; do
+    run jq -e '[.bypass_actors[].actor_type] | (index("OrganizationAdmin") and index("Integration"))' "$RULESETS_DIR/$f.json"
+    [ "$status" -eq 0 ]
+  done
+}
+
+# ── apply behavior: create / update / dry-run ─────────────────────────────────
+@test "apply --repo: creates rulesets when absent (POST per file)" {
+  _stub_gh
+  export RULESETS_LIST='[]'
+  run bash "$APPLY" --repo petry-projects/acme
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"done (2 ruleset(s))"* ]]
+  [ "$(grep -c 'method POST' "$CALLS")" -eq 2 ]
+  ! grep -q 'method PUT' "$CALLS"
+}
+
+@test "apply --repo: updates when present (PUT by id)" {
+  _stub_gh
+  export RULESETS_LIST='[{"id":7,"name":"code-quality"},{"id":9,"name":"pr-quality"}]'
+  run bash "$APPLY" --repo petry-projects/acme
+  [ "$status" -eq 0 ]
+  grep -q 'method PUT' "$CALLS"
+  ! grep -q 'method POST' "$CALLS"
+}
+
+@test "apply: --dry-run makes no write calls" {
+  _stub_gh
+  export RULESETS_LIST='[]'
+  run bash "$APPLY" --repo petry-projects/acme --dry-run
+  [ "$status" -eq 0 ]
+  [ ! -f "$CALLS" ]
+  [[ "$output" == *"dry-run"* ]]
+}
+
+# ── target resolution: bare name (back-compat) + name filter ──────────────────
+@test "apply: a bare <repo-name> resolves to \$ORG/<name>" {
+  _stub_gh
+  export RULESETS_LIST='[]'
+  run bash "$APPLY" acme --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"repo=petry-projects/acme"* ]]
+}
+
+@test "apply: a name filter applies only that ruleset" {
+  _stub_gh
+  export RULESETS_LIST='[]'
+  run bash "$APPLY" --repo petry-projects/acme code-quality --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"code-quality"* ]]
+  [[ "$output" != *"pr-quality"* ]]
+  [[ "$output" == *"done (1 ruleset(s))"* ]]
+}
+
+@test "apply: unknown ruleset name errors" {
+  _stub_gh
+  run bash "$APPLY" --repo petry-projects/acme no-such-ruleset
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no ruleset file no-such-ruleset.json"* ]]
+}
+
+# ── fleet mode ────────────────────────────────────────────────────────────────
+@test "apply --all: iterates every non-archived org repo" {
+  _stub_gh
+  export RULESETS_LIST='[]' REPO_LIST=$'alpha\nbeta'
+  run bash "$APPLY" --all --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"repo=petry-projects/alpha"* ]]
+  [[ "$output" == *"repo=petry-projects/beta"* ]]
+  [[ "$output" == *"across the fleet"* ]]
+}
+
+@test "apply: --all and --repo are mutually exclusive" {
+  _stub_gh
+  run bash "$APPLY" --all --repo petry-projects/acme
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"mutually exclusive"* ]]
+}
+
+@test "apply: a bare token after --all is a ruleset-name filter (unknown → errors)" {
+  _stub_gh
+  export REPO_LIST=$'alpha'
+  run bash "$APPLY" --all not-a-ruleset --dry-run
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no ruleset file not-a-ruleset.json"* ]]
+}
+
+# ── sourced helpers ───────────────────────────────────────────────────────────
+@test "ruleset_id_by_name: resolves id from the list" {
+  _stub_gh
+  export RULESETS_LIST='[{"id":42,"name":"pr-quality"},{"id":7,"name":"code-quality"}]'
+  run bash -c "source '$APPLY' && ruleset_id_by_name petry-projects/acme code-quality"
+  [ "$status" -eq 0 ]; [ "$output" = "7" ]
+}


### PR DESCRIPTION
## Summary

Implements your **#580 decision — Option 1 (retire)**, not the annotate that dev-lead delivered. **Supersedes #583.**

Replaces the detection-based `apply-rulesets.sh` (which probed each repo's workflows and *generated* the ruleset in-code — the source of the `Dev-Lead Agent` divergence) with the **codified, file-driven** applier reading the `standards/rulesets/*.json` source of truth. Net **−400 lines**.

## The new applier
- Reads local [`standards/rulesets/`](../tree/main/standards/rulesets) (co-located in `.github`).
- `--repo owner/repo` · `<repo-name>` (back-compat positional) · `--all` · `--dry-run` · optional `[<name>…]` filter.
- Find-or-create per ruleset (PUT by id / POST); idempotent.

## "Ensure all detection items are in the file-driven approach" — nothing org-wide is lost
| Detection item | Where it lives now |
|---|---|
| SonarCloud, CodeQL, agent-shield/AgentShield, dependency-audit/Detect ecosystems | Static in `code-quality.json` |
| **Dev-Lead Agent** | Intentionally excluded (the divergence this retires) |
| CI Pipeline (`build-and-test`) | Repo-specific job → per-repo branch protection |
| Secret scan (gitleaks) + coverage | Template-produced; staged fleet-wide via #581 |

Documented in the applier header + `github-settings.md`.

## Tests + CI (salvages #583's guard)
- `test/scripts/apply-rulesets/apply-rulesets.bats` — 13 tests, incl. a **"code-quality.json does NOT require Dev-Lead Agent"** guard (the anti-divergence check, now against the codified source rather than the retired script).
- `.github/workflows/apply-rulesets-tests.yml` — shellcheck + bats.

## Reference reconciliation (detection language → codified model)
`github-settings.md` (intro, preamble, **SonarCloud row** — was detection-derived `SonarCloud Analysis / SonarCloud`, codified is `SonarCloud`), `ci-standards.md §CodeQL`, `push-protection.md` step 4, `compliance-audit.sh` remediation message, `ruleset-remediation-runbook.md`, and a **dated correction note** in `pull-request-limits-adr.md` (its "no static JSON / generated in-code" premise no longer holds; the §7.2/7.3 conclusion is unaffected).

## Verified
- shellcheck + yamllint + actionlint + markdownlint clean; 13/13 bats.
- Live `--dry-run` against `petry-projects/.github-private` resolves the **local** `standards/rulesets/` and **updates the existing rulesets in place** (PUT by id, no recreate).

## Follow-up (noted, out of scope)
`.github-private` still has its own file-driven applier (#1013) for bootstrap + `release-channel-tags`. It reads the **same** codified source, so there's **no divergence** — but collapsing to a single physical applier (the cross-repo "bootstrap story" #583 punted on) is a separate step.

Closes #580.

🤖 Generated with [Claude Code](https://claude.com/claude-code)