### PR TITLE
ci(#614): repin feature-ideation onto ring channels

### DIFF
--- a/.github/workflows/feature-ideation.yml
+++ b/.github/workflows/feature-ideation.yml
@@ -182,7 +182,7 @@ jobs:
       discussions: write
       id-token: write
       actions: read
-    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@8118d137a78352b6a87e3bf3916ba544986e38d2 # v1
+    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@feature-ideation/ring0  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
       # All values below come from `needs.prep.outputs.*` (resolved in the `prep`
       # job) — NOT the `inputs` context — so this reusable `with:` compiles on the

--- a/standards/workflows/feature-ideation.yml
+++ b/standards/workflows/feature-ideation.yml
@@ -182,7 +182,7 @@ jobs:
       discussions: write
       id-token: write
       actions: read
-    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@e20a8fac1b6a10bd6ad0999258e88a423f890ba6 # v1
+    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@feature-ideation/stable  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
       # All values below come from `needs.prep.outputs.*` (resolved in the `prep`
       # job) — NOT the `inputs` context — so this reusable `with:` compiles on the


### PR DESCRIPTION
Completes the feature-ideation ring rollout (#614): channels ring0/ring1/stable were cut at v1.1.0 and it's registered in canary-rings.json (petry-projects/.github#661). Repin this consumer from its old ref onto the ring-appropriate feature-ideation channel.