### PR TITLE
feat(#613): enable canary-rollout schedule in .github (cutover)

### DIFF
--- a/.github/workflows/canary-rollout.yml
+++ b/.github/workflows/canary-rollout.yml
@@ -41,8 +41,8 @@
 name: Canary Rollout
 
 on:
-  # schedule:  # DISABLED until epic #613 step-4 cutover — see PR (relocated from .github-private, must not double-run)
-  #   - cron: "0 */4 * * *"   # every 4 hours — evaluate only (RE-ENABLE at cutover)
+  schedule:
+    - cron: "0 */4 * * *"   # every 4 hours — autocut → promote-all → sync-issues
   workflow_dispatch:
     inputs:
       command:


### PR DESCRIPTION
## What

**PR-C2 of the epic #613 cutover.** Re-enables the 4-hourly `schedule:` on the relocated canary-rollout workflow (shipped disabled in #624), making `.github` the live host for **autocut → promote-all → sync-issues**.

```diff
 on:
-  # schedule:  # DISABLED until epic #613 step-4 cutover …
-  #   - cron: "0 */4 * * *"
+  schedule:
+    - cron: "0 */4 * * *"   # every 4 hours
   workflow_dispatch:
```

## ⚠️ Merge order (hard requirement)

**Must land AFTER [petry-projects/.github-private#1128](https://github.com/petry-projects/.github-private/pull/1128)**, which deletes the engine + workflow there and stops that repo's schedule. Both `CANARY_AUTO_CUT` and `CANARY_AUTO_PROMOTE` are `true`, so the two schedules must never overlap (they'd race on tag mutations). Sequenced strictly after the `.github-private` removal.

## Already live-validated

`workflow_dispatch` evaluate run [28990172900](https://github.com/petry-projects/.github/actions/runs/28990172900) in `.github` minted the release-manager App token, resolved cross-repo `dev-lead` channel tags on `.github-private`, and computed the #548 gate — the engine runs correctly from its new home.

Refs #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)