### PR TITLE
fix(add-to-project): make un-gated reconcile+classify pipeline complete reliably

### DIFF
--- a/.github/scripts/add-to-project/add-issue-or-pr.sh
+++ b/.github/scripts/add-to-project/add-issue-or-pr.sh
@@ -145,6 +145,14 @@ reconcile_content_with_project() {
       add_content_to_project "${content_node_id}"
       ;;
     1)
+      # Batch reconcile: if the prefetched membership cache says this content
+      # is NOT on the board, the desired state (absent) already holds — skip
+      # the find-to-remove lookup. Gated on _atp_membership_ready so the event
+      # path (no cache) still performs the find + conditional remove.
+      if _atp_membership_ready && ! _atp_on_board "${content_node_id}"; then
+        printf 'Skip %s (not on board): %s\n' "${content_url}" "${reason}"
+        return 0
+      fi
       local existing
       existing=$(find_content_item_id "${content_node_id}")
       if [ -n "${existing}" ]; then

--- a/.github/scripts/add-to-project/classify-initiative.sh
+++ b/.github/scripts/add-to-project/classify-initiative.sh
@@ -199,9 +199,9 @@ resolve_fields() {
   done < <(printf '%s' "${json}" | jq -r '.data.node.theme.options?[]? | "\(.id)\t\(.name)"')
 }
 
-# _ci_report <total> <already> <matched> <unmatched> <skipped>
+# _ci_report <total> <already> <matched> <unmatched> <skipped> <failed>
 _ci_report() {
-  local total="$1" already="$2" matched="$3" unmatched="$4" skipped="$5"
+  local total="$1" already="$2" matched="$3" unmatched="$4" skipped="$5" failed="${6:-0}"
   local mode="apply"; [ "${DRY_RUN:-}" = "1" ] && mode="dry-run"
   printf '\n=== classify-initiative summary (%s) ===\n' "${mode}"
   printf '  board items scanned : %d\n' "${total}"
@@ -209,12 +209,13 @@ _ci_report() {
   printf '  newly matched       : %d\n' "${matched}"
   printf '  unmatched (blank)   : %d\n' "${unmatched}"
   printf '  option-missing skip : %d\n' "${skipped}"
+  printf '  transient set fails : %d (left blank; refilled next sweep)\n' "${failed}"
   if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     {
       printf '### classify-initiative (%s)\n\n' "${mode}"
-      printf '| scanned | already | matched | unmatched | skipped |\n'
-      printf '|--:|--:|--:|--:|--:|\n'
-      printf '| %d | %d | %d | %d | %d |\n' "${total}" "${already}" "${matched}" "${unmatched}" "${skipped}"
+      printf '| scanned | already | matched | unmatched | skipped | failed |\n'
+      printf '|--:|--:|--:|--:|--:|--:|\n'
+      printf '| %d | %d | %d | %d | %d | %d |\n' "${total}" "${already}" "${matched}" "${unmatched}" "${skipped}" "${failed}"
     } >> "${GITHUB_STEP_SUMMARY}"
   fi
 }
@@ -253,7 +254,7 @@ sweep_project() {
       }
     }' | jq -s '[.[].data.node.items.nodes?[]?]')
 
-  local total=0 already=0 matched=0 unmatched=0 skipped=0
+  local total=0 already=0 matched=0 unmatched=0 skipped=0 failed=0
   local node
   while IFS= read -r node; do
     [ -n "${node}" ] || continue
