### PR TITLE
feat: org-wide SonarCloud audit → idempotent, priority-labeled issues

### DIFF
--- a/.github/workflows/sonarcloud-audit-tests.yml
+++ b/.github/workflows/sonarcloud-audit-tests.yml
@@ -1,0 +1,53 @@
+# Quality gates for the SonarCloud audit script and its unit tests.
+#
+# Gates (all must pass before merge):
+#   1. shellcheck — static analysis for the audit script
+#   2. bats       — unit tests for its pure helpers (rule→family classification,
+#                   project→repo mapping, severity→priority-label mapping)
+name: SonarCloud Audit Tests
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/sonarcloud-audit.sh'
+      - 'test/scripts/sonarcloud-audit/**'
+      - '.github/workflows/sonarcloud-audit-tests.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'scripts/sonarcloud-audit.sh'
+      - 'test/scripts/sonarcloud-audit/**'
+      - '.github/workflows/sonarcloud-audit-tests.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sonarcloud-audit-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Lint and bats
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: Install bats, shellcheck, and jq
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends bats shellcheck jq
+
+      - name: shellcheck
+        run: |
+          set -euo pipefail
+          shellcheck --severity=warning -x scripts/sonarcloud-audit.sh
+
+      - name: Run bats suite
+        run: bats --print-output-on-failure test/scripts/sonarcloud-audit/

--- a/.github/workflows/sonarcloud-audit.yml
+++ b/.github/workflows/sonarcloud-audit.yml
@@ -3,15 +3,18 @@
 # Scans every SonarCloud project in the org, groups open findings per
 # (repo × rule-family workstream), and idempotently creates/updates/closes one
 # GitHub issue per group with dev-lead + priority:<severity> labels. Emits a
-# dashboard to the workflow step summary. Runs Mondays, offset from the Friday
-# compliance audit so the two do not contend for the same issue surface.
+# dashboard to the workflow step summary. Runs Tuesdays around midday US Central,
+# offset from the Friday compliance audit so the two do not contend for the same
+# issue surface.
 #
 # Idempotency, labeling, and lifecycle live in scripts/sonarcloud-audit.sh.
 name: SonarCloud Audit
 
 on:
   schedule:
-    - cron: '0 13 * * 1'   # Every Monday at 13:00 UTC
+    # 17:15 UTC = 12:15 US Central during CDT (summer). GitHub cron is UTC-only
+    # and does not observe DST, so this lands at 11:15 Central during CST (winter).
+    - cron: '15 17 * * 2'   # Every Tuesday at 17:15 UTC
   workflow_dispatch:
     inputs:
       target_repo:

--- a/.github/workflows/sonarcloud-audit.yml
+++ b/.github/workflows/sonarcloud-audit.yml
@@ -1,0 +1,73 @@
+# Weekly org-wide SonarCloud audit.
+#
+# Scans every SonarCloud project in the org, groups open findings per
+# (repo × rule-family workstream), and idempotently creates/updates/closes one
+# GitHub issue per group with dev-lead + priority:<severity> labels. Emits a
+# dashboard to the workflow step summary. Runs Mondays, offset from the Friday
+# compliance audit so the two do not contend for the same issue surface.
+#
+# Idempotency, labeling, and lifecycle live in scripts/sonarcloud-audit.sh.
+name: SonarCloud Audit
+
+on:
+  schedule:
+    - cron: '0 13 * * 1'   # Every Monday at 13:00 UTC
+  workflow_dispatch:
+    inputs:
+      target_repo:
+        description: 'Limit to a specific repo (owner/name or name). Leave blank to scan all.'
+        required: false
+        type: string
+      dry_run:
+        description: 'Dry run — scan and report only, skip issue writes'
+        required: false
+        default: 'false'
+        type: boolean
+
+permissions: {}
+
+concurrency:
+  group: sonarcloud-audit
+  cancel-in-progress: false   # let a running audit finish to avoid partial issue state
+
+jobs:
+  audit:
+    name: SonarCloud Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
+    env:
+      GH_TOKEN: ${{ secrets.ORG_SCORECARD_TOKEN }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    steps:
+      - name: Checkout .github repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Run SonarCloud audit
+        env:
+          ORG: ${{ github.repository_owner }}
+          SONAR_ORG: ${{ github.repository_owner }}
+          REPORT_DIR: ${{ runner.temp }}/sonarcloud-report
+          TARGET_REPO: ${{ inputs.target_repo || '' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          CREATE_ISSUES: 'true'
+        run: bash scripts/sonarcloud-audit.sh
+
+      - name: Write step summary
+        if: always()
+        run: |
+          if [ -f "${{ runner.temp }}/sonarcloud-report/summary.md" ]; then
+            cat "${{ runner.temp }}/sonarcloud-report/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "SonarCloud audit did not produce a summary." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload audit report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sonarcloud-report
+          path: ${{ runner.temp }}/sonarcloud-report/
+          retention-days: 90

--- a/scripts/sonarcloud-audit.sh
+++ b/scripts/sonarcloud-audit.sh
@@ -166,15 +166,24 @@ _sonar_get() {
 
 # Echo the list of SonarCloud project keys in the org.
 sonar_list_projects() {
-  _sonar_get "/api/components/search?organization=${SONAR_ORG}&qualifiers=TRK&ps=500" \
-    | jq -r '.components[].key'
+  local page=1 resp total page_count
+  while :; do
+    resp=$(_sonar_get "/api/components/search?organization=${SONAR_ORG}&qualifiers=TRK&ps=500&p=${page}") \
+      || { warn "sonar_list_projects: page ${page} fetch failed — results may be incomplete"; return 1; }
+    echo "$resp" | jq -r '.components[].key'
+    total=$(echo "$resp" | jq '.paging.total')
+    page_count=$(echo "$resp" | jq '.components | length')
+    { [ "$((page * 500))" -ge "$total" ] || [ "$page_count" -eq 0 ]; } && break
+    page=$((page + 1))
+  done
 }
 
 # Fetch all open issues for a project as a JSON array (paginated).
 sonar_project_issues() {
   local key="$1" page=1 out="[]" resp total fetched=0
   while :; do
-    resp=$(_sonar_get "/api/issues/search?organization=${SONAR_ORG}&componentKeys=${key}&resolved=false&ps=500&p=${page}") || break
+    resp=$(_sonar_get "/api/issues/search?organization=${SONAR_ORG}&componentKeys=${key}&resolved=false&ps=500&p=${page}") \
+      || { warn "sonar_project_issues: page ${page} fetch failed for ${key} — results may be incomplete"; return 1; }
     total=$(echo "$resp" | jq '.total')
     out=$(jq -s '.[0] + .[1]' <(echo "$out") <(echo "$resp" | jq '.issues'))
     fetched=$(echo "$out" | jq 'length')
@@ -194,16 +203,17 @@ scan() {
     target_name="${TARGET_REPO#"$ORG/"}"
   fi
 
-  echo "[]" > "$FINDINGS_FILE"
+  local ndjson_file="$REPORT_DIR/findings.ndjson"
+  : > "$ndjson_file"
   local project repo issues family
 
   for project in $(sonar_list_projects); do
     repo=$(sonar_project_to_repo "$project")
     [ -n "$target_name" ] && [ "$repo" != "$target_name" ] && continue
-    info "Scanning $project → $repo"
+    info "Scanning $project -> $repo"
     issues=$(sonar_project_issues "$project")
 
-    # Emit one finding per issue with its computed family.
+    # Emit one NDJSON object per issue with its computed family.
     while IFS= read -r row; do
       [ -z "$row" ] && continue
       local rule sev typ msg comp
@@ -213,18 +223,25 @@ scan() {
       msg=$(echo "$row" | jq -r '.message // ""')
       comp=$(echo "$row" | jq -r '.component // "" | sub("^[^:]+:";"")')
       family=$(classify_workstream "$rule")
-      jq --arg repo "$repo" --arg project "$project" --arg rule "$rule" \
+      jq -n --arg repo "$repo" --arg project "$project" --arg rule "$rule" \
          --arg severity "$sev" --arg type "$typ" --arg family "$family" \
          --arg message "$msg" --arg file "$comp" \
-         '. += [{repo:$repo,project:$project,rule:$rule,severity:$severity,type:$type,family:$family,message:$message,file:$file}]' \
-         "$FINDINGS_FILE" > "$FINDINGS_FILE.tmp" && mv "$FINDINGS_FILE.tmp" "$FINDINGS_FILE"
+         '{repo:$repo,project:$project,rule:$rule,severity:$severity,type:$type,family:$family,message:$message,file:$file}' \
+         >> "$ndjson_file"
     done < <(echo "$issues" | jq -c '.[]')
   done
+
+  # Convert NDJSON to a JSON array in a single O(n) pass.
+  if [ -s "$ndjson_file" ]; then
+    jq -s '.' "$ndjson_file" > "$FINDINGS_FILE"
+  else
+    echo "[]" > "$FINDINGS_FILE"
+  fi
 
   # Aggregate into per (repo, family) groups.
   jq '
     def sevrank: {"BLOCKER":5,"CRITICAL":4,"MAJOR":3,"MINOR":2,"INFO":1}[.] // 0;
-    group_by(.repo + " " + .family)
+    sort_by(.repo, .family) | group_by([.repo, .family])
     | map({
         repo: .[0].repo,
         project: .[0].project,
@@ -232,8 +249,8 @@ scan() {
         count: length,
         has_vuln: (any(.[]; .type == "VULNERABILITY")),
         max_severity: (max_by(.severity | sevrank) | .severity),
-        rules: (group_by(.rule) | map({rule: .[0].rule, count: length, message: .[0].message}) | sort_by(-.count)),
-        files: (group_by(.file) | map({file: .[0].file, count: length}) | sort_by(-.count))
+        rules: (sort_by(.rule) | group_by(.rule) | map({rule: .[0].rule, count: length, message: .[0].message}) | sort_by(-.count)),
+        files: (sort_by(.file) | group_by(.file) | map({file: .[0].file, count: length}) | sort_by(-.count))
       })
     | sort_by(.repo, .family)
   ' "$FINDINGS_FILE" > "$GROUPS_FILE"

--- a/scripts/sonarcloud-audit.sh
+++ b/scripts/sonarcloud-audit.sh
@@ -109,6 +109,14 @@ family_is_security() {
   esac
 }
 
+# Stable idempotency key, embedded as a hidden HTML comment in each issue body.
+# Keyed on repo/family so matching survives human title edits and lets the audit
+# ADOPT (rather than duplicate) a pre-existing issue that carries the marker.
+# args: <repo> <family>
+issue_marker() {
+  echo "<!-- sonarcloud-audit:key=$1/$2 -->"
+}
+
 # Numeric rank for a Sonar severity (higher = worse). Used to pick a bucket's
 # worst severity for its priority label.
 severity_rank() {
@@ -295,6 +303,8 @@ Labeled \`$(severity_priority_label "$max_sev")\` — mapped from this bucket's 
 
 ---
 *Idempotent issue — updated automatically each audit run; auto-closed when the finding count reaches zero.*
+
+$(issue_marker "$repo" "$family")
 BODY
 }
 
@@ -323,10 +333,13 @@ manage_group_issue() {
 
   ensure_labels "$repo"
 
-  local existing
+  # Match on the hidden body marker (repo/family), not the human title — robust
+  # to title edits and lets the audit adopt a pre-existing marker-bearing issue.
+  local existing marker
+  marker="sonarcloud-audit:key=${repo}/${family}"
   existing=$(gh issue list --repo "$ORG/$repo" --label "$SONAR_AUDIT_LABEL" --state open \
-    --search "\"$stable_title\" in:title" --json number,title \
-    -q ".[] | select(.title == \"$stable_title\") | .number" 2>/dev/null | head -1 || echo "")
+    --json number,body --limit 200 2>/dev/null \
+    | jq -r --arg m "$marker" '.[] | select((.body // "") | contains($m)) | .number' 2>/dev/null | head -1 || echo "")
 
   if [ -n "$existing" ]; then
     # Refresh the dashboard body + ensure current priority label, drop stale ones.
@@ -366,22 +379,25 @@ manage_group_issue() {
 }
 
 # Close audit issues whose (repo, family) group no longer has findings.
+# Reads the family from each issue's hidden body marker (not its title), so a
+# renamed issue is still matched to its group.
 close_resolved() {
   local repo="$1"
   local open_issues
   open_issues=$(gh issue list --repo "$ORG/$repo" --label "$SONAR_AUDIT_LABEL" --state open \
-    --json number,title -q '.[] | "\(.number)\t\(.title)"' 2>/dev/null || echo "")
+    --json number,body --limit 200 2>/dev/null \
+    | jq -r '.[] | "\(.number)\t" + ((.body // "") | (try (capture("sonarcloud-audit:key=[^/]+/(?<fam>[a-z0-9]+)").fam) catch ""))' 2>/dev/null || echo "")
   [ -z "$open_issues" ] && return
 
-  # Current family titles present for this repo.
-  local current_titles
-  current_titles=$(jq -r --arg repo "$repo" '.[] | select(.repo == $repo) | .family' "$GROUPS_FILE" 2>/dev/null \
-    | while read -r fam; do [ -n "$fam" ] && echo "SonarCloud: $(family_title "$fam")"; done)
+  # Families currently present for this repo.
+  local current_fams
+  current_fams=$(jq -r --arg repo "$repo" '.[] | select(.repo == $repo) | .family' "$GROUPS_FILE" 2>/dev/null)
 
-  local num ttl
-  while IFS=$'\t' read -r num ttl; do
+  local num fam
+  while IFS=$'\t' read -r num fam; do
     [ -z "$num" ] && continue
-    if ! echo "$current_titles" | grep -qxF "$ttl"; then
+    [ -z "$fam" ] && continue   # not a marker-bearing audit issue — leave it alone
+    if ! echo "$current_fams" | grep -qxF "$fam"; then
       gh issue close "$num" --repo "$ORG/$repo" \
         --comment "Resolved! No open SonarCloud findings remain in this workstream as of $(date -u +%Y-%m-%d). Closing automatically." 2>/dev/null \
         && { ISSUES_REMOVED=$((ISSUES_REMOVED + 1)); info "Closed resolved #$num in $repo"; } || true

--- a/scripts/sonarcloud-audit.sh
+++ b/scripts/sonarcloud-audit.sh
@@ -1,0 +1,465 @@
+#!/usr/bin/env bash
+# Org-wide SonarCloud audit → idempotent GitHub issues.
+#
+# Scans every SonarCloud project in the organization, groups open findings
+# per (GitHub repo × rule-family workstream), and creates/updates/closes one
+# GitHub issue per group. Issues carry:
+#   - dev-lead            → autonomous remediation pickup (all findings)
+#   - sonarcloud-audit    → marker label for idempotent listing/closing
+#   - priority:<severity> → prioritization from the bucket's worst Sonar severity
+#   - security            → when the family or any finding is a vulnerability
+#
+# Idempotency: one issue per (repo, family), keyed by a STABLE title
+# "SonarCloud: <family title>". Re-runs update the body/comment and re-trigger
+# dev-lead on persistent findings; groups that drop to zero are auto-closed.
+#
+# Env:
+#   ORG            GitHub owner            (default: petry-projects)
+#   SONAR_ORG      SonarCloud organization (default: petry-projects)
+#   SONAR_URL      SonarCloud base URL     (default: https://sonarcloud.io)
+#   SONAR_TOKEN    optional; enables auth (private projects, higher rate limits)
+#   REPORT_DIR     output dir              (default: mktemp -d)
+#   TARGET_REPO    limit to one repo (owner/name or name); blank = all
+#   DRY_RUN        "true" → scan + report, no issue writes   (default: false)
+#   CREATE_ISSUES  "true" → manage issues                    (default: true)
+#
+# Standard: https://github.com/<owner>/.github/tree/main/standards
+set -euo pipefail
+
+ORG="${ORG:-petry-projects}"
+SONAR_ORG="${SONAR_ORG:-petry-projects}"
+SONAR_URL="${SONAR_URL:-https://sonarcloud.io}"
+SONAR_AUDIT_LABEL="sonarcloud-audit"
+DRY_RUN="${DRY_RUN:-false}"
+CREATE_ISSUES="${CREATE_ISSUES:-true}"
+TARGET_REPO="${TARGET_REPO:-}"
+REPORT_DIR="${REPORT_DIR:-$(mktemp -d)}"
+
+FINDINGS_FILE="$REPORT_DIR/findings.json"
+GROUPS_FILE="$REPORT_DIR/groups.json"
+SUMMARY_FILE="$REPORT_DIR/summary.md"
+COUNTS_FILE="$REPORT_DIR/issue-counts.json"
+
+ISSUES_ADDED=0
+ISSUES_EXISTING=0
+ISSUES_RETRIGGERED=0
+ISSUES_REMOVED=0
+
+# Shared dev-lead retrigger helpers — dl_dev_lead_active() and
+# dl_cycle_trigger_label(). Only sourced when present (skipped under bats).
+_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/dev-lead-retrigger.sh"
+# shellcheck source=/dev/null
+[ -f "$_LIB" ] && source "$_LIB"
+
+info() { echo "[info] $*" >&2; }
+warn() { echo "[warn] $*" >&2; }
+
+# ---------------------------------------------------------------------------
+# Pure helpers (unit-tested via bats; keep free of side effects)
+# ---------------------------------------------------------------------------
+
+# Map a SonarCloud project key → GitHub repo name.
+# Strips the "<org>_" prefix; a small override table handles projects whose
+# key diverges from the repo (e.g. a re-provisioned project with a "2" suffix).
+sonar_project_to_repo() {
+  local key="$1"
+  local stripped="${key#"${SONAR_ORG}"_}"
+  case "$stripped" in
+    broodminder-export2) echo "broodminder-export" ;;
+    *)                   echo "$stripped" ;;
+  esac
+}
+
+# Classify a Sonar rule into a stable workstream family.
+# Ordering matters: more specific rules first.
+classify_workstream() {
+  case "$1" in
+    githubactions:S7635)                 echo "s7635" ;;
+    githubactions:S1135)                 echo "misc" ;;
+    githubactions:*|text:S8564|text:S8565) echo "ghactions" ;;
+    shelldre:*)                          echo "shell" ;;
+    pythonsecurity:*)                    echo "pysec" ;;
+    *:S3776)                             echo "complexity" ;;
+    javascript:S5906)                    echo "tests" ;;
+    javascript:*|typescript:*)           echo "jsquality" ;;
+    *)                                   echo "misc" ;;
+  esac
+}
+
+# Human-readable title for a family (used verbatim in the stable issue title).
+family_title() {
+  case "$1" in
+    s7635)      echo "S7635 secrets-inherit caller stubs" ;;
+    ghactions)  echo "GitHub Actions / dependency hardening" ;;
+    pysec)      echo "code security review (pythonsecurity)" ;;
+    complexity) echo "cognitive complexity (S3776)" ;;
+    shell)      echo "shell script hygiene" ;;
+    tests)      echo "test assertion quality (S5906)" ;;
+    jsquality)  echo "JavaScript/TypeScript code quality" ;;
+    *)          echo "miscellaneous findings" ;;
+  esac
+}
+
+# Families that are inherently security-relevant (get the `security` label even
+# when Sonar classifies the item as a CODE_SMELL).
+family_is_security() {
+  case "$1" in
+    s7635|ghactions|pysec) return 0 ;;
+    *)                     return 1 ;;
+  esac
+}
+
+# Numeric rank for a Sonar severity (higher = worse). Used to pick a bucket's
+# worst severity for its priority label.
+severity_rank() {
+  case "$1" in
+    BLOCKER)  echo 5 ;;
+    CRITICAL) echo 4 ;;
+    MAJOR)    echo 3 ;;
+    MINOR)    echo 2 ;;
+    INFO)     echo 1 ;;
+    *)        echo 0 ;;
+  esac
+}
+
+# Map a Sonar severity → prioritization label (faithful 1:1 with Sonar's scale).
+severity_priority_label() {
+  case "$1" in
+    BLOCKER)  echo "priority:blocker" ;;
+    CRITICAL) echo "priority:critical" ;;
+    MAJOR)    echo "priority:major" ;;
+    MINOR)    echo "priority:minor" ;;
+    INFO)     echo "priority:info" ;;
+    *)        echo "priority:minor" ;;
+  esac
+}
+
+# Hex color for a priority label (escalating red→grey).
+priority_label_color() {
+  case "$1" in
+    priority:blocker)  echo "b60205" ;;
+    priority:critical) echo "d93f0b" ;;
+    priority:major)    echo "fbca04" ;;
+    priority:minor)    echo "0e8a16" ;;
+    priority:info)     echo "c5def5" ;;
+    *)                 echo "ededed" ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# SonarCloud API
+# ---------------------------------------------------------------------------
+_sonar_get() {
+  local path="$1"
+  local auth=()
+  [ -n "${SONAR_TOKEN:-}" ] && auth=(-u "${SONAR_TOKEN}:")
+  curl -sf "${auth[@]}" "${SONAR_URL}${path}"
+}
+
+# Echo the list of SonarCloud project keys in the org.
+sonar_list_projects() {
+  _sonar_get "/api/components/search?organization=${SONAR_ORG}&qualifiers=TRK&ps=500" \
+    | jq -r '.components[].key'
+}
+
+# Fetch all open issues for a project as a JSON array (paginated).
+sonar_project_issues() {
+  local key="$1" page=1 out="[]" resp total fetched=0
+  while :; do
+    resp=$(_sonar_get "/api/issues/search?organization=${SONAR_ORG}&componentKeys=${key}&resolved=false&ps=500&p=${page}") || break
+    total=$(echo "$resp" | jq '.total')
+    out=$(jq -s '.[0] + .[1]' <(echo "$out") <(echo "$resp" | jq '.issues'))
+    fetched=$(echo "$out" | jq 'length')
+    { [ "$fetched" -ge "$total" ] || [ "$(echo "$resp" | jq '.issues | length')" -eq 0 ]; } && break
+    page=$((page + 1))
+    [ "$page" -gt 40 ] && break   # 20k-issue backstop
+  done
+  echo "$out"
+}
+
+# ---------------------------------------------------------------------------
+# Scan: build findings.json (flat) then groups.json (per repo × family)
+# ---------------------------------------------------------------------------
+scan() {
+  local target_name=""
+  if [ -n "$TARGET_REPO" ]; then
+    target_name="${TARGET_REPO#"$ORG/"}"
+  fi
+
+  echo "[]" > "$FINDINGS_FILE"
+  local project repo issues family
+
+  for project in $(sonar_list_projects); do
+    repo=$(sonar_project_to_repo "$project")
+    [ -n "$target_name" ] && [ "$repo" != "$target_name" ] && continue
+    info "Scanning $project → $repo"
+    issues=$(sonar_project_issues "$project")
+
+    # Emit one finding per issue with its computed family.
+    while IFS= read -r row; do
+      [ -z "$row" ] && continue
+      local rule sev typ msg comp
+      rule=$(echo "$row" | jq -r '.rule')
+      sev=$(echo "$row" | jq -r '.severity // "MINOR"')
+      typ=$(echo "$row" | jq -r '.type // "CODE_SMELL"')
+      msg=$(echo "$row" | jq -r '.message // ""')
+      comp=$(echo "$row" | jq -r '.component // "" | sub("^[^:]+:";"")')
+      family=$(classify_workstream "$rule")
+      jq --arg repo "$repo" --arg project "$project" --arg rule "$rule" \
+         --arg severity "$sev" --arg type "$typ" --arg family "$family" \
+         --arg message "$msg" --arg file "$comp" \
+         '. += [{repo:$repo,project:$project,rule:$rule,severity:$severity,type:$type,family:$family,message:$message,file:$file}]' \
+         "$FINDINGS_FILE" > "$FINDINGS_FILE.tmp" && mv "$FINDINGS_FILE.tmp" "$FINDINGS_FILE"
+    done < <(echo "$issues" | jq -c '.[]')
+  done
+
+  # Aggregate into per (repo, family) groups.
+  jq '
+    def sevrank: {"BLOCKER":5,"CRITICAL":4,"MAJOR":3,"MINOR":2,"INFO":1}[.] // 0;
+    group_by(.repo + " " + .family)
+    | map({
+        repo: .[0].repo,
+        project: .[0].project,
+        family: .[0].family,
+        count: length,
+        has_vuln: (any(.[]; .type == "VULNERABILITY")),
+        max_severity: (max_by(.severity | sevrank) | .severity),
+        rules: (group_by(.rule) | map({rule: .[0].rule, count: length, message: .[0].message}) | sort_by(-.count)),
+        files: (group_by(.file) | map({file: .[0].file, count: length}) | sort_by(-.count))
+      })
+    | sort_by(.repo, .family)
+  ' "$FINDINGS_FILE" > "$GROUPS_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# Issue management
+# ---------------------------------------------------------------------------
+ensure_labels() {
+  local repo="$1"
+  local specs=(
+    "sonarcloud-audit|1f6feb|SonarCloud audit finding (idempotent marker)"
+    "dev-lead|8B5CF6|For dev-lead agent pickup"
+    "security|d93f0b|Security-related PRs and issues"
+    "priority:blocker|b60205|SonarCloud BLOCKER severity"
+    "priority:critical|d93f0b|SonarCloud CRITICAL severity"
+    "priority:major|fbca04|SonarCloud MAJOR severity"
+    "priority:minor|0e8a16|SonarCloud MINOR severity"
+    "priority:info|c5def5|SonarCloud INFO severity"
+  )
+  local name color desc
+  for spec in "${specs[@]}"; do
+    IFS='|' read -r name color desc <<< "$spec"
+    gh label create "$name" --repo "$ORG/$repo" --color "$color" \
+      --description "$desc" --force 2>/dev/null || true
+  done
+}
+
+# Render the issue body (dashboard) for a group JSON object.
+render_body() {
+  local group="$1"
+  local repo family project count max_sev title
+  repo=$(echo "$group" | jq -r '.repo')
+  family=$(echo "$group" | jq -r '.family')
+  project=$(echo "$group" | jq -r '.project')
+  count=$(echo "$group" | jq -r '.count')
+  max_sev=$(echo "$group" | jq -r '.max_severity')
+  title=$(family_title "$family")
+
+  local rules_tbl files_tbl
+  rules_tbl=$(echo "$group" | jq -r '
+    .rules[] | "| [\(.rule)](https://rules.sonarsource.com/\(.rule | split(":")[0])/RULE/\(.rule | split(":")[1])/) | \(.count) | \((.message // "")[0:90] | gsub("\\|";"\\\\|")) |"')
+  files_tbl=$(echo "$group" | jq -r '.files[0:20][] | "- `\(.file)` (\(.count))"')
+
+  cat <<BODY
+## SonarCloud: ${title}
+
+**${count}** open SonarCloud finding(s) in \`${ORG}/${repo}\`, worst severity **${max_sev}**. Generated by the org [SonarCloud Audit](https://github.com/${ORG}/.github/blob/main/.github/workflows/sonarcloud-audit.yml).
+
+[View in SonarCloud →](${SONAR_URL}/project/issues?id=${project}&resolved=false)
+
+### Findings
+| Rule | Count | Representative message |
+|---|---:|---|
+${rules_tbl}
+
+### Affected files
+${files_tbl}
+
+### Priority
+Labeled \`$(severity_priority_label "$max_sev")\` — mapped from this bucket's worst SonarCloud severity (\`${max_sev}\`).
+
+### Acceptance
+- [ ] All findings in this workstream resolved to zero in SonarCloud
+- [ ] No behavior change; CI green
+- [ ] Real fixes (no blanket \`NOSONAR\` unless a confirmed false positive, noted inline)
+
+---
+*Idempotent issue — updated automatically each audit run; auto-closed when the finding count reaches zero.*
+BODY
+}
+
+# Create or update the issue for a single group.
+manage_group_issue() {
+  local group="$1"
+  local repo family title stable_title max_sev prio labels
+  repo=$(echo "$group" | jq -r '.repo')
+  family=$(echo "$group" | jq -r '.family')
+  max_sev=$(echo "$group" | jq -r '.max_severity')
+  stable_title="SonarCloud: $(family_title "$family")"
+  prio=$(severity_priority_label "$max_sev")
+
+  labels="$SONAR_AUDIT_LABEL,dev-lead,$prio"
+  if family_is_security "$family" || [ "$(echo "$group" | jq -r '.has_vuln')" = "true" ]; then
+    labels="$labels,security"
+  fi
+
+  local body
+  body=$(render_body "$group")
+
+  if [ "$DRY_RUN" = "true" ] || [ "$CREATE_ISSUES" != "true" ]; then
+    info "[dry-run] $repo :: $stable_title [$labels]"
+    return
+  fi
+
+  ensure_labels "$repo"
+
+  local existing
+  existing=$(gh issue list --repo "$ORG/$repo" --label "$SONAR_AUDIT_LABEL" --state open \
+    --search "\"$stable_title\" in:title" --json number,title \
+    -q ".[] | select(.title == \"$stable_title\") | .number" 2>/dev/null | head -1 || echo "")
+
+  if [ -n "$existing" ]; then
+    # Refresh the dashboard body + ensure current priority label, drop stale ones.
+    gh issue edit "$existing" --repo "$ORG/$repo" --body "$body" \
+      --add-label "$prio" 2>/dev/null || true
+    local other
+    for other in priority:blocker priority:critical priority:major priority:minor priority:info; do
+      [ "$other" != "$prio" ] && gh issue edit "$existing" --repo "$ORG/$repo" \
+        --remove-label "$other" 2>/dev/null || true
+    done
+    gh issue comment "$existing" --repo "$ORG/$repo" \
+      --body "**SonarCloud Audit** ($(date -u +%Y-%m-%d)): still open — $(echo "$group" | jq -r '.count') finding(s), worst severity \`${max_sev}\`." 2>/dev/null || true
+    ISSUES_EXISTING=$((ISSUES_EXISTING + 1))
+    info "Updated #$existing in $repo :: $stable_title"
+
+    # Re-engage dev-lead on persistent findings (cycle the trigger label unless
+    # dev-lead is already working the issue).
+    if declare -f dl_dev_lead_active >/dev/null 2>&1 && dl_dev_lead_active "$ORG" "$repo" "$existing"; then
+      info "#$existing in $repo — dev-lead already active, not re-triggering"
+    elif declare -f dl_cycle_trigger_label >/dev/null 2>&1 && dl_cycle_trigger_label "$ORG" "$repo" "$existing" "dev-lead" "$DRY_RUN"; then
+      ISSUES_RETRIGGERED=$((ISSUES_RETRIGGERED + 1))
+    else
+      gh issue edit "$existing" --repo "$ORG/$repo" --add-label "dev-lead" 2>/dev/null || true
+    fi
+    return
+  fi
+
+  local url
+  url=$(gh issue create --repo "$ORG/$repo" --title "$stable_title" \
+    --label "$labels" --body "$body" 2>/dev/null || echo "")
+  if [ -n "$url" ]; then
+    ISSUES_ADDED=$((ISSUES_ADDED + 1))
+    info "Created $url"
+  else
+    warn "Failed to create issue in $repo :: $stable_title"
+  fi
+}
+
+# Close audit issues whose (repo, family) group no longer has findings.
+close_resolved() {
+  local repo="$1"
+  local open_issues
+  open_issues=$(gh issue list --repo "$ORG/$repo" --label "$SONAR_AUDIT_LABEL" --state open \
+    --json number,title -q '.[] | "\(.number)\t\(.title)"' 2>/dev/null || echo "")
+  [ -z "$open_issues" ] && return
+
+  # Current family titles present for this repo.
+  local current_titles
+  current_titles=$(jq -r --arg repo "$repo" '.[] | select(.repo == $repo) | .family' "$GROUPS_FILE" 2>/dev/null \
+    | while read -r fam; do [ -n "$fam" ] && echo "SonarCloud: $(family_title "$fam")"; done)
+
+  local num ttl
+  while IFS=$'\t' read -r num ttl; do
+    [ -z "$num" ] && continue
+    if ! echo "$current_titles" | grep -qxF "$ttl"; then
+      gh issue close "$num" --repo "$ORG/$repo" \
+        --comment "Resolved! No open SonarCloud findings remain in this workstream as of $(date -u +%Y-%m-%d). Closing automatically." 2>/dev/null \
+        && { ISSUES_REMOVED=$((ISSUES_REMOVED + 1)); info "Closed resolved #$num in $repo"; } || true
+    fi
+  done <<< "$open_issues"
+}
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+generate_summary() {
+  local total repos_n
+  total=$(jq 'length' "$FINDINGS_FILE")
+  repos_n=$(jq '[.[].repo] | unique | length' "$FINDINGS_FILE")
+
+  {
+    echo "# SonarCloud Audit — $(date -u +%Y-%m-%d)"
+    echo ""
+    echo "**Org:** \`${SONAR_ORG}\` · **Open findings:** ${total} · **Repos with findings:** ${repos_n}"
+    echo ""
+    echo "## By severity"
+    echo "| Severity | Count |"
+    echo "|---|---:|"
+    jq -r '
+      def rank: {"BLOCKER":5,"CRITICAL":4,"MAJOR":3,"MINOR":2,"INFO":1}[.] // 0;
+      group_by(.severity) | sort_by(-(.[0].severity | rank))
+      | .[] | "| \(.[0].severity) | \(length) |"' "$FINDINGS_FILE"
+    echo ""
+    echo "## By repo × workstream (one issue each)"
+    echo "| Repo | Workstream | Findings | Worst severity | Priority |"
+    echo "|---|---|---:|---|---|"
+    jq -c '.[]' "$GROUPS_FILE" | while IFS= read -r g; do
+      local r f c s
+      r=$(echo "$g" | jq -r '.repo'); f=$(family_title "$(echo "$g" | jq -r '.family')")
+      c=$(echo "$g" | jq -r '.count'); s=$(echo "$g" | jq -r '.max_severity')
+      echo "| $r | $f | $c | $s | $(severity_priority_label "$s") |"
+    done
+    echo ""
+    echo "## Issue actions"
+    echo "| Action | Count |"
+    echo "|---|---:|"
+    echo "| Added | $ISSUES_ADDED |"
+    echo "| Updated | $ISSUES_EXISTING |"
+    echo "| dev-lead re-triggered | $ISSUES_RETRIGGERED |"
+    echo "| Closed (resolved) | $ISSUES_REMOVED |"
+    echo ""
+    echo "---"
+    echo "*Generated by the SonarCloud Audit workflow.*"
+  } > "$SUMMARY_FILE"
+}
+
+# ---------------------------------------------------------------------------
+main() {
+  mkdir -p "$REPORT_DIR"
+  info "SonarCloud audit — org=$SONAR_ORG dry_run=$DRY_RUN create_issues=$CREATE_ISSUES"
+  scan
+
+  if [ "$CREATE_ISSUES" = "true" ] && [ "$DRY_RUN" != "true" ]; then
+    while IFS= read -r group; do
+      manage_group_issue "$group"
+    done < <(jq -c '.[]' "$GROUPS_FILE")
+    # Close resolved issues per repo that had (or previously had) findings.
+    while IFS= read -r repo; do
+      [ -n "$repo" ] && close_resolved "$repo"
+    done < <(gh repo list "$ORG" --no-archived --limit 100 --json name -q '.[].name' 2>/dev/null || jq -r '[.[].repo]|unique[]' "$GROUPS_FILE")
+  else
+    while IFS= read -r group; do manage_group_issue "$group"; done < <(jq -c '.[]' "$GROUPS_FILE")
+  fi
+
+  jq -n --argjson added "$ISSUES_ADDED" --argjson existing "$ISSUES_EXISTING" \
+        --argjson retriggered "$ISSUES_RETRIGGERED" --argjson removed "$ISSUES_REMOVED" \
+        '{added:$added,existing:$existing,retriggered:$retriggered,removed:$removed}' > "$COUNTS_FILE"
+
+  generate_summary
+  info "Done. Findings: $(jq length "$FINDINGS_FILE"); groups: $(jq length "$GROUPS_FILE"); added=$ISSUES_ADDED existing=$ISSUES_EXISTING removed=$ISSUES_REMOVED"
+}
+
+# Guard: only run when executed directly (sourcing defines functions for bats).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/test/scripts/sonarcloud-audit/pure-helpers.bats
+++ b/test/scripts/sonarcloud-audit/pure-helpers.bats
@@ -11,7 +11,9 @@ bats_require_minimum_version 1.5.0
 SCRIPT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)/scripts/sonarcloud-audit.sh"
 
 call() {
-  run bash -c 'source "$1" >/dev/null 2>&1; "$2" "$3"' _ "$SCRIPT" "$1" "$2"
+  local func="$1"
+  shift
+  run bash -c 'source "$1" >/dev/null 2>&1; shift; "$@"' _ "$SCRIPT" "$func" "$@"
 }
 
 # ── classify_workstream ────────────────────────────────────────────────────
@@ -98,19 +100,19 @@ call() {
 
 # ── family_is_security ─────────────────────────────────────────────────────
 @test "s7635 is a security family" {
-  run bash -c 'source "$1" >/dev/null 2>&1; family_is_security s7635' _ "$SCRIPT"; [ "$status" -eq 0 ]
+  call family_is_security s7635; [ "$status" -eq 0 ]
 }
 @test "ghactions is a security family" {
-  run bash -c 'source "$1" >/dev/null 2>&1; family_is_security ghactions' _ "$SCRIPT"; [ "$status" -eq 0 ]
+  call family_is_security ghactions; [ "$status" -eq 0 ]
 }
 @test "pysec is a security family" {
-  run bash -c 'source "$1" >/dev/null 2>&1; family_is_security pysec' _ "$SCRIPT"; [ "$status" -eq 0 ]
+  call family_is_security pysec; [ "$status" -eq 0 ]
 }
 @test "shell is NOT a security family" {
-  run bash -c 'source "$1" >/dev/null 2>&1; family_is_security shell' _ "$SCRIPT"; [ "$status" -ne 0 ]
+  call family_is_security shell; [ "$status" -ne 0 ]
 }
 @test "tests is NOT a security family" {
-  run bash -c 'source "$1" >/dev/null 2>&1; family_is_security tests' _ "$SCRIPT"; [ "$status" -ne 0 ]
+  call family_is_security tests; [ "$status" -ne 0 ]
 }
 
 # ── issue_marker (hidden idempotency key) ──────────────────────────────────

--- a/test/scripts/sonarcloud-audit/pure-helpers.bats
+++ b/test/scripts/sonarcloud-audit/pure-helpers.bats
@@ -113,6 +113,16 @@ call() {
   run bash -c 'source "$1" >/dev/null 2>&1; family_is_security tests' _ "$SCRIPT"; [ "$status" -ne 0 ]
 }
 
+# ── issue_marker (hidden idempotency key) ──────────────────────────────────
+@test "issue_marker embeds a stable repo/family key as an HTML comment" {
+  run bash -c 'source "$1" >/dev/null 2>&1; issue_marker "$2" "$3"' _ "$SCRIPT" "markets" "ghactions"
+  [ "$output" = "<!-- sonarcloud-audit:key=markets/ghactions -->" ]
+}
+@test "issue_marker handles dotted repo names (.github)" {
+  run bash -c 'source "$1" >/dev/null 2>&1; issue_marker "$2" "$3"' _ "$SCRIPT" ".github" "misc"
+  [ "$output" = "<!-- sonarcloud-audit:key=.github/misc -->" ]
+}
+
 # ── family_title stability (used as the idempotency key) ───────────────────
 @test "family_title is non-empty for every known family" {
   run bash -c 'source "$1" >/dev/null 2>&1;

--- a/test/scripts/sonarcloud-audit/pure-helpers.bats
+++ b/test/scripts/sonarcloud-audit/pure-helpers.bats
@@ -1,0 +1,122 @@
+#!/usr/bin/env bats
+# Unit tests for the pure helpers in scripts/sonarcloud-audit.sh:
+#   classify_workstream, family_title, family_is_security,
+#   sonar_project_to_repo, severity_rank, severity_priority_label.
+#
+# The script's `main` is guarded, so sourcing only defines functions — the real
+# helpers are exercised directly in an isolated subshell.
+
+bats_require_minimum_version 1.5.0
+
+SCRIPT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)/scripts/sonarcloud-audit.sh"
+
+call() {
+  run bash -c 'source "$1" >/dev/null 2>&1; "$2" "$3"' _ "$SCRIPT" "$1" "$2"
+}
+
+# ── classify_workstream ────────────────────────────────────────────────────
+@test "S7635 → s7635 (its own family, not generic ghactions)" {
+  call classify_workstream "githubactions:S7635"; [ "$output" = "s7635" ]
+}
+@test "githubactions:S1135 (TODO tag) → misc, not ghactions-security" {
+  call classify_workstream "githubactions:S1135"; [ "$output" = "misc" ]
+}
+@test "other githubactions rule → ghactions" {
+  call classify_workstream "githubactions:S6505"; [ "$output" = "ghactions" ]
+}
+@test "text lockfile rule → ghactions" {
+  call classify_workstream "text:S8564"; [ "$output" = "ghactions" ]
+}
+@test "shelldre rule → shell" {
+  call classify_workstream "shelldre:S7688"; [ "$output" = "shell" ]
+}
+@test "pythonsecurity rule → pysec" {
+  call classify_workstream "pythonsecurity:S8707"; [ "$output" = "pysec" ]
+}
+@test "python:S3776 → complexity (not misc)" {
+  call classify_workstream "python:S3776"; [ "$output" = "complexity" ]
+}
+@test "javascript:S3776 → complexity (not jsquality)" {
+  call classify_workstream "javascript:S3776"; [ "$output" = "complexity" ]
+}
+@test "javascript:S5906 → tests (its own family)" {
+  call classify_workstream "javascript:S5906"; [ "$output" = "tests" ]
+}
+@test "other javascript rule → jsquality" {
+  call classify_workstream "javascript:S6582"; [ "$output" = "jsquality" ]
+}
+@test "typescript rule → jsquality" {
+  call classify_workstream "typescript:S1234"; [ "$output" = "jsquality" ]
+}
+@test "css rule → misc" {
+  call classify_workstream "css:S7924"; [ "$output" = "misc" ]
+}
+@test "unknown rule → misc" {
+  call classify_workstream "docker:S6471"; [ "$output" = "misc" ]
+}
+
+# ── sonar_project_to_repo ──────────────────────────────────────────────────
+@test "strips org prefix" {
+  call sonar_project_to_repo "petry-projects_markets"; [ "$output" = "markets" ]
+}
+@test "broodminder-export2 key maps to the real repo broodminder-export" {
+  call sonar_project_to_repo "petry-projects_broodminder-export2"; [ "$output" = "broodminder-export" ]
+}
+@test "dotted repo name survives prefix strip" {
+  call sonar_project_to_repo "petry-projects_.github"; [ "$output" = ".github" ]
+}
+
+# ── severity_rank ordering ─────────────────────────────────────────────────
+@test "severity ranks are strictly ordered blocker>critical>major>minor>info" {
+  run bash -c 'source "$1" >/dev/null 2>&1;
+    [ "$(severity_rank BLOCKER)" -gt "$(severity_rank CRITICAL)" ] &&
+    [ "$(severity_rank CRITICAL)" -gt "$(severity_rank MAJOR)" ] &&
+    [ "$(severity_rank MAJOR)" -gt "$(severity_rank MINOR)" ] &&
+    [ "$(severity_rank MINOR)" -gt "$(severity_rank INFO)" ]' _ "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+# ── severity_priority_label mapping ────────────────────────────────────────
+@test "BLOCKER → priority:blocker" {
+  call severity_priority_label "BLOCKER"; [ "$output" = "priority:blocker" ]
+}
+@test "CRITICAL → priority:critical" {
+  call severity_priority_label "CRITICAL"; [ "$output" = "priority:critical" ]
+}
+@test "MAJOR → priority:major" {
+  call severity_priority_label "MAJOR"; [ "$output" = "priority:major" ]
+}
+@test "MINOR → priority:minor" {
+  call severity_priority_label "MINOR"; [ "$output" = "priority:minor" ]
+}
+@test "INFO → priority:info" {
+  call severity_priority_label "INFO"; [ "$output" = "priority:info" ]
+}
+@test "unknown severity defaults to priority:minor" {
+  call severity_priority_label "WEIRD"; [ "$output" = "priority:minor" ]
+}
+
+# ── family_is_security ─────────────────────────────────────────────────────
+@test "s7635 is a security family" {
+  run bash -c 'source "$1" >/dev/null 2>&1; family_is_security s7635' _ "$SCRIPT"; [ "$status" -eq 0 ]
+}
+@test "ghactions is a security family" {
+  run bash -c 'source "$1" >/dev/null 2>&1; family_is_security ghactions' _ "$SCRIPT"; [ "$status" -eq 0 ]
+}
+@test "pysec is a security family" {
+  run bash -c 'source "$1" >/dev/null 2>&1; family_is_security pysec' _ "$SCRIPT"; [ "$status" -eq 0 ]
+}
+@test "shell is NOT a security family" {
+  run bash -c 'source "$1" >/dev/null 2>&1; family_is_security shell' _ "$SCRIPT"; [ "$status" -ne 0 ]
+}
+@test "tests is NOT a security family" {
+  run bash -c 'source "$1" >/dev/null 2>&1; family_is_security tests' _ "$SCRIPT"; [ "$status" -ne 0 ]
+}
+
+# ── family_title stability (used as the idempotency key) ───────────────────
+@test "family_title is non-empty for every known family" {
+  run bash -c 'source "$1" >/dev/null 2>&1;
+    for f in s7635 ghactions pysec complexity shell tests jsquality misc; do
+      t=$(family_title "$f"); [ -n "$t" ] || exit 1; done' _ "$SCRIPT"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

A weekly, org-wide **SonarCloud audit** modeled on the existing compliance-audit system. It scans every SonarCloud project in `petry-projects`, groups open findings per **(repo × rule-family workstream)**, and idempotently **creates / updates / closes** one GitHub issue per group — each carrying a **`dev-lead`** label (autonomous remediation) and a **`priority:<severity>`** label mapped from the bucket's worst SonarCloud severity.

Requested capabilities, all implemented:
- ✅ **Scans all SonarCloud profiles/projects** for the org (authenticated with `SONAR_TOKEN`, anonymous fallback for public projects).
- ✅ **Generates issues for open findings** — one per repo × workstream, in the correct repo (Sonar project→GitHub repo mapping, incl. the `broodminder-export2`→`broodminder-export` case).
- ✅ **Idempotency** — stable-title keying: first run creates, re-runs refresh the dashboard body + comment and re-trigger `dev-lead` on persistent findings, and groups that drop to zero are **auto-closed**.
- ✅ **Dashboard report in the workflow** — by-severity and by-repo×workstream tables written to the run's step summary, plus a 90-day report artifact.
- ✅ **Prioritization labels from SonarCloud severity** — `priority:blocker|critical|major|minor|info`, 1:1 with Sonar's scale; `security` added on vulnerability/security families.

## Design (mirrors `compliance-audit`)

| Piece | File |
|---|---|
| Deterministic scanner + issue lifecycle | `scripts/sonarcloud-audit.sh` |
| Scheduled workflow (Mon 13:00 UTC, offset from Fri compliance) | `.github/workflows/sonarcloud-audit.yml` |
| shellcheck + bats gate | `.github/workflows/sonarcloud-audit-tests.yml` |
| Unit tests for pure helpers | `test/scripts/sonarcloud-audit/pure-helpers.bats` |

Reuses the shared `scripts/lib/dev-lead-retrigger.sh` helpers for persistent-finding re-engagement, and the guarded-`main` convention so helpers are unit-testable.

## Validation

- `shellcheck --severity=warning -x` — clean.
- `bats` — full suite green (rule→family classification, project→repo mapping, severity→priority mapping, security-family, stable titles).
- **Live dry-run** against the real SonarCloud API: **144 open findings → 19 issue groups**, correct families/severities/labels, dashboard renders. No issues written (dry-run).

Example grouping (dry-run): `broodminder-export → cognitive complexity (S3776)` → `priority:critical`; `markets → GitHub Actions / dependency hardening` → `priority:major, security`; `repo-template → S7635 secrets-inherit caller stubs` → `priority:major, security`.

## Notes / follow-ups

- `workflow_dispatch` supports `dry_run` and `target_repo` for safe first runs and single-repo scoping. **Recommend a dispatch dry-run before the first scheduled run.**
- Complements the one-time drawdown tracked in #593; going forward this keeps findings ticketed and prioritized automatically.
- Not included (deliberate, to keep scope tight): a `standards/` doc entry and a persistent rolling dashboard issue — easy follow-ups if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MjwnCh1LRVYajVwDBtVBkf