### PR TITLE
feat(#1008): onboard initiative-planner + idea-triage (organic-traffic model, no canary)

### DIFF
--- a/standards/canary-rings.json
+++ b/standards/canary-rings.json
@@ -466,6 +466,132 @@
           }
         }
       }
+    },
+    "initiative-planner": {
+      "host": "petry-projects/.github",
+      "reusable": ".github/workflows/initiative-planner-reusable.yml",
+      "run_workflow": "Initiative Planner \u2014 Approval Trigger",
+      "rings": [
+        {
+          "channel": "next",
+          "order": 0,
+          "members": [
+            "petry-projects/.github-private"
+          ]
+        },
+        {
+          "channel": "ring0",
+          "order": 1,
+          "members": [
+            "petry-projects/.github"
+          ]
+        },
+        {
+          "channel": "ring1",
+          "order": 2,
+          "members": [
+            "petry-projects/TalkTerm",
+            "petry-projects/bmad-bgreat-suite"
+          ]
+        },
+        {
+          "channel": "stable",
+          "order": 3,
+          "members": [
+            "*"
+          ]
+        }
+      ],
+      "gate": {
+        "_standard": "petry-projects/.github#548 \u2014 graduated dwell/sample gate over a per-candidate cumulative window. These are registry-configurable per-transition knobs; the values below are the #548 defaults.",
+        "baseline_window_days": 14,
+        "baseline_spike_cap_multiple": 3,
+        "benign_failure_classes": [],
+        "control": {
+          "allow_pre_existing": false
+        },
+        "_benign_note": "benign_failure_classes (#1025 P2): per-reusable allowlist matched against a failed run's workflow name (`workflow` ERE) + failed-step signature (`step` ERE, matched via `gh run view`). Matches are excluded from cum_fail \u2014 but ONLY when the candidate's reusable is byte-identical to the prior channel (differs=0), so the allowlist can never mask a candidate-introduced regression. `control.allow_pre_existing`, or `promote --allow-pre-existing`, advances a BLOCKED+PRE_EXISTING frontier (never REGRESSION).",
+        "transitions": {
+          "next->ring0": {
+            "dwell_hours": 4,
+            "sample_fraction_permille": 250,
+            "sample_clamp_min": 3,
+            "sample_clamp_max": 15,
+            "waive_sample_if_no_caller": true
+          },
+          "ring0->ring1": {
+            "dwell_hours": 8,
+            "waive_sample": true
+          },
+          "ring1->stable": {
+            "dwell_hours": 12,
+            "sample_min": 1
+          }
+        }
+      }
+    },
+    "idea-triage": {
+      "host": "petry-projects/.github",
+      "reusable": ".github/workflows/idea-triage-reusable.yml",
+      "run_workflow": "Idea Triage \u2014 Weekly Shortlist",
+      "rings": [
+        {
+          "channel": "next",
+          "order": 0,
+          "members": [
+            "petry-projects/.github-private"
+          ]
+        },
+        {
+          "channel": "ring0",
+          "order": 1,
+          "members": [
+            "petry-projects/.github"
+          ]
+        },
+        {
+          "channel": "ring1",
+          "order": 2,
+          "members": [
+            "petry-projects/TalkTerm",
+            "petry-projects/bmad-bgreat-suite"
+          ]
+        },
+        {
+          "channel": "stable",
+          "order": 3,
+          "members": [
+            "*"
+          ]
+        }
+      ],
+      "gate": {
+        "_standard": "petry-projects/.github#548 \u2014 graduated dwell/sample gate over a per-candidate cumulative window. These are registry-configurable per-transition knobs; the values below are the #548 defaults.",
+        "baseline_window_days": 14,
+        "baseline_spike_cap_multiple": 3,
+        "benign_failure_classes": [],
+        "control": {
+          "allow_pre_existing": false
+        },
+        "_benign_note": "benign_failure_classes (#1025 P2): per-reusable allowlist matched against a failed run's workflow name (`workflow` ERE) + failed-step signature (`step` ERE, matched via `gh run view`). Matches are excluded from cum_fail \u2014 but ONLY when the candidate's reusable is byte-identical to the prior channel (differs=0), so the allowlist can never mask a candidate-introduced regression. `control.allow_pre_existing`, or `promote --allow-pre-existing`, advances a BLOCKED+PRE_EXISTING frontier (never REGRESSION).",
+        "transitions": {
+          "next->ring0": {
+            "dwell_hours": 4,
+            "sample_fraction_permille": 250,
+            "sample_clamp_min": 3,
+            "sample_clamp_max": 15,
+            "waive_sample_if_no_caller": true
+          },
+          "ring0->ring1": {
+            "dwell_hours": 8,
+            "waive_sample": true
+          },
+          "ring1->stable": {
+            "dwell_hours": 12,
+            "sample_min": 1
+          }
+        }
+      }
     }
   }
 }

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -210,6 +210,34 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
+@test "canary-rings.json: idea->initiative pipeline agents onboarded (standard rings + gate, #1008)" {
+  # initiative-planner + idea-triage are host=.github agents with sparse, event-driven
+  # traffic. They ride the STANDARD ring model + gate — NO synthetic canary: the empty
+  # inner rings waive on dwell (no caller), and ring1->stable soaks until real
+  # TalkTerm/bmad traffic (organic or human-triggered) arrives.
+  local a
+  for a in initiative-planner idea-triage; do
+    run jq -e --arg a "$a" '.agents[$a].host == "petry-projects/.github"' "$RINGS"
+    [ "$status" -eq 0 ]
+    run bash -c "jq -r --arg a '$a' '.agents[\$a].rings | sort_by(.order) | map(.channel) | join(\",\")' '$RINGS'"
+    [ "$output" = "next,ring0,ring1,stable" ]
+    # ring1 = the real consumers that gate ring1->stable
+    run jq -e --arg a "$a" '.agents[$a].rings[] | select(.channel=="ring1") | (.members|index("petry-projects/TalkTerm")) and (.members|index("petry-projects/bmad-bgreat-suite"))' "$RINGS"
+    [ "$status" -eq 0 ]
+    # standard #548 gate: inner rings waive, ring1->stable needs >=1 real run
+    run jq -e --arg a "$a" '.agents[$a].gate.transitions["next->ring0"].waive_sample_if_no_caller == true and .agents[$a].gate.transitions["ring0->ring1"].waive_sample == true and .agents[$a].gate.transitions["ring1->stable"].sample_min == 1' "$RINGS"
+    [ "$status" -eq 0 ]
+    # NO synthetic-canary machinery — organic traffic drives the rollout (design decision #1008)
+    run jq -e --arg a "$a" '.agents[$a] | (has("next_tier_health_signal")|not) and (has("soak_start_ring")|not)' "$RINGS"
+    [ "$status" -eq 0 ]
+  done
+  # run_workflow names = what the gate samples on the ring tiers
+  run jq -e '.agents["initiative-planner"].run_workflow | startswith("Initiative Planner")' "$RINGS"
+  [ "$status" -eq 0 ]
+  run jq -e '.agents["idea-triage"].run_workflow | startswith("Idea Triage")' "$RINGS"
+  [ "$status" -eq 0 ]
+}
+
 @test "canary-rings.json: gate block carries #548 per-transition defaults" {
   # baseline window + spike cap
   run jq -e '.agents["dev-lead"].gate.baseline_window_days == 14' "$RINGS"


### PR DESCRIPTION
Closes #1008 (planner/triage half). Unblocked by epic #613 (engine + registry now in `.github`).

## What
Registers the two idea→initiative pipeline agents in `standards/canary-rings.json` so the canary engine soaks/gates/rolls-back/dashboards them. They were flagged by `canary-rollout drift` as unregistered (`drift` 8 → 6 after this).

## Design decision: **no synthetic canary** (per maintainer)
PR #1010 proposed dedicated `*-canary.yml` health-signal workflows + `soak_start_ring`/`next_tier_health_signal` engine machinery to *manufacture* soak traffic for these low-traffic, event-driven agents. Instead, **organic (or human-triggered) traffic drives the rollout** — the standard #548 gate already handles sparse traffic correctly:

- empty inner rings (`next`/`ring0` — no channel caller) **waive the sample** and advance on dwell + cumulative health (`waive_sample_if_no_caller` / `waive_sample`);
- `ring1→stable` requires **≥1 real ring1 run** (TalkTerm/bmad), so it **SOAKS** (waits) until real traffic arrives. Low-traffic rollouts taking days/weeks is acceptable; humans drive the event triggers as needed.

**Zero engine changes, no canary workflows.** Both agents reuse agent-shield's `rings` + `gate` verbatim (mirroring the six existing `.github`-hosted agents). This also moots idea-triage's earlier blocker (a missing `idea-triage-canary.yml`) — no canary is needed.

## Validation (engine, read-only vs live tags)
- `evaluate initiative-planner` / `evaluate idea-triage` → **COMPLETE** (all channels on `v1.0.0` `4d05546`) — fully rolled out, no pending promotion, **no stuck soak**.
- `drift`: **8 → 6** unregistered (both removed).
- `canary_rollout.bats` **94/94** — added the onboarding shape test (asserts standard rings + gate, and **no** `soak_start_ring`/`next_tier_health_signal`).

## Not in scope (remaining pipeline work)
`idea-enhancer` (broken `@stable` pin) and `feature-ideation` (#614) still need initial channel work — tracked in #1008 / #515 / #614.

Refs #1008 #613 #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)