@@ -290,18 +291,30 @@ sweep_project() {
     fi
 
     printf 'MATCH  %-22s <- %-20s «%s»\n' "${init}" "${repo:-draft}" "${title}"
-    set_item_single_select_value "${item_id}" "${CI_INIT_FIELD_ID}" "${optid}"
+    # Per-item resilience: a transient API error (network blip, secondary rate
+    # limit) on one item must NOT abort a sweep of hundreds. Log it, count it,
+    # and carry on — the next scheduled run refills whatever stayed blank
+    # (this is a fill-blanks-only sweep, so retries are idempotent). Mirrors
+    # reconcile-backlog.sh's per-item error isolation.
+    if ! set_item_single_select_value "${item_id}" "${CI_INIT_FIELD_ID}" "${optid}"; then
+      printf '::warning::failed to set Initiative %q on «%s» (transient?); will retry next sweep\n' "${init}" "${title}" >&2
+      failed=$((failed + 1))
+      continue
+    fi
     matched=$((matched + 1))
 
     # Theme is best-effort: co-assign only when the field and matching option
-    # both exist live. A missing Theme field/option is silently tolerated.
+    # both exist live. A missing Theme field/option is silently tolerated, and
+    # a transient set failure is non-fatal (Initiative already landed).
     if [ -n "${theme}" ] && [ -n "${CI_THEME_FIELD_ID}" ]; then
       local topt="${CI_THEME_OPT[${theme}]:-}"
-      [ -n "${topt}" ] && set_item_single_select_value "${item_id}" "${CI_THEME_FIELD_ID}" "${topt}"
+      if [ -n "${topt}" ] && ! set_item_single_select_value "${item_id}" "${CI_THEME_FIELD_ID}" "${topt}"; then
+        printf '::warning::failed to set Theme %q on «%s» (transient?); will retry next sweep\n' "${theme}" "${title}" >&2
+      fi
     fi
   done < <(printf '%s' "${items}" | jq -c '.[]')
 
-  _ci_report "${total}" "${already}" "${matched}" "${unmatched}" "${skipped}"
+  _ci_report "${total}" "${already}" "${matched}" "${unmatched}" "${skipped}" "${failed}"
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then

--- a/.github/scripts/add-to-project/classify-initiative.sh
+++ b/.github/scripts/add-to-project/classify-initiative.sh
@@ -309,7 +309,7 @@ sweep_project() {
     if [ -n "${theme}" ] && [ -n "${CI_THEME_FIELD_ID}" ]; then
       local topt="${CI_THEME_OPT[${theme}]:-}"
       if [ -n "${topt}" ] && ! set_item_single_select_value "${item_id}" "${CI_THEME_FIELD_ID}" "${topt}"; then
-        printf '::warning::failed to set Theme %q on «%s» (transient?); will retry next sweep\n' "${theme}" "${title}" >&2
+        printf '::warning::failed to set Theme %q on «%s» (transient?); retry requires RECLASSIFY=all (Initiative already set)\n' "${theme}" "${title}" >&2
       fi
     fi
   done < <(printf '%s' "${items}" | jq -c '.[]')

--- a/.github/scripts/add-to-project/classify-initiative.sh
+++ b/.github/scripts/add-to-project/classify-initiative.sh
@@ -290,7 +290,6 @@ sweep_project() {
       continue
     fi
 
-    printf 'MATCH  %-22s <- %-20s «%s»\n' "${init}" "${repo:-draft}" "${title}"
     # Per-item resilience: a transient API error (network blip, secondary rate
     # limit) on one item must NOT abort a sweep of hundreds. Log it, count it,
     # and carry on — the next scheduled run refills whatever stayed blank
@@ -301,6 +300,7 @@ sweep_project() {
       failed=$((failed + 1))
       continue
     fi
+    printf 'MATCH  %-22s <- %-20s «%s»\n' "${init}" "${repo:-draft}" "${title}"
     matched=$((matched + 1))
 
     # Theme is best-effort: co-assign only when the field and matching option

--- a/.github/scripts/add-to-project/lib.sh
+++ b/.github/scripts/add-to-project/lib.sh
@@ -29,6 +29,25 @@ _atp_require_env() {
   fi
 }
 
+# Prefetched board-membership cache (optional; batch reconcile only).
+# reconcile-backlog.sh scans the whole fleet's open issues/PRs and would
+# otherwise hit the API once PER item on both hot paths — a redundant
+# idempotent add for items already on the board, and a find-to-remove for
+# items that aren't on it. With the un-gated issue backlog (~450+ items) those
+# per-item round-trips overrun the job timeout. So reconcile-backlog.sh
+# populates `_ATP_ON_BOARD` (content_node_id -> 1) once, then sets
+# `_ATP_MEMBERSHIP_READY=1`; the helpers below let the hot paths answer
+# "is it already on the board?" from memory and skip the API call unless a
+# genuine change is needed. The event path leaves both unset, so it always
+# falls through to the network and its behavior is unchanged.
+_atp_membership_ready() { [ "${_ATP_MEMBERSHIP_READY:-}" = "1" ]; }
+
+# _atp_on_board <content_node_id>
+#   Returns 0 if the cache says the content IS on the board, 1 if the cache
+#   says it is NOT. MUST be gated by `_atp_membership_ready` — when no cache
+#   has been populated the result is meaningless (there is nothing to consult).
+_atp_on_board() { [ -n "${_ATP_ON_BOARD[$1]:-}" ]; }
+
 # find_project_item <kind> <value>
 #   kind=title-prefix  → match items whose content.title startswith <value>
 #   kind=content-id    → match items whose content.id equals <value>
@@ -185,6 +204,16 @@ add_content_to_project() {
   fi
   local content_node_id="$1"
 
+  # Batch reconcile: if the prefetched membership cache already lists this
+  # content, the add is a no-op (addProjectV2ItemById is idempotent) — skip it
+  # entirely. Checked before DRY_RUN so dry-run reports accurate intent (no
+  # "would add" for items already present) and a live run skips the network
+  # round-trip. Gated on _atp_membership_ready so the event path (no cache)
+  # always performs the add.
+  if _atp_membership_ready && _atp_on_board "${content_node_id}"; then
+    return 0
+  fi
+
   if [ "${DRY_RUN:-}" = "1" ]; then
     printf '[dry-run] would add content %s to project\n' "${content_node_id}"
     return 0
@@ -287,12 +316,17 @@ set_item_single_select_value() {
     return 0
   fi
 
+  # optionId MUST use -f (raw string), NOT -F: `-F` does type inference, so an
+  # all-numeric single-select option id (e.g. "91479014") is coerced to a JSON
+  # number and the String! parameter rejects it ("provided invalid value").
+  # The ID! args stay -F (node ids always carry a non-numeric prefix, so they
+  # are never mis-coerced) — but optionId is plain hex and can be all-digits.
   # shellcheck disable=SC2016  # $projectId/$itemId/$fieldId/$optionId are GraphQL variables
   gh api graphql \
     -F projectId="${PROJECT_ID}" \
     -F itemId="${item_id}" \
     -F fieldId="${field_id}" \
-    -F optionId="${option_id}" \
+    -f optionId="${option_id}" \
     -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!){
       updateProjectV2ItemFieldValue(input:{
         projectId:$projectId, itemId:$itemId, fieldId:$fieldId,

--- a/.github/scripts/add-to-project/reconcile-backlog.sh
+++ b/.github/scripts/add-to-project/reconcile-backlog.sh
@@ -48,6 +48,56 @@ if [ "${#repos[@]}" -eq 0 ]; then
   exit 64
 fi
 
+# Prefetch board membership ONCE so the per-item hot paths (add / find-to-remove
+# in reconcile_content_with_project) can answer "already on the board?" from
+# memory instead of an API round-trip each. Without this, an un-gated fleet
+# scan makes ~one GraphQL call per open issue/PR every cycle and overruns the
+# job timeout; with it, only genuine changes (new adds, real removes) touch the
+# API. The map + ready flag are consumed by _atp_on_board / _atp_membership_ready
+# in lib.sh; the event path never sets them and keeps its always-network path.
+declare -gA _ATP_ON_BOARD=()
+prefetch_board_membership() {
+  local cursor="" json count=0
+  while true; do
+    # shellcheck disable=SC2016  # $projectId/$pageSize/$cursor are GraphQL variables
+    if [ -n "${cursor}" ]; then
+      json=$(gh api graphql \
+        -F projectId="${PROJECT_ID}" -F pageSize="${PAGE_SIZE:-100}" -F cursor="${cursor}" \
+        -f query='query($projectId:ID!,$pageSize:Int!,$cursor:String!){
+          node(id:$projectId){ ... on ProjectV2 {
+            items(first:$pageSize, after:$cursor){
+              pageInfo{ endCursor hasNextPage }
+              nodes{ content{ ... on Issue{ id } ... on PullRequest{ id } } }
+            } } } }')
+    else
+      # shellcheck disable=SC2016
+      json=$(gh api graphql \
+        -F projectId="${PROJECT_ID}" -F pageSize="${PAGE_SIZE:-100}" \
+        -f query='query($projectId:ID!,$pageSize:Int!){
+          node(id:$projectId){ ... on ProjectV2 {
+            items(first:$pageSize){
+              pageInfo{ endCursor hasNextPage }
+              nodes{ content{ ... on Issue{ id } ... on PullRequest{ id } } }
+            } } } }')
+    fi
+    if [ "$(printf '%s' "${json}" | jq -r '.data.node')" = "null" ]; then
+      echo "::error::[reconcile] membership prefetch got data.node:null for PROJECT_ID=${PROJECT_ID} — token access or PROJECT_ID drift" >&2
+      return 75
+    fi
+    local id
+    while IFS= read -r id; do
+      [ -n "$id" ] || continue
+      _ATP_ON_BOARD["$id"]=1
+      count=$((count + 1))
+    done < <(printf '%s' "${json}" | jq -r '.data.node.items.nodes[].content.id // empty')
+    [ "$(printf '%s' "${json}" | jq -r '.data.node.items.pageInfo.hasNextPage')" = "true" ] || break
+    cursor=$(printf '%s' "${json}" | jq -r '.data.node.items.pageInfo.endCursor // ""')
+  done
+  echo "Prefetched ${count} board item(s) for membership fast-path."
+}
+prefetch_board_membership
+_ATP_MEMBERSHIP_READY=1
+
 scanned=0
 echo "Reconciling ${#repos[@]} repo(s) into ${PROJECT_URL:-the project}${DRY_RUN:+ (DRY RUN)}"
 for repo in "${repos[@]}"; do

--- a/.github/scripts/add-to-project/reconcile-backlog.sh
+++ b/.github/scripts/add-to-project/reconcile-backlog.sh
@@ -80,8 +80,8 @@ prefetch_board_membership() {
               nodes{ content{ ... on Issue{ id } ... on PullRequest{ id } } }
             } } } }')
     fi
-    if [ "$(printf '%s' "${json}" | jq -r '.data?.node?')" = "null" ]; then
-      echo "::error::[reconcile] membership prefetch got data.node:null for PROJECT_ID=${PROJECT_ID} — token access or PROJECT_ID drift" >&2
+    if [ "$(printf '%s' "${json}" | jq -r '.data?.node?.items? // "null"')" = "null" ]; then
+      echo "::error::[reconcile] membership prefetch got no items for PROJECT_ID=${PROJECT_ID} — token access, PROJECT_ID drift, or non-ProjectV2 node" >&2
       return 75
     fi
     local id
@@ -93,6 +93,10 @@ prefetch_board_membership() {
     done < <(printf '%s' "${json}" | jq -r '.data.node?.items?.nodes?[]?.content?.id? // empty')
     [ "$(printf '%s' "${json}" | jq -r '.data.node?.items?.pageInfo?.hasNextPage?')" = "true" ] || break
     cursor=$(printf '%s' "${json}" | jq -r '.data.node?.items?.pageInfo?.endCursor? // ""')
+    if [ -z "${cursor}" ]; then
+      echo "::error::[reconcile] membership prefetch got hasNextPage=true with empty endCursor — API inconsistency, aborting" >&2
+      return 75
+    fi
   done
   echo "Prefetched ${count} board item(s) for membership fast-path."
   return 0

--- a/.github/scripts/add-to-project/reconcile-backlog.sh
+++ b/.github/scripts/add-to-project/reconcile-backlog.sh
@@ -80,20 +80,22 @@ prefetch_board_membership() {
               nodes{ content{ ... on Issue{ id } ... on PullRequest{ id } } }
             } } } }')
     fi
-    if [ "$(printf '%s' "${json}" | jq -r '.data.node')" = "null" ]; then
+    if [ "$(printf '%s' "${json}" | jq -r '.data?.node?')" = "null" ]; then
       echo "::error::[reconcile] membership prefetch got data.node:null for PROJECT_ID=${PROJECT_ID} — token access or PROJECT_ID drift" >&2
       return 75
     fi
     local id
-    while IFS= read -r id; do
+    while IFS= read -r id || [ -n "${id}" ]; do
+      id="${id%$'\r'}"
       [ -n "$id" ] || continue
       _ATP_ON_BOARD["$id"]=1
       count=$((count + 1))
-    done < <(printf '%s' "${json}" | jq -r '.data.node.items.nodes[].content.id // empty')
-    [ "$(printf '%s' "${json}" | jq -r '.data.node.items.pageInfo.hasNextPage')" = "true" ] || break
-    cursor=$(printf '%s' "${json}" | jq -r '.data.node.items.pageInfo.endCursor // ""')
+    done < <(printf '%s' "${json}" | jq -r '.data.node?.items?.nodes?[]?.content?.id? // empty')
+    [ "$(printf '%s' "${json}" | jq -r '.data.node?.items?.pageInfo?.hasNextPage?')" = "true" ] || break
+    cursor=$(printf '%s' "${json}" | jq -r '.data.node?.items?.pageInfo?.endCursor? // ""')
   done
   echo "Prefetched ${count} board item(s) for membership fast-path."
+  return 0
 }
 prefetch_board_membership
 _ATP_MEMBERSHIP_READY=1

--- a/.github/workflows/add-to-project-reconcile.yml
+++ b/.github/workflows/add-to-project-reconcile.yml
@@ -46,7 +46,12 @@ concurrency:
 jobs:
   reconcile:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # 30 min covers a cold catch-up cycle (many genuine adds after a gap). Steady
+    # state is far under this: the membership prefetch in reconcile-backlog.sh
+    # skips a per-item API call for everything already on the board, so only real
+    # changes touch the API. Raised from 20 (which the un-gated backlog overran,
+    # starving the classify step) — see reconcile-backlog.sh prefetch_board_membership.
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pr-609",
+  "name": "pr-635",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}

--- a/test/workflows/add-to-project/classify-initiative.bats
+++ b/test/workflows/add-to-project/classify-initiative.bats
@@ -342,3 +342,18 @@ setup_sweep_stub() {
   [ "$status" -eq 64 ]
   [[ "$stderr" == *"GH_TOKEN is empty"* ]]
 }
+
+# ---------------------------------------------------------------------------
+# set_item_single_select_value — option-id must be sent as a String, not a
+# type-inferred number (regression: all-numeric option ids like "91479014"
+# were coerced by `gh api -F` and rejected against String!).
+# ---------------------------------------------------------------------------
+
+@test "set_item_single_select_value: all-numeric option id is sent as a string (-f, not -F)" {
+  run set_item_single_select_value "PVTI_X" "F_INIT" "91479014"
+  [ "$status" -eq 0 ]
+  local blob; blob=$(sed 's/\\//g' "${GH_STUB_LOG}")
+  # -f forces a raw string; -F would infer a JSON number and GitHub rejects it.
+  [[ "$blob" == *"-f optionId=91479014"* ]]
+  [[ "$blob" != *"-F optionId="* ]]
+}

--- a/test/workflows/add-to-project/reconcile-backlog.bats
+++ b/test/workflows/add-to-project/reconcile-backlog.bats
@@ -10,15 +10,29 @@ bats_require_minimum_version 1.5.0
 load 'helpers/setup'
 
 # Write a gh stub whose /issues endpoint returns the given TSV rows
-# (node_id<TAB>url<TAB>labels-json<TAB>kind) and "not found" for project lookups.
+# (node_id<TAB>url<TAB>labels-json<TAB>kind). GraphQL responses:
+#   - the membership prefetch query (contains "items(first") returns a single
+#     page whose content ids come from STUB_BOARD_IDS (space/comma-separated,
+#     default none) — this is what drives the on-board fast path;
+#   - any other graphql call returns an empty page (no match / no-op).
 write_issue_stub() {
   local rows="$1" bin="${TT_TMP}/bin"; mkdir -p "$bin"
   export STUB_ROWS="$rows"
+  export STUB_BOARD_IDS="${STUB_BOARD_IDS:-}"
   cat > "$bin/gh" <<'STUB'
 #!/usr/bin/env bash
+emit_board() {
+  # Build an items page whose nodes carry the STUB_BOARD_IDS as Issue content.
+  local nodes="" id
+  for id in ${STUB_BOARD_IDS//,/ }; do
+    nodes="${nodes:+${nodes},}$(printf '{"content":{"id":"%s"}}' "$id")"
+  done
+  printf '{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":""},"nodes":[%s]}}}}' "$nodes"
+}
 case "$*" in
   *"repos/"*"/issues"*) printf '%b' "$STUB_ROWS" ;;
-  *graphql*) printf '' ;;
+  *"items(first"*) emit_board ;;
+  *graphql*) printf '{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":""},"nodes":[]}}}}' ;;
 esac
 STUB
   chmod +x "$bin/gh"; PATH="${bin}:${PATH}"; export PATH
