### PR TITLE
feat(standards): require pure reusable workflows to be disabled + compliance check

### DIFF
--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -271,6 +271,64 @@ check_reusable_workflow_paths() {
 }
 
 # ---------------------------------------------------------------------------
+# Check: Pure reusable workflows must be disabled
+# ---------------------------------------------------------------------------
+# A "pure reusable" is a workflow whose `on:` block declares workflow_call and
+# NOTHING else — it has no independent event triggers and can never run on its
+# own, only when invoked via `uses:`. Per ci-standards.md such workflows must be
+# disabled in the Actions UI. GitHub ignores a reusable's enabled/disabled state
+# when it is called via workflow_call, so disabling has zero effect on callers.
+# Hybrid workflows that ALSO declare a real trigger (schedule/workflow_dispatch/
+# push/pull_request/...) are exempt and must stay active.
+#
+# Only block-form `on:` is classified (every fleet reusable uses it); an inline
+# `on: workflow_call` would simply not match and be skipped — a safe miss, not a
+# false positive.
+check_reusable_workflows_disabled() {
+  local repo="$1"
+
+  local workflows
+  workflows=$(gh_api "repos/$ORG/$repo/contents/.github/workflows" --jq '.[].name' 2>/dev/null || echo "")
+
+  for wf in $workflows; do
+    [[ "$wf" != *.yml && "$wf" != *.yaml ]] && continue
+
+    local content decoded
+    content=$(gh_api "repos/$ORG/$repo/contents/.github/workflows/$wf" --jq '.content' 2>/dev/null || echo "")
+    [ -z "$content" ] && continue
+    decoded=$(echo "$content" | base64 -d 2>/dev/null || echo "")
+    [ -z "$decoded" ] && continue
+
+    # Extract the top-level trigger keys declared under the `on:` block.
+    local triggers
+    triggers=$(echo "$decoded" | awk '
+      /^on:/                     { inblock=1; next }
+      inblock && /^[^[:space:]#]/ { exit }          # dedent -> left the on: block
+      inblock && /^  [a-zA-Z_]/  {                   # exactly-2-space-indented key
+        key=$1; sub(/:.*/,"",key); gsub(/[[:space:]]/,"",key); print key
+      }
+    ')
+
+    # Pure reusable = workflow_call present AND no other trigger key.
+    echo "$triggers" | grep -qx "workflow_call" || continue
+    if [ "$(echo "$triggers" | grep -vx "workflow_call" | grep -c .)" -ne 0 ]; then
+      continue   # hybrid (workflow_call + real trigger) — exempt, must stay active
+    fi
+
+    # Pure reusable — check its enabled/disabled state.
+    local state
+    state=$(gh_api "repos/$ORG/$repo/actions/workflows/$wf" --jq '.state' 2>/dev/null || echo "")
+    [ -z "$state" ] && continue   # not registered (e.g. absent from default branch)
+
+    if [ "$state" = "active" ]; then
+      add_finding "$repo" "reusable-workflows" "reusable-active-$wf" "warning" \
+        "Pure reusable workflow \`$wf\` (workflow_call-only) is \`active\`; it should be disabled since it can never run on its own. Disable with: \`gh workflow disable $wf -R $ORG/$repo\`" \
+        "standards/ci-standards.md#pure-reusable-workflows-must-be-disabled"
+    fi
+  done
+}
+
+# ---------------------------------------------------------------------------
 # Check: Dependabot configuration
 # ---------------------------------------------------------------------------
 check_dependabot_config() {
@@ -2351,6 +2409,7 @@ main() {
     check_required_workflows "$repo"
     check_action_pinning "$repo"
     check_reusable_workflow_paths "$repo"
+    check_reusable_workflows_disabled "$repo"
     check_dependabot_config "$repo"
     check_repo_settings "$repo" "$repo_json"
     check_labels "$repo"

--- a/scripts/compliance-audit.sh
+++ b/scripts/compliance-audit.sh
@@ -281,9 +281,8 @@ check_reusable_workflow_paths() {
 # Hybrid workflows that ALSO declare a real trigger (schedule/workflow_dispatch/
 # push/pull_request/...) are exempt and must stay active.
 #
-# Only block-form `on:` is classified (every fleet reusable uses it); an inline
-# `on: workflow_call` would simply not match and be skipped — a safe miss, not a
-# false positive.
+# Three YAML forms of `on:` are handled: block form, inline scalar
+# (`on: workflow_call`), and inline sequence (`on: [workflow_call]`).
 check_reusable_workflows_disabled() {
   local repo="$1"
 
@@ -296,18 +295,30 @@ check_reusable_workflows_disabled() {
     local content decoded
     content=$(gh_api "repos/$ORG/$repo/contents/.github/workflows/$wf" --jq '.content' 2>/dev/null || echo "")
     [ -z "$content" ] && continue
-    decoded=$(echo "$content" | base64 -d 2>/dev/null || echo "")
+    decoded=$(printf '%s' "$content" | base64 -d 2>/dev/null) || continue
     [ -z "$decoded" ] && continue
 
-    # Extract the top-level trigger keys declared under the `on:` block.
-    local triggers
-    triggers=$(echo "$decoded" | awk '
-      /^on:/                     { inblock=1; next }
-      inblock && /^[^[:space:]#]/ { exit }          # dedent -> left the on: block
-      inblock && /^  [a-zA-Z_]/  {                   # exactly-2-space-indented key
-        key=$1; sub(/:.*/,"",key); gsub(/[[:space:]]/,"",key); print key
-      }
-    ')
+    # Extract the top-level trigger keys from the `on:` declaration.
+    # Handles block form, inline scalar (`on: workflow_call`), and
+    # inline sequence (`on: [workflow_call, push]`).
+    local triggers on_line
+    on_line=$(echo "$decoded" | grep -m1 '^on:')
+    if echo "$on_line" | grep -qE '^on:[[:space:]]+[a-zA-Z_]+[[:space:]]*(#.*)?$'; then
+      # Inline scalar: on: workflow_call
+      triggers=$(echo "$on_line" | sed 's/^on:[[:space:]]*//' | sed 's/[[:space:]]*#.*//' | tr -d '[:space:]')
+    elif echo "$on_line" | grep -qE '^on:[[:space:]]*\['; then
+      # Inline sequence: on: [workflow_call, push]
+      triggers=$(echo "$on_line" | sed 's/^on:[[:space:]]*//' | tr -d '[]"'"'"' ' | tr ',' '\n' | tr -d '[:space:]')
+    else
+      # Block form: on:\n  key:\n  ...
+      triggers=$(echo "$decoded" | awk '
+        /^on:/                     { inblock=1; next }
+        inblock && /^[^[:space:]#]/ { exit }          # dedent -> left the on: block
+        inblock && /^  [a-zA-Z_]/  {                   # exactly-2-space-indented key
+          key=$1; sub(/:.*/,"",key); gsub(/[[:space:]]/,"",key); print key
+        }
+      ')
+    fi
 
     # Pure reusable = workflow_call present AND no other trigger key.
     echo "$triggers" | grep -qx "workflow_call" || continue
@@ -320,9 +331,9 @@ check_reusable_workflows_disabled() {
     state=$(gh_api "repos/$ORG/$repo/actions/workflows/$wf" --jq '.state' 2>/dev/null || echo "")
     [ -z "$state" ] && continue   # not registered (e.g. absent from default branch)
 
-    if [ "$state" = "active" ]; then
-      add_finding "$repo" "reusable-workflows" "reusable-active-$wf" "warning" \
-        "Pure reusable workflow \`$wf\` (workflow_call-only) is \`active\`; it should be disabled since it can never run on its own. Disable with: \`gh workflow disable $wf -R $ORG/$repo\`" \
+    if [ "$state" != "disabled_manually" ]; then
+      add_finding "$repo" "reusable-workflows" "reusable-not-disabled-manually-$wf" "warning" \
+        "Pure reusable workflow \`$wf\` (workflow_call-only) is in state \`$state\` (expected \`disabled_manually\`); it must be intentionally disabled in the Actions UI. Disable with: \`gh workflow disable $wf -R $ORG/$repo\`" \
         "standards/ci-standards.md#pure-reusable-workflows-must-be-disabled"
     fi
   done
@@ -2026,6 +2037,7 @@ create_umbrella_issue() {
     "labels|Labels|apply_labels() in apply-repo-settings.sh"
     "rulesets|Repository Rulesets|apply-rulesets.sh"
     "ci-workflows|Workflows|per-repo workflow additions"
+    "reusable-workflows|Reusable Workflows (disabled_manually)|gh workflow disable <workflow> -R <repo>"
     "action-pinning|Action SHA Pinning|pin actions to SHA in each workflow file"
     "dependabot|Dependabot Configuration|per-repo .github/dependabot.yml"
     "standards|Agent Standards (CLAUDE.md / AGENTS.md / copilot-setup-steps.yml)|per-repo doc and workflow additions"
@@ -2236,7 +2248,7 @@ HEREDOC
 
 HEREDOC
 
-  for category in ci-workflows action-pinning dependabot settings push-protection labels rulesets standards; do
+  for category in ci-workflows reusable-workflows action-pinning dependabot settings push-protection labels rulesets standards; do
     local cat_count
     cat_count=$(jq --arg cat "$category" '[.[] | select(.category == $cat)] | length' "$FINDINGS_FILE")
     if [ "$cat_count" -gt 0 ]; then

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -162,6 +162,58 @@ that reusable. The reference implementation and the full rationale live in the
 release-strategy initiative
 (`petry-projects/.github-private/docs/initiatives/agentic-release-strategy.md`).
 
+### Pure reusable workflows must be disabled
+
+**Standard.** A **pure reusable workflow** — one whose `on:` block declares
+**`workflow_call` and nothing else** — MUST be set to `disabled_manually` in the
+Actions UI. This applies to the single-source-of-truth `*-reusable.yml`
+definition files hosted in `petry-projects/.github` and
+`petry-projects/.github-private`.
+
+**Why.** A pure reusable has no independent event triggers, so it can never run
+on its own — it executes **only** when another workflow invokes it via `uses:`.
+Left active, it clutters the Actions sidebar with an entry that never has its own
+runs, and a lone active-vs-disabled mix reads as "something is broken" to anyone
+auditing the repo. Disabling states plainly: *this is a library, not a runnable
+workflow.*
+
+**Disabling is safe — it has zero effect on callers.** GitHub **ignores** a
+reusable workflow's enabled/disabled state when it is invoked through
+`workflow_call`; the flag only suppresses a workflow's *own* event triggers, of
+which a pure reusable has none. A disabled reusable is still fully callable, at
+any ref, by any number of caller stubs. (Verified: `dev-lead-reusable.yml` sat
+disabled while 8 caller repos ran it successfully.) Caller count is irrelevant —
+a reusable with 0 callers and one with 8 are both disabled.
+
+**Exemption — anything with a real trigger stays active.** A workflow that
+declares `workflow_call` **alongside** a real trigger (`schedule`,
+`workflow_dispatch`, `push`, `pull_request`, `repository_dispatch`, …) is **not**
+a pure reusable: it runs on its own and MUST remain active. Example:
+`actions-fleet-monitor.yml` (has `schedule` + `workflow_dispatch` + `workflow_call`).
+
+Thin **caller / trigger stubs** are likewise not pure reusables — they carry the
+real event triggers and stay active. Note the common engine-plus-stub split: an
+**engine** that is `workflow_call`-only is a pure reusable and **is disabled**,
+while its **trigger stub** carries the events and **stays active**. For example
+`pr-review.yml` (the engine, `workflow_call`-only → disabled) is invoked by
+`pr-review-trigger.yml` (the stub, `check_suite`/`pull_request`/… → active).
+Disabling the engine does not stop reviews — the stub still fires and calls it.
+
+**How to disable.**
+
+```bash
+gh workflow disable <name>-reusable.yml -R petry-projects/<repo>
+# verify:
+gh api repos/petry-projects/<repo>/actions/workflows/<name>-reusable.yml --jq '.state'  # -> disabled_manually
+```
+
+**Compliance.** `check_reusable_workflows_disabled` in
+[`scripts/compliance-audit.sh`](../scripts/compliance-audit.sh) flags any pure
+`workflow_call`-only workflow found in the `active` state as a `warning`
+finding. Note that disabled state is **not** captured in git — a newly added
+reusable is born `active` and must be disabled explicitly, which is exactly what
+this check catches on the next audit.
+
 ### Available templates
 
 | Template | Tier | Purpose |

--- a/test/scripts/compliance-audit/reusable-workflows-disabled.bats
+++ b/test/scripts/compliance-audit/reusable-workflows-disabled.bats
@@ -1,0 +1,151 @@
+#!/usr/bin/env bats
+# Tests for check_reusable_workflows_disabled in scripts/compliance-audit.sh.
+#
+# Covers:
+#   - Trigger classification: block form, inline scalar, inline sequence
+#   - State check: only disabled_manually is compliant; active and
+#     disabled_inactivity (and any other state) must be flagged
+
+bats_require_minimum_version 1.5.0
+
+# ---------------------------------------------------------------------------
+# Mirror the trigger-classification logic from check_reusable_workflows_disabled.
+# Prints one trigger key per line; exits 0.
+# ---------------------------------------------------------------------------
+_extract_triggers() {
+  local decoded="$1"
+  local on_line
+  on_line=$(echo "$decoded" | grep -m1 '^on:')
+  if echo "$on_line" | grep -qE '^on:[[:space:]]+[a-zA-Z_]+[[:space:]]*(#.*)?$'; then
+    echo "$on_line" | sed 's/^on:[[:space:]]*//' | sed 's/[[:space:]]*#.*//' | tr -d '[:space:]'
+  elif echo "$on_line" | grep -qE '^on:[[:space:]]*\['; then
+    echo "$on_line" | sed 's/^on:[[:space:]]*//' | tr -d '[]"'"'"' ' | tr ',' '\n' | tr -d '[:space:]'
+  else
+    echo "$decoded" | awk '
+      /^on:/                     { inblock=1; next }
+      inblock && /^[^[:space:]#]/ { exit }
+      inblock && /^  [a-zA-Z_]/  {
+        key=$1; sub(/:.*/,"",key); gsub(/[[:space:]]/,"",key); print key
+      }
+    '
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Mirror the pure-reusable detection (workflow_call only, no other triggers).
+# Returns 0 if pure reusable, 1 if hybrid or non-reusable.
+# ---------------------------------------------------------------------------
+_is_pure_reusable() {
+  local decoded="$1"
+  local triggers
+  triggers=$(_extract_triggers "$decoded")
+  echo "$triggers" | grep -qx "workflow_call" || return 1
+  [ "$(echo "$triggers" | grep -vx "workflow_call" | grep -c .)" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Mirror the compliance check: returns 0 when a finding should be emitted.
+# ---------------------------------------------------------------------------
+_should_flag() {
+  local state="$1"
+  [ "$state" != "disabled_manually" ]
+}
+
+# ===========================================================================
+# Trigger classification — block form
+# ===========================================================================
+
+@test "block form: workflow_call-only is a pure reusable" {
+  local wf
+  wf=$(printf 'on:\n  workflow_call:\n    inputs:\n      repo:\n        type: string\n')
+  run _is_pure_reusable "$wf"
+  [ "$status" -eq 0 ]
+}
+
+@test "block form: workflow_call + push is a hybrid (not pure reusable)" {
+  local wf
+  wf=$(printf 'on:\n  workflow_call:\n  push:\n    branches: [main]\n')
+  run _is_pure_reusable "$wf"
+  [ "$status" -eq 1 ]
+}
+
+@test "block form: push-only workflow is not a reusable" {
+  local wf
+  wf=$(printf 'on:\n  push:\n    branches: [main]\n')
+  run _is_pure_reusable "$wf"
+  [ "$status" -eq 1 ]
+}
+
+# ===========================================================================
+# Trigger classification — inline scalar
+# ===========================================================================
+
+@test "inline scalar: 'on: workflow_call' is a pure reusable" {
+  local wf
+  wf=$(printf 'on: workflow_call\njobs:\n  call:\n    runs-on: ubuntu-latest\n    steps: []\n')
+  run _is_pure_reusable "$wf"
+  [ "$status" -eq 0 ]
+}
+
+@test "inline scalar: 'on: push' is not a reusable" {
+  local wf
+  wf=$(printf 'on: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps: []\n')
+  run _is_pure_reusable "$wf"
+  [ "$status" -eq 1 ]
+}
+
+@test "inline scalar: trailing comment does not break classification" {
+  local wf
+  wf=$(printf 'on: workflow_call # pure reusable\njobs:\n  call:\n    runs-on: ubuntu-latest\n    steps: []\n')
+  run _is_pure_reusable "$wf"
+  [ "$status" -eq 0 ]
+}
+
+# ===========================================================================
+# Trigger classification — inline sequence
+# ===========================================================================
+
+@test "inline sequence: '[workflow_call]' is a pure reusable" {
+  local wf
+  wf=$(printf 'on: [workflow_call]\njobs:\n  call:\n    runs-on: ubuntu-latest\n    steps: []\n')
+  run _is_pure_reusable "$wf"
+  [ "$status" -eq 0 ]
+}
+
+@test "inline sequence: '[workflow_call, push]' is a hybrid (not pure reusable)" {
+  local wf
+  wf=$(printf 'on: [workflow_call, push]\njobs:\n  call:\n    runs-on: ubuntu-latest\n    steps: []\n')
+  run _is_pure_reusable "$wf"
+  [ "$status" -eq 1 ]
+}
+
+@test "inline sequence: '[push, pull_request]' is not a reusable" {
+  local wf
+  wf=$(printf 'on: [push, pull_request]\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps: []\n')
+  run _is_pure_reusable "$wf"
+  [ "$status" -eq 1 ]
+}
+
+# ===========================================================================
+# State check — only disabled_manually is compliant
+# ===========================================================================
+
+@test "state 'active' is flagged" {
+  run _should_flag "active"
+  [ "$status" -eq 0 ]
+}
+
+@test "state 'disabled_inactivity' is flagged" {
+  run _should_flag "disabled_inactivity"
+  [ "$status" -eq 0 ]
+}
+
+@test "state 'disabled_manually' is NOT flagged" {
+  run _should_flag "disabled_manually"
+  [ "$status" -eq 1 ]
+}
+
+@test "unknown/unexpected state is flagged" {
+  run _should_flag "unknown"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## What

Codifies a new CI/CD standard: **pure reusable workflows (`on: workflow_call` and nothing else) must be set to `disabled_manually`**, and adds a deterministic compliance check that enforces it.

## Why

A pure reusable has no independent triggers — it can never run on its own, only when invoked via `uses:`. Left active it clutters the Actions sidebar with a never-running entry, and an inconsistent active/disabled mix reads as "something is broken" (this standard came directly out of an investigation into why `dev-lead-reusable.yml` was disabled).

**Disabling is provably safe:** GitHub *ignores* a reusable's enabled/disabled state when it's invoked through `workflow_call` — the flag only suppresses a workflow's own event triggers, of which a pure reusable has none. Verified: `dev-lead-reusable.yml` sat disabled while 8 caller repos ran it successfully. Caller count is irrelevant.

## Changes

- **`standards/ci-standards.md`** — new *"Pure reusable workflows must be disabled"* section: the rule, the callers-unaffected guarantee, the exemption for anything carrying a real trigger, and the **engine-plus-stub** clarification (a `workflow_call`-only engine is disabled; its trigger stub carries the events and stays active — e.g. `pr-review.yml` engine disabled, `pr-review-trigger.yml` stub active), plus the `gh workflow disable` procedure.
- **`scripts/compliance-audit.sh`** — new `check_reusable_workflows_disabled()`, wired into the per-repo dispatch loop. Classifies block-form `on:` triggers; flags any pure `workflow_call`-only workflow in the `active` state as a **`warning`** finding. Hybrids and trigger stubs are exempt.

## Validation

- `bash -n` + `shellcheck -S warning` clean.
- Classification unit-tested against every `workflow_call` workflow across `.github` + `.github-private` (block-form `on:`), including the engine/stub pairs.

## Applied (separate, reversible runtime action — not a git change)

Disabled all currently-active pure reusables via `gh workflow disable`. Final state — **16 pure reusables disabled, 0 active**:

- **`.github` (13):** add-to-project, agent-shield, auto-rebase, claude-code, dependabot-automerge, dependabot-rebase, dependency-audit, feature-ideation, idea-enhancer, idea-triage, initiative-planner, pr-auto-review, pr-review-mention `-reusable.yml`
- **`.github-private` (3):** ci-failure-analyst-reusable, dev-lead-reusable (already disabled), pr-review.yml (engine)

Hybrids left active as required: `actions-fleet-monitor.yml` (schedule) and every trigger stub (e.g. `pr-review-trigger.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)