### PR TITLE
fix(canary): route blocker issues to dev-lead + fix broken needs-human labeling

### DIFF
--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -766,6 +766,13 @@ cmd_sync_issues() {
   echo "== canary-rollout sync-issues: repo=$ISSUE_REPO dry=$dry (gate standard: .github#548) =="
   if [ "$dry" != true ]; then
     gh label create canary-blocker --repo "$ISSUE_REPO" --color ededed --description "canary-rollout automation" >/dev/null 2>&1 || true
+    # Route blockers so they get ACTIONED, not left sitting: `dev-lead` (dev-lead-intent
+    # treats a `dev-lead`-labelled issue as an actionable "issue" intent and picks it up —
+    # the App token applies the label, so the `issues: labeled` event DOES trigger the agent,
+    # unlike a github.token edit). `needs-human` additionally flags REGRESSION blockers, which
+    # the gate escalates to a human (roll back rather than blind --override).
+    gh label create dev-lead --repo "$ISSUE_REPO" --color 5319e7 --description "Route to the dev-lead agent for action" >/dev/null 2>&1 || true
+    gh label create needs-human --repo "$ISSUE_REPO" --color d93f0b --description "Requires human judgement (canary regression)" >/dev/null 2>&1 || true
   fi
   local rows="" agent
   while IFS= read -r agent; do
@@ -789,6 +796,7 @@ cmd_sync_issues() {
         if [ "$dry" = true ]; then echo "  [DRY] would OPEN blocker issue for $agent ($triage)"; blk="(new)"; else
           num="$(_gh_issue_create "$title" "$body" "canary-blocker" || true)"
           if [ -n "$num" ]; then
+            gh issue edit "$num" --repo "$ISSUE_REPO" --add-label dev-lead >/dev/null 2>&1 || true
             [ "$triage" = "REGRESSION" ] && gh issue edit "$num" --repo "$ISSUE_REPO" --add-label needs-human >/dev/null 2>&1 || true
             echo "  opened blocker issue #$num for $agent"; blk="#$num"
           else echo "::warning::could not open blocker issue for $agent (Issues:write on the App?)"; fi
@@ -798,6 +806,7 @@ cmd_sync_issues() {
           [ "$istate" = "OPEN" ] || gh issue reopen "$num" --repo "$ISSUE_REPO" >/dev/null 2>&1 || true
           gh issue edit "$num" --repo "$ISSUE_REPO" --title "$title" --body "$body" >/dev/null 2>&1 \
             || echo "::warning::could not update blocker issue #$num for $agent"
+          gh issue edit "$num" --repo "$ISSUE_REPO" --add-label dev-lead >/dev/null 2>&1 || true
           [ "$triage" = "REGRESSION" ] && gh issue edit "$num" --repo "$ISSUE_REPO" --add-label needs-human >/dev/null 2>&1 || true
           echo "  updated blocker issue #$num for $agent"; blk="#$num"
         fi

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -863,6 +863,9 @@ GHEOF
   grep -q -- "--label canary-blocker" "$ISSUE_LOG"
   ! grep -q -- "--label canary-dashboard" "$ISSUE_LOG"
   ! grep -q "^PIN|" "$ISSUE_LOG"
+  # Blocker is ROUTED to the dev-lead agent for action (label applied via the App token,
+  # so the `issues: labeled` event triggers dev-lead) — not left sitting unowned.
+  grep -q -- "--add-label dev-lead" "$ISSUE_LOG"
   # The fleet-status table landed in the job summary file.
   grep -q "Canary Rollout — fleet status" "$summ"
   grep -q "dev-lead" "$summ"


### PR DESCRIPTION
Canary-blocker issues were sitting **unowned** (#664 is the live example). Two bugs:

1. sync-issues tried to `--add-label needs-human` for REGRESSION blockers, but only ever *created* the `canary-blocker` label → the needs-human edit silently failed (label didn't exist), so #664 had only `canary-blocker`.
2. Nothing routed the blocker to an actor.

**Fix (per direction — tag blockers for dev-lead):**
- Create the `dev-lead` + `needs-human` labels alongside `canary-blocker`.
- Apply `dev-lead` to every blocker (open + update; idempotent) → dev-lead-intent treats a `dev-lead`-labelled issue as actionable and picks it up. Since sync-issues labels with the **App token** (not `github.token`), the `issues: labeled` event *does* trigger the agent.
- Keep `needs-human` on REGRESSION (now that the label exists) so a human retains the override/rollback call the gate escalates for regressions.

bats 99/99 (asserts the blocker is routed to dev-lead).

Follow-up noted: dev-lead treats a labelled issue as an *implementation* task, but a canary-blocker is a status report — its handling of that context may want refinement (triage vs implement), tied to #668.

🤖 Generated with [Claude Code](https://claude.com/claude-code)