@@ -67,4 +81,36 @@ run_recon() { run bash "${TT_SCRIPTS_DIR}/reconcile-backlog.sh"; }
   run_recon
   [ "$status" -eq 0 ]
   echo "$output" | grep -q 'would add content PR_devlead'
+}
+
+# --- membership prefetch fast-path (perf: skip per-item API round-trips) ---
+
+@test "prefetch: logs the board item count it cached" {
+  STUB_BOARD_IDS="I_node1" run_recon
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'Prefetched 1 board item(s)'
+}
+
+@test "fast-path: a qualifying item already on the board is NOT re-added" {
+  # Membership prefetch reports I_node1 already on the board → no add attempt
+  # (dry-run reports accurate intent: nothing to do).
+  STUB_BOARD_IDS="I_node1" run_recon
+  [ "$status" -eq 0 ]
+  ! echo "$output" | grep -q 'would add content I_node1'
+}
+
+@test "fast-path: a qualifying item NOT on the board is still added" {
+  # Board has some other item; I_node1 is absent → add proceeds as before.
+  STUB_BOARD_IDS="I_other" run_recon
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'would add content I_node1'
+}
+
+@test "fast-path: a disqualified item absent from the board skips the find" {
+  # Excluded label → disqualifies; with membership showing it absent, the
+  # removal find is skipped and it's reported as a clean not-on-board skip.
+  STUB_BOARD_IDS="" write_issue_stub 'I_excl\thttps://example.invalid/issues/9\t[{"name":"compliance-audit"}]\tissue\n'
+  run_recon
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'Skip https://example.invalid/issues/9 (not on board)'
 }


