### PR TITLE
feat(#1159): register ci-failure-analyst in canary-rings.json (PR-2)

### DIFF
--- a/standards/canary-rings.json
+++ b/standards/canary-rings.json
@@ -592,6 +592,82 @@
           }
         }
       }
+    },
+    "ci-failure-analyst": {
+      "host": "petry-projects/.github-private",
+      "reusable": ".github/workflows/ci-failure-analyst-reusable.yml",
+      "run_workflow": "CI Failure Analyst",
+      "rings": [
+        {
+          "channel": "next",
+          "order": 0,
+          "members": [
+            "$host"
+          ]
+        },
+        {
+          "channel": "ring0",
+          "order": 1,
+          "members": [
+            "$org_infra"
+          ]
+        },
+        {
+          "channel": "ring1",
+          "order": 2,
+          "members": [
+            "petry-projects/TalkTerm",
+            "petry-projects/bmad-bgreat-suite"
+          ]
+        },
+        {
+          "channel": "stable",
+          "order": 3,
+          "members": [
+            "*"
+          ]
+        }
+      ],
+      "gate": {
+        "_standard": "petry-projects/.github#548 \u2014 graduated dwell/sample gate over a per-candidate cumulative window. These are registry-configurable per-transition knobs; the values below are the #548 defaults.",
+        "baseline_window_days": 14,
+        "baseline_spike_cap_multiple": 3,
+        "benign_failure_classes": [
+          {
+            "id": "dependabot-context-dispatch",
+            "workflow": "Dev-Lead Agent",
+            "step": "[Dd]ependabot",
+            "reason": "#864 \u2014 a Dev-Lead run dispatched in a Dependabot context cannot read repo secrets; version-independent benign failure, not a candidate regression."
+          },
+          {
+            "id": "fix-review-git-push-permission",
+            "workflow": "Dev-Lead Agent",
+            "step": "[Pp]ush",
+            "reason": "fix-review git push denied by branch protection / missing write scope; version-independent benign failure, not a candidate regression."
+          }
+        ],
+        "control": {
+          "allow_pre_existing": false
+        },
+        "_benign_note": "benign_failure_classes (#1025 P2): per-reusable allowlist matched against a failed run's workflow name (`workflow` ERE) + failed-step signature (`step` ERE, matched via `gh run view`). Matches are excluded from cum_fail \u2014 but ONLY when the candidate's reusable is byte-identical to the prior channel (differs=0), so the allowlist can never mask a candidate-introduced regression. `control.allow_pre_existing`, or `promote --allow-pre-existing`, advances a BLOCKED+PRE_EXISTING frontier (never REGRESSION).",
+        "transitions": {
+          "next->ring0": {
+            "dwell_hours": 4,
+            "sample_fraction_permille": 250,
+            "sample_clamp_min": 3,
+            "sample_clamp_max": 15,
+            "waive_sample_if_no_caller": true
+          },
+          "ring0->ring1": {
+            "dwell_hours": 8,
+            "waive_sample": true
+          },
+          "ring1->stable": {
+            "dwell_hours": 12,
+            "sample_min": 1
+          }
+        }
+      }
     }
   },
   "unmanaged": {

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -201,6 +201,22 @@ setup() {
 }
 
 # ── canary-rings.json SoT shape (rings + gate knobs) ──────────────────────────
+@test "canary-rings.json: ci-failure-analyst onboarded (this-repo host, standard rings, #1159)" {
+  run jq -e '.agents["ci-failure-analyst"].host == "petry-projects/.github-private"' "$RINGS"
+  [ "$status" -eq 0 ]
+  run jq -e '.agents["ci-failure-analyst"].reusable == ".github/workflows/ci-failure-analyst-reusable.yml"' "$RINGS"
+  [ "$status" -eq 0 ]
+  run jq -e '.agents["ci-failure-analyst"].run_workflow == "CI Failure Analyst"' "$RINGS"
+  [ "$status" -eq 0 ]
+  run bash -c "jq -r '.agents[\"ci-failure-analyst\"].rings | sort_by(.order) | map(.channel) | join(\",\")' '$RINGS'"
+  [ "$output" = "next,ring0,ring1,stable" ]
+  # standard #548 gate + organic-traffic model (no synthetic-canary fields)
+  run jq -e '.agents["ci-failure-analyst"].gate.transitions["ring1->stable"].sample_min == 1' "$RINGS"
+  [ "$status" -eq 0 ]
+  run jq -e '.agents["ci-failure-analyst"] | (has("next_tier_health_signal")|not) and (has("soak_start_ring")|not)' "$RINGS"
+  [ "$status" -eq 0 ]
+}
+
 @test "canary-rings.json: valid JSON + dev-lead host + ordered rings" {
   run jq -e '.agents["dev-lead"].host == "petry-projects/.github-private"' "$RINGS"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
PR-2 of #1159. With PR-1 (petry-projects/.github-private#1165) landed, I cut `ci-failure-analyst/v1.0.0` + `next`/`ring0`/`ring1`/`stable` (all aligned on `cc0bc61` = main HEAD) and now register it so the canary engine manages it.

Hosted in `.github-private`, so it mirrors **dev-lead's** ring + gate structure (host-relative `$host`/`$org_infra` tokens; ring1 = TalkTerm+bmad; stable = *) — standard organic-traffic model (no synthetic-canary fields), `run_workflow="CI Failure Analyst"`.

**Validated (read-only vs live tags):** `evaluate` → COMPLETE (all channels on v1.0.0); `drift` **3 → 2** (ci-failure-analyst removed; only `feature-ideation` #614 + `idea-enhancer` #515 remain). `canary_rollout.bats` 96/96.

**Remaining for #1159:** repin the 4 consumers (TalkTerm, bmad, google-app-scripts, `.github-private` template) from raw SHA → `@ci-failure-analyst/stable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)