### PR TITLE
feat(rulesets): relocate release-channel-tags to .github as targeted org standard (#596)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Read the relevant standard *before* making changes that touch CI, repo settings,
 | **Workflow templates** | [`standards/workflows/`](https://github.com/petry-projects/.github/tree/main/standards/workflows) | Copy-paste-ready templates: `agent-shield.yml`, `dev-lead.yml`, `dependabot-automerge.yml`, `dependabot-rebase.yml`, `dependency-audit.yml`, `feature-ideation.yml` |
 | **Agent configuration** | [`standards/agent-standards.md`](https://github.com/petry-projects/.github/blob/main/standards/agent-standards.md) | CLAUDE.md / AGENTS.md / SKILL.md required structure, frontmatter rules, cross-references |
 | **Repo settings + labels** | [`standards/github-settings.md`](https://github.com/petry-projects/.github/blob/main/standards/github-settings.md) | Required settings, label set with exact colors, code-quality ruleset, branch protection |
-| **Rulesets** | [`standards/rulesets/`](https://github.com/petry-projects/.github/tree/main/standards/rulesets) | Codified source-of-truth JSON for the org-wide `pr-quality` + `code-quality` rulesets (applied by `apply-rulesets.sh`). `release-channel-tags` stays repo-local in `.github-private` |
+| **Rulesets** | [`standards/rulesets/`](https://github.com/petry-projects/.github/tree/main/standards/rulesets) | Codified source-of-truth JSON for the org-wide `pr-quality`, `code-quality`, and `release-channel-tags` rulesets (applied by `apply-rulesets.sh`) |
 | **Dependabot config** | [`standards/dependabot-policy.md`](https://github.com/petry-projects/.github/blob/main/standards/dependabot-policy.md) and [`standards/dependabot/`](https://github.com/petry-projects/.github/tree/main/standards/dependabot) | Per-ecosystem dependabot.yml templates and policy |
 | **Advanced Security (GHAS)** | [`standards/advanced-security.md`](https://github.com/petry-projects/.github/blob/main/standards/advanced-security.md) | Org-wide GHAS enablement via the "GitHub recommended" code security configuration, licensing model, and how to verify push protection actually enforces |
 | **Push protection** | [`standards/push-protection.md`](https://github.com/petry-projects/.github/blob/main/standards/push-protection.md) | Secret scanning + push protection, local gitleaks hooks, CI secret-scan job, incident response |
@@ -42,14 +42,14 @@ ruleset JSONs is `standards/rulesets/`.
 
 **`petry-projects/.github-private` is scoped to agents, skills, and their reusable
 workflows/assets.** It must **not** be the source of truth for org-wide policy.
-The only ruleset that legitimately lives there is `release-channel-tags` — it
-protects `.github-private`'s own `pr-review/**` and `dev-lead/**` agent-release tags.
+No rulesets should be defined there; all rulesets are owned by `.github/standards/rulesets/`.
 
-**Rule of thumb:** if a standard or ruleset applies to the whole fleet, it belongs
-in `.github/standards/`. If it protects an agent's/skill's own assets, it stays in
-`.github-private`. When in doubt, put it in `.github` and have `.github-private`
-**consume** it — the way repo-seeding tooling fetches `standards/workflows/` from
-`.github`. Do **not** add new org-wide standards or rulesets to `.github-private`.
+**Rule of thumb:** all standards and rulesets belong in `.github/standards/`, whether
+they apply fleet-wide (like `pr-quality` and `code-quality`) or are targeted to specific
+repos (like `release-channel-tags` for meta-repos). When in doubt, put it in `.github`
+and have `.github-private` **consume** it — the way repo-seeding tooling fetches
+`standards/workflows/` from `.github`. Do **not** add new org-wide standards or rulesets
+to `.github-private`.
 
 > **Known exception being remediated:** `code-quality.json` and `pr-quality.json`
 > currently live in `.github-private/.github/rulesets/` (added ad-hoc under

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pr-595",
+  "name": "pr-609",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}

--- a/scripts/apply-rulesets.sh
+++ b/scripts/apply-rulesets.sh
@@ -26,6 +26,12 @@ set -euo pipefail
 # Rulesets live ON each repo: editing a JSON here changes the desired state, not any
 # live ruleset, until this applier runs.
 #
+# Default set: with NO ruleset name, only the FLEET_RULESETS allowlist (code-quality,
+# pr-quality) is applied — NOT every *.json in the dir. standards/rulesets/ also holds
+# release-channel-tags.json (a tag ruleset protecting the reusable-hosting meta-repos'
+# channel/version tags); it is targeted, not fleet-wide, so it is applied ONLY when
+# named explicitly:  ./scripts/apply-rulesets.sh --repo petry-projects/.github release-channel-tags
+#
 # Usage:
 #   GH_TOKEN=<admin> ./scripts/apply-rulesets.sh --repo owner/repo [--dry-run] [<name>...]
 #   GH_TOKEN=<admin> ./scripts/apply-rulesets.sh <repo-name>       [--dry-run]   # bare name → $ORG/<name>
@@ -41,6 +47,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 ORG="${ORG:-petry-projects}"
 RULESETS_DIR="${RULESETS_DIR:-$(cd "${SCRIPT_DIR}/.." && pwd)/standards/rulesets}"
 DRY_RUN="${DRY_RUN:-false}"
+
+# The fleet-wide compliance rulesets applied by DEFAULT (when no ruleset name is
+# given), on --repo and --all alike. This is an ALLOWLIST, not "every *.json in the
+# dir": standards/rulesets/ also holds release-channel-tags.json, which is a targeted
+# tag ruleset for the reusable-hosting meta-repos only and must NOT be swept fleet-
+# wide — it is applied only when named explicitly (e.g. `--repo <meta> release-channel-tags`).
+FLEET_RULESETS=(code-quality pr-quality)
 
 # ruleset_id_by_name <repo> <name> — echo the id of an existing ruleset, or empty.
 ruleset_id_by_name() {
@@ -123,18 +136,15 @@ main() {
   gh auth status >/dev/null 2>&1 || { echo "::error::GitHub authentication failed — set GH_TOKEN or run 'gh auth login'" >&2; return 1; }
   [ -d "$RULESETS_DIR" ] || { echo "::error::rulesets dir not found: $RULESETS_DIR" >&2; return 1; }
 
-  # Select the ruleset files (all *.json, or only the named ones).
+  # Select the ruleset files: the named ones, else the fleet allowlist (NOT every
+  # *.json — that would sweep release-channel-tags fleet-wide; see FLEET_RULESETS).
   local files=()
-  if [ "${#names[@]}" -gt 0 ]; then
-    local n
-    for n in "${names[@]}"; do
-      [ -f "${RULESETS_DIR}/${n}.json" ] && files+=("${RULESETS_DIR}/${n}.json") \
-        || { echo "::error::no ruleset file ${n}.json in ${RULESETS_DIR}" >&2; return 1; }
-    done
-  else
-    local f
-    for f in "${RULESETS_DIR}"/*.json; do [ -e "$f" ] && files+=("$f"); done
-  fi
+  if [ "${#names[@]}" -eq 0 ]; then names=("${FLEET_RULESETS[@]}"); fi
+  local n
+  for n in "${names[@]}"; do
+    [ -f "${RULESETS_DIR}/${n}.json" ] && files+=("${RULESETS_DIR}/${n}.json") \
+      || { echo "::error::no ruleset file ${n}.json in ${RULESETS_DIR}" >&2; return 1; }
+  done
   [ "${#files[@]}" -gt 0 ] || { echo "  no ruleset files to apply"; return 0; }
 
   if [ "$all" = true ]; then

--- a/scripts/apply-rulesets.sh
+++ b/scripts/apply-rulesets.sh
@@ -53,7 +53,7 @@ DRY_RUN="${DRY_RUN:-false}"
 # dir": standards/rulesets/ also holds release-channel-tags.json, which is a targeted
 # tag ruleset for the reusable-hosting meta-repos only and must NOT be swept fleet-
 # wide — it is applied only when named explicitly (e.g. `--repo <meta> release-channel-tags`).
-FLEET_RULESETS=(code-quality pr-quality)
+readonly FLEET_RULESETS=(code-quality pr-quality)
 
 # ruleset_id_by_name <repo> <name> — echo the id of an existing ruleset, or empty.
 ruleset_id_by_name() {

--- a/standards/github-settings.md
+++ b/standards/github-settings.md
@@ -125,13 +125,13 @@ rules are deprecated — migrate existing classic rules to rulesets.
 
 ### Source of truth & repo boundary
 
-The codified ruleset JSONs are the source of truth for the two sanctioned
-rulesets; `scripts/apply-rulesets.sh` (and any org automation consuming it) applies them to each repo.
+The codified ruleset JSONs are the source of truth for all rulesets;
+`scripts/apply-rulesets.sh` (and any org automation consuming it) applies them to each repo.
 As **org-wide compliance policy they are owned by `petry-projects/.github`**, and
-their canonical home is `standards/rulesets/`. Do **not** author them in
+their canonical home is `standards/rulesets/`. Do **not** author rulesets in
 `petry-projects/.github-private` — that repo is scoped to agents/skills and their
-reusable assets. The only ruleset that belongs there is `release-channel-tags`
-(it protects `.github-private`'s own `pr-review/**` / `dev-lead/**` release tags).
+reusable assets. All rulesets, including targeted ones like `release-channel-tags`,
+are defined in `.github/standards/rulesets/`.
 See the repo-boundary rule in [`AGENTS.md`](../AGENTS.md).
 
 > **In transit:** `code-quality.json` and `pr-quality.json` currently still live
@@ -152,14 +152,11 @@ silently drops a merge gate. `check_legacy_rulesets()` in
 legacy ruleset and reports the exact migration delta (checks to move into
 `code-quality` first, or "safe to delete").
 
-**Source of truth.** The codified `pr-quality` and `code-quality` ruleset JSONs
-live in this repo at [`standards/rulesets/`](rulesets/) — `.github` owns org-wide
-compliance policy (see [`AGENTS.md`](../AGENTS.md#organization-standards) for the
-repo-boundary rule, codified in #576). Run `apply-rulesets.sh` to converge each
-repo's live ruleset to the desired state documented here. The one ruleset that stays in
-`petry-projects/.github-private` is `release-channel-tags` — it protects that
-repo's own `pr-review/**` and `dev-lead/**` agent-release tags and is therefore
-correctly repo-local.
+**Source of truth.** All ruleset JSONs — `pr-quality`, `code-quality`, and
+`release-channel-tags` — live in this repo at [`standards/rulesets/`](rulesets/).
+`.github` owns org-wide compliance policy (see [`AGENTS.md`](../AGENTS.md#organization-standards)
+for the repo-boundary rule, codified in #576). Run `apply-rulesets.sh` to converge each
+repo's live ruleset to the desired state documented here.
 
 > **Remediating ruleset findings is a manual, admin-token procedure** —
 > `compliance-remediate.sh` skips the `rulesets` category. Follow the

--- a/standards/rulesets/README.md
+++ b/standards/rulesets/README.md
@@ -11,9 +11,13 @@ these rulesets are enforced.
 |------|---------|--------|----------|
 | [`pr-quality.json`](pr-quality.json) | `pr-quality` | `~DEFAULT_BRANCH` | 1 approval, code-owner review, thread resolution, dismiss-stale, squash-only merge |
 | [`code-quality.json`](code-quality.json) | `code-quality` | `~DEFAULT_BRANCH` | Required status checks (SonarCloud, CodeQL, agent-shield, dependency-audit) |
+| [`release-channel-tags.json`](release-channel-tags.json) | `release-channel-tags` | `refs/tags/**` | Blocks unauthorized **update/deletion** of any tag (protects moving channel pointers + version tags); creation stays free |
 
-Both carry the two mandatory bypass actors — `OrganizationAdmin` and the
-`dependabot-automerge-petry` Integration app (id `3167543`), both `bypass_mode: always`.
+`pr-quality` / `code-quality` carry the two mandatory bypass actors —
+`OrganizationAdmin` and the `dependabot-automerge-petry` Integration app (id
+`3167543`), both `bypass_mode: always`. `release-channel-tags` additionally grants
+bypass to the **release-manager** Integration app (id `4193127`) so channel promotion
+and dev-lead autocut can move channel tags.
 
 ## Applying
 
@@ -29,10 +33,20 @@ GH_TOKEN=<admin-token> bash scripts/apply-rulesets.sh <repo> --dry-run
 
 ## Scope boundary
 
-- **Fleet-wide → here.** `pr-quality` / `code-quality` are org-wide policy.
-- **Protects an agent/skill's own assets → stays in `.github-private`.**
-  `release-channel-tags` lives in `petry-projects/.github-private` because it
-  protects that repo's own `pr-review/**` and `dev-lead/**` release tags.
+- **Org standards → here.** All ruleset definitions are org standards owned by
+  `.github`. `pr-quality` / `code-quality` are applied **fleet-wide** (the default
+  set); `release-channel-tags` is an org standard but **targeted** — applied only to
+  the reusable-hosting meta-repos (`.github`, `.github-private`), whose tags are all
+  release-management tags. It is applied by name, never swept fleet-wide:
+
+  ```bash
+  GH_TOKEN=<admin> bash scripts/apply-rulesets.sh --repo petry-projects/.github release-channel-tags
+  GH_TOKEN=<admin> bash scripts/apply-rulesets.sh --repo petry-projects/.github-private release-channel-tags
+  ```
+
+- **The default (no-name) set is the `FLEET_RULESETS` allowlist**, *not* every
+  `*.json` here — so adding a targeted ruleset like `release-channel-tags` never
+  leaks into `--all` / `--repo` fleet runs.
 
 ## Changing the required-check set
 

--- a/standards/rulesets/README.md
+++ b/standards/rulesets/README.md
@@ -1,5 +1,16 @@
 # Repository Rulesets — codified source of truth
 
+> **These are org-level policy, applied per-repo.** Every JSON here is an
+> **organization-level** ruleset in intent — including `release-channel-tags`, whose
+> bypass actors are org-scoped identities (`OrganizationAdmin` + org-installed Apps).
+> GitHub's native **org-level rulesets require the Team plan**; `petry-projects` is on
+> Free (`GET /orgs/petry-projects/rulesets` → 403 *"Upgrade to GitHub Team"*), so
+> `scripts/apply-rulesets.sh` **replicates each definition onto its target repos** as
+> repo-level rulesets. That per-repo projection is our stand-in for the paywalled
+> feature — do not mistake these for repo-specific config. If the org moves to Team,
+> the simplification is to define each once at `/orgs/{org}/rulesets` (with
+> repository-targeting conditions) and retire the replication loop.
+
 This directory holds the **org-wide compliance ruleset JSONs** for `petry-projects`.
 `.github` owns org-wide standards and compliance policy; its canonical home is
 `standards/`. See [`AGENTS.md`](../../AGENTS.md#organization-standards) for the

--- a/standards/rulesets/release-channel-tags.json
+++ b/standards/rulesets/release-channel-tags.json
@@ -1,0 +1,31 @@
+{
+  "name": "release-channel-tags",
+  "target": "tag",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "always"
+    },
+    {
+      "actor_id": 3167543,
+      "actor_type": "Integration",
+      "bypass_mode": "always"
+    },
+    {
+      "actor_id": 4193127,
+      "actor_type": "Integration",
+      "bypass_mode": "always"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/tags/**"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {"type": "update"},
+    {"type": "deletion"}
+  ]
+}

--- a/test/scripts/apply-rulesets/apply-rulesets.bats
+++ b/test/scripts/apply-rulesets/apply-rulesets.bats
@@ -49,6 +49,19 @@ EOF
   done
 }
 
+@test "release-channel-tags.json: tag ruleset, generic refs/tags/** include, update+deletion only" {
+  run jq -er '.target == "tag"
+    and (.conditions.ref_name.include == ["refs/tags/**"])
+    and ([.rules[].type] | sort == ["deletion","update"])' "$RULESETS_DIR/release-channel-tags.json"
+  [ "$status" -eq 0 ]
+}
+
+@test "release-channel-tags.json: carries OrgAdmin + both Integration apps (automation 3167543 + release-manager 4193127)" {
+  run jq -er '([.bypass_actors[] | select(.actor_type=="Integration") | .actor_id] | sort == [3167543,4193127])
+    and ([.bypass_actors[].actor_type] | index("OrganizationAdmin"))' "$RULESETS_DIR/release-channel-tags.json"
+  [ "$status" -eq 0 ]
+}
+
 # ── apply behavior: create / update / dry-run ─────────────────────────────────
 @test "apply --repo: creates rulesets when absent (POST per file)" {
   _stub_gh
@@ -94,6 +107,25 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" == *"code-quality"* ]]
   [[ "$output" != *"pr-quality"* ]]
+  [[ "$output" == *"done (1 ruleset(s))"* ]]
+}
+
+@test "apply: default set is the fleet allowlist only — release-channel-tags is NOT swept in" {
+  _stub_gh
+  export RULESETS_LIST='[]'
+  run bash "$APPLY" --repo petry-projects/acme
+  [ "$status" -eq 0 ]
+  # code-quality + pr-quality applied; release-channel-tags excluded despite being in the dir.
+  [[ "$output" == *"done (2 ruleset(s))"* ]]
+  [[ "$output" != *"release-channel-tags"* ]]
+}
+
+@test "apply: release-channel-tags applies only when named explicitly" {
+  _stub_gh
+  export RULESETS_LIST='[]'
+  run bash "$APPLY" --repo petry-projects/.github release-channel-tags --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"release-channel-tags"* ]]
   [[ "$output" == *"done (1 ruleset(s))"* ]]
 }
 


### PR DESCRIPTION
## What

Realizes the first slice of #596 — **standards live only in `.github`** — for the `release-channel-tags` ruleset, and generalizes it per review.

- **`standards/rulesets/release-channel-tags.json`** (new) — the tag ruleset is now a codified org standard owned by `.github`.
  - **Generic rule** `refs/tags/**` instead of an enumerated namespace list (which drifted every time a new reusable/agent channel was added). On the reusable-hosting meta-repos every tag *is* a release tag, so "protect all tags" matches intent exactly.
  - Rules are **`update` + `deletion` only** — creation stays free, so dev-lead autocut can still cut new `vX.Y.Z` tags; only *moving* a channel pointer or *deleting* a tag needs bypass.
  - Bypass actors: `OrganizationAdmin` + automation Integration `3167543` + **release-manager App `4193127`** (all `always`), so channel promotion / autocut work. (This matches the live ruleset on `.github-private`, which was just updated to add `4193127`.)
- **`scripts/apply-rulesets.sh`** — the no-name default is now the `FLEET_RULESETS` allowlist (`code-quality`, `pr-quality`), **not** "every `*.json` in the dir". Without this, adding `release-channel-tags.json` would sweep it onto every repo via `--all` / `--repo`. It is now applied **only when named explicitly**.
- README + bats updated — **17/17 green**.

## Apply plan (post-merge, targeted to the two meta-repos only)

```bash
GH_TOKEN=<admin> bash scripts/apply-rulesets.sh --repo petry-projects/.github         release-channel-tags
GH_TOKEN=<admin> bash scripts/apply-rulesets.sh --repo petry-projects/.github-private release-channel-tags
```

## Not in this PR (follow-ups for #596)

- Move `bootstrap-new-repo.sh` into `.github` (+ reconcile the divergent `apply-repo-settings.sh` copies).
- Delete the duplicate `.github-private/scripts/apply-rulesets.sh` and the repo-local `.github/rulesets/release-channel-tags.json`.

Refs #596.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new managed ruleset for tag-based release channel controls.
  * Default ruleset application now targets only the standard fleet-wide policies, with the tag ruleset applied only when explicitly requested.

* **Bug Fixes**
  * Prevented the tag ruleset from being included in broad bulk application runs.
  * Clarified allowed tag update and deletion behavior while preserving tag creation.

* **Documentation**
  * Updated ruleset ownership and scope guidance across internal documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->