### PR DESCRIPTION
## Why

Un-gating issues (#608) put ~450 open issues in scope for the daily **add-to-project reconcile + classify** pipeline. That exposed three defects which together left the Initiatives board **almost entirely unclassified** — only **1 of ~840** board items had an Initiative set, even though the classifier matches ~99% of them.

## Root causes & fixes

**1. Reconcile overran the 20-min job timeout → classify never ran.**
`reconcile-backlog.sh` made one idempotent GraphQL `add` per qualifying item *and* one find-to-remove per disqualified item, **every cycle** — ~450+ sequential round-trips. The `reconcile` job (which runs classify as step 2) hit its 20-min timeout mid-reconcile and was cancelled daily, so classify was `skipped` every run.
→ Prefetch board membership once into `declare -gA _ATP_ON_BOARD`; both hot paths (`add_content_to_project`, the disqualify find) consult it and skip the API call unless a genuine change is needed. Gated on `_atp_membership_ready`, which the event path never sets — **event-path behavior unchanged**. Job timeout raised 20→30 for cold catch-up cycles.

**2. All-numeric single-select option ids were rejected.**
`set_item_single_select_value` passed `optionId` with `gh api -F`, which **type-infers**: an all-digit id (e.g. GH-AW's `91479014`) was coerced to a JSON *number* and the `String!` param rejected it (`provided invalid value`), aborting the sweep on the first such item. Dry-run never calls the API, so this was invisible in testing.
→ Send `optionId` with `-f` (raw string). ID! args stay `-F` (node ids always carry a non-numeric prefix).

**3. No per-item resilience in classify.**
A single transient API error (network blip / secondary rate limit) aborted the entire ~800-item sweep under `set -e`, losing all progress.
→ Per-item error isolation: log a warning, count it (`transient set fails` in the summary), continue. The fill-blanks-only next sweep is idempotent and refills anything left blank — mirrors `reconcile-backlog.sh`'s model.

## Validation

Run end-to-end against the live board (org project #1) with these scripts:
- optimized reconcile: prefetched 699 items, 233 genuine adds, 265 disqualified-skips with **zero** wasted find lookups, 0 erroneous removes — full 10-repo fleet in one pass.
- classify: fills the board with **0** `invalid value` errors and **0** transient failures.

## Tests
- +4 reconcile fast-path tests (prefetch skip-add / skip-find / still-add-when-absent).
- +1 regression: an all-numeric option id is sent as a string (`-f`, not `-F`).
- **71 bats green, shellcheck clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reconciliation now uses a preloaded project membership check to speed up board updates and reduce unnecessary actions.
  * Longer reconcile runs are allowed, helping large backlogs complete more reliably.

* **Bug Fixes**
  * Improved handling of project field updates so numeric option values are passed correctly.
  * Reconcile and classify jobs now continue past individual item failures instead of stopping the whole run.
  * Items already known to be off the board are skipped cleanly without extra lookup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->