### PR TITLE
fix(pr-review-mention): guard ack-comment post against the 2500-comment cap (finishes #594)

### DIFF
--- a/.github/workflows/pr-review-mention-reusable.yml
+++ b/.github/workflows/pr-review-mention-reusable.yml
@@ -149,7 +149,14 @@ jobs:
             ACTOR="${{ github.event.comment.user.login }}"
             MSG="@${ACTOR} I'm on it — starting a fresh review now. Results will appear in a few minutes."
           fi
-          gh pr comment "$PR_URL" --body "$(printf '<!-- pr-review-agent mention-ack -->\n%s' "${MSG}")"
+          # Best-effort (issue #594): the ack comment ran unguarded under `bash -e`,
+          # so a single PR at GitHub's 2500-comment cap ("Commenting is disabled on
+          # issues with more than 2500 comments"), a secondary rate limit, or a
+          # transient 5xx failed the whole step — blocking the pr-review-mention
+          # ring1→stable canary soak. The ack is cosmetic; the review dispatch in the
+          # next step is what matters, so swallow a comment-side failure as a warning.
+          gh pr comment "$PR_URL" --body "$(printf '<!-- pr-review-agent mention-ack -->\n%s' "${MSG}")" \
+            || echo "::warning::could not post ack comment on $PR_URL (comment cap / API error) — continuing"
 
       - name: Trigger review agent
         if: steps.trust.outputs.trusted == 'true'


### PR DESCRIPTION
## Why
Issue #594 ("unguarded conflict-comment aborts the whole run when a PR hits the 2500-comment cap — blocks the ring1→stable soak gate") was closed by PR #595, but that PR only guarded the **auto-rebase** conflict-comment. The **pr-review-mention** reusable's own `gh pr comment` (the `Post acknowledgement comment` step) was left unguarded.

That ack post runs under `bash -e`, so bmad-bgreat-suite's PR #205 hitting GitHub's 2500-comment cap failed the whole step — recording an in-window failure that has kept the pr-review-mention canary **pinned at ring1→stable** (`gate=BLOCKED, cum_fail=1, triage=PRE_EXISTING`) across every scheduled canary-rollout run. It is the **last of the six #482 reusables not yet at STABLE**.

Evidence: `petry-projects/bmad-bgreat-suite` run [28318567437](https://github.com/petry-projects/bmad-bgreat-suite/actions/runs/28318567437) — failed step `Post acknowledgement comment`.

## What
Mirror the #595 treatment exactly: make the ack **best-effort** — a comment-cap / secondary-rate-limit / transient 5xx is logged as a `::warning::` and swallowed. The ack is cosmetic; the review-agent `repository_dispatch` in the next step is what actually drives the review and is unaffected.

## Rollout effect
Changing the reusable blob makes canary **autocut** seat a fresh `pr-review-mention/vX.Y.Z` candidate on the next scheduled tick, so the ring1→stable soak restarts clean on the guarded version and graduates via the normal #548 gate — no manual tag move or `--override` needed.

Finishes #594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)