### PR TITLE
feat(#651): bring add-to-project under the full canary ring model

### DIFF
--- a/standards/canary-rings.json
+++ b/standards/canary-rings.json
@@ -794,14 +794,72 @@
           }
         }
       }
-    }
-  },
-  "unmanaged": {
+    },
     "add-to-project": {
       "host": "petry-projects/.github",
       "reusable": ".github/workflows/add-to-project-reusable.yml",
-      "reason": "Single-hop @add-to-project/stable channel (5 consumers); low-risk project-automation plumbing, intentionally out of the full ring gate (#651)."
-    },
+      "run_workflow": "Auto-add to Initiatives project",
+      "rings": [
+        {
+          "channel": "next",
+          "order": 0,
+          "members": [
+            "petry-projects/.github-private"
+          ]
+        },
+        {
+          "channel": "ring0",
+          "order": 1,
+          "members": [
+            "petry-projects/.github"
+          ]
+        },
+        {
+          "channel": "ring1",
+          "order": 2,
+          "members": [
+            "petry-projects/TalkTerm",
+            "petry-projects/bmad-bgreat-suite"
+          ]
+        },
+        {
+          "channel": "stable",
+          "order": 3,
+          "members": [
+            "*"
+          ]
+        }
+      ],
+      "gate": {
+        "_standard": "petry-projects/.github#548 \u2014 graduated dwell/sample gate over a per-candidate cumulative window. These are registry-configurable per-transition knobs; the values below are the #548 defaults.",
+        "baseline_window_days": 14,
+        "baseline_spike_cap_multiple": 3,
+        "benign_failure_classes": [],
+        "control": {
+          "allow_pre_existing": false
+        },
+        "_benign_note": "benign_failure_classes (#1025 P2): per-reusable allowlist matched against a failed run's workflow name (`workflow` ERE) + failed-step signature (`step` ERE, matched via `gh run view`). Matches are excluded from cum_fail \u2014 but ONLY when the candidate's reusable is byte-identical to the prior channel (differs=0), so the allowlist can never mask a candidate-introduced regression. `control.allow_pre_existing`, or `promote --allow-pre-existing`, advances a BLOCKED+PRE_EXISTING frontier (never REGRESSION).",
+        "transitions": {
+          "next->ring0": {
+            "dwell_hours": 4,
+            "sample_fraction_permille": 250,
+            "sample_clamp_min": 3,
+            "sample_clamp_max": 15,
+            "waive_sample_if_no_caller": true
+          },
+          "ring0->ring1": {
+            "dwell_hours": 8,
+            "waive_sample": true
+          },
+          "ring1->stable": {
+            "dwell_hours": 12,
+            "sample_min": 1
+          }
+        }
+      }
+    }
+  },
+  "unmanaged": {
     "pr-auto-review": {
       "host": "petry-projects/.github",
       "reusable": ".github/workflows/pr-auto-review-reusable.yml",

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -201,6 +201,18 @@ setup() {
 }
 
 # ── canary-rings.json SoT shape (rings + gate knobs) ──────────────────────────
+@test "canary-rings.json: add-to-project onboarded to full ring model (#651)" {
+  run jq -e '.agents["add-to-project"].host == "petry-projects/.github"' "$RINGS"
+  [ "$status" -eq 0 ]
+  run bash -c "jq -r '.agents[\"add-to-project\"].rings | sort_by(.order) | map(.channel) | join(\",\")' '$RINGS'"
+  [ "$output" = "next,ring0,ring1,stable" ]
+  # moved OUT of the unmanaged block (now a managed ring agent)
+  run jq -e '.unmanaged | has("add-to-project") | not' "$RINGS"
+  [ "$status" -eq 0 ]
+  run jq -e '.agents["add-to-project"] | (has("next_tier_health_signal")|not) and (has("soak_start_ring")|not)' "$RINGS"
+  [ "$status" -eq 0 ]
+}
+
 @test "canary-rings.json: feature-ideation onboarded (cross-repo host, standard rings, #614)" {
   run jq -e '.agents["feature-ideation"].host == "petry-projects/.github"' "$RINGS"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Per direction, promote add-to-project from single-hop `@stable` to the full ring-gated model (it's an actively-deployed fleet reusable — shims in 4 repos + template).

- Cut next/ring0/ring1 at v1.0.0 (aligned on `151347e`).
- Register as a managed agent (host=.github, standard rings/gate), **removed from `unmanaged{}`**.

**Validated:** evaluate → COMPLETE; **drift 0** (only pr-auto-review remains unmanaged). bats 98/98.

Remaining: repin consumers onto ring channels (follow-up commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)