### PR TITLE
feat(#614): register feature-ideation in canary-rings.json — fleet drift now 0

### DIFF
--- a/standards/canary-rings.json
+++ b/standards/canary-rings.json
@@ -731,6 +731,69 @@
           }
         }
       }
+    },
+    "feature-ideation": {
+      "host": "petry-projects/.github",
+      "reusable": ".github/workflows/feature-ideation-reusable.yml",
+      "run_workflow": "Feature Research & Ideation (BMAD Analyst)",
+      "rings": [
+        {
+          "channel": "next",
+          "order": 0,
+          "members": [
+            "petry-projects/.github-private"
+          ]
+        },
+        {
+          "channel": "ring0",
+          "order": 1,
+          "members": [
+            "petry-projects/.github"
+          ]
+        },
+        {
+          "channel": "ring1",
+          "order": 2,
+          "members": [
+            "petry-projects/TalkTerm",
+            "petry-projects/bmad-bgreat-suite"
+          ]
+        },
+        {
+          "channel": "stable",
+          "order": 3,
+          "members": [
+            "*"
+          ]
+        }
+      ],
+      "gate": {
+        "_standard": "petry-projects/.github#548 \u2014 graduated dwell/sample gate over a per-candidate cumulative window. These are registry-configurable per-transition knobs; the values below are the #548 defaults.",
+        "baseline_window_days": 14,
+        "baseline_spike_cap_multiple": 3,
+        "benign_failure_classes": [],
+        "control": {
+          "allow_pre_existing": false
+        },
+        "_benign_note": "benign_failure_classes (#1025 P2): per-reusable allowlist matched against a failed run's workflow name (`workflow` ERE) + failed-step signature (`step` ERE, matched via `gh run view`). Matches are excluded from cum_fail \u2014 but ONLY when the candidate's reusable is byte-identical to the prior channel (differs=0), so the allowlist can never mask a candidate-introduced regression. `control.allow_pre_existing`, or `promote --allow-pre-existing`, advances a BLOCKED+PRE_EXISTING frontier (never REGRESSION).",
+        "transitions": {
+          "next->ring0": {
+            "dwell_hours": 4,
+            "sample_fraction_permille": 250,
+            "sample_clamp_min": 3,
+            "sample_clamp_max": 15,
+            "waive_sample_if_no_caller": true
+          },
+          "ring0->ring1": {
+            "dwell_hours": 8,
+            "waive_sample": true
+          },
+          "ring1->stable": {
+            "dwell_hours": 12,
+            "sample_min": 1
+          }
+        }
+      }
     }
   },
   "unmanaged": {

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -201,6 +201,19 @@ setup() {
 }
 
 # ── canary-rings.json SoT shape (rings + gate knobs) ──────────────────────────
+@test "canary-rings.json: feature-ideation onboarded (cross-repo host, standard rings, #614)" {
+  run jq -e '.agents["feature-ideation"].host == "petry-projects/.github"' "$RINGS"
+  [ "$status" -eq 0 ]
+  run jq -e '.agents["feature-ideation"].reusable == ".github/workflows/feature-ideation-reusable.yml"' "$RINGS"
+  [ "$status" -eq 0 ]
+  run bash -c "jq -r '.agents[\"feature-ideation\"].rings | sort_by(.order) | map(.channel) | join(\",\")' '$RINGS'"
+  [ "$output" = "next,ring0,ring1,stable" ]
+  run jq -e '.agents["feature-ideation"].gate.transitions["ring1->stable"].sample_min == 1' "$RINGS"
+  [ "$status" -eq 0 ]
+  run jq -e '.agents["feature-ideation"] | (has("next_tier_health_signal")|not) and (has("soak_start_ring")|not)' "$RINGS"
+  [ "$status" -eq 0 ]
+}
+
 @test "canary-rings.json: ci-failure-analyst onboarded (this-repo host, standard rings, #1159)" {
   run jq -e '.agents["ci-failure-analyst"].host == "petry-projects/.github-private"' "$RINGS"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Completes the feature-ideation channel/ring rollout (#614/#866). It had `feature-ideation/next` + v1.0.0/v1.1.0 but was missing ring0/ring1/stable and wasn't registered. Cut ring0/ring1/stable at v1.1.0 (aligned on `c60e75af`) + register (host=.github, standard rings/gate mirroring agent-shield).

**Validated:** `evaluate` → COMPLETE; **`drift` 1 → 0** — the entire fleet reusable registry is now in sync. `canary_rollout.bats` 97/97.

Remaining for #614: repin consumers onto their ring channels (follow-up commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)