### PR TITLE
fix(rulesets): drop Free-plan-rejected copilot param from pr-quality

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pr-672",
+  "name": "pr-681",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pr-672",
+  "name": "pr-681",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/standards/rulesets/pr-quality.json
+++ b/standards/rulesets/pr-quality.json
@@ -28,7 +28,6 @@
         "required_review_thread_resolution": true,
         "dismiss_stale_reviews_on_push": true,
         "require_last_push_approval": true,
-        "automatic_copilot_code_review_enabled": false,
         "allowed_merge_methods": ["squash"]
       }
     }

--- a/test/scripts/apply-rulesets/apply-rulesets.bats
+++ b/test/scripts/apply-rulesets/apply-rulesets.bats
@@ -49,6 +49,15 @@ EOF
   done
 }
 
+@test "pr-quality.json: omits 'automatic_copilot_code_review_enabled' (Free-plan API rejects it)" {
+  # GitHub's rulesets API 422s ("Unexpected parameter") on this pull_request
+  # parameter for Free-plan orgs, which blocks apply-rulesets from creating or
+  # updating pr-quality fleet-wide. It must stay out of the codified ruleset.
+  run jq -e '.rules[] | select(.type=="pull_request") | .parameters | has("automatic_copilot_code_review_enabled")' "$RULESETS_DIR/pr-quality.json"
+  # jq `has` prints false and exits 1 when the key is absent — that is the pass condition.
+  [ "$status" -ne 0 ]
+}
+
 @test "release-channel-tags.json: tag ruleset, generic refs/tags/** include, update+deletion only" {
   run jq -er '.target == "tag"
     and (.conditions.ref_name.include == ["refs/tags/**"])

--- a/test/scripts/apply-rulesets/apply-rulesets.bats
+++ b/test/scripts/apply-rulesets/apply-rulesets.bats
@@ -53,9 +53,9 @@ EOF
   # GitHub's rulesets API 422s ("Unexpected parameter") on this pull_request
   # parameter for Free-plan orgs, which blocks apply-rulesets from creating or
   # updating pr-quality fleet-wide. It must stay out of the codified ruleset.
-  run jq -e '.rules[] | select(.type=="pull_request") | .parameters | has("automatic_copilot_code_review_enabled")' "$RULESETS_DIR/pr-quality.json"
-  # jq `has` prints false and exits 1 when the key is absent — that is the pass condition.
-  [ "$status" -ne 0 ]
+  run jq '.rules[] | select(.type=="pull_request") | .parameters | has("automatic_copilot_code_review_enabled")' "$RULESETS_DIR/pr-quality.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "false" ]
 }
 
 @test "release-channel-tags.json: tag ruleset, generic refs/tags/** include, update+deletion only" {


### PR DESCRIPTION
## Problem

`apply-rulesets.sh` POSTs/PUTs `standards/rulesets/pr-quality.json` **verbatim**. That file's `pull_request` rule carries `automatic_copilot_code_review_enabled`, which GitHub's rulesets API rejects on our **Free-plan** org:

```
422 Validation Failed — Invalid rule 'pull_request': Unexpected parameter `automatic_copilot_code_review_enabled`
```

Because `petry-projects` is a Free org (no Copilot code review), this 422 blocks **creating or updating the `pr-quality` ruleset fleet-wide** — every `bootstrap-new-repo` / `apply-rulesets` run fails on `pr-quality`. Discovered while bootstrapping the new `petry-projects/incubator` repo.

## Fix

Remove the `automatic_copilot_code_review_enabled` key from the codified ruleset. It was `false` — which is also GitHub's default — so this is **behavior-neutral**. If the org later moves to a plan with Copilot code review, it can be re-added.

Adds a regression guard in `apply-rulesets.bats` so the codified ruleset never carries this key again.

## Test results

**Unit — full `apply-rulesets.bats` suite (18/18, incl. new guard):**
```
ok 3 pr-quality.json + code-quality.json carry both bypass actors (OrgAdmin + Integration)
ok 4 pr-quality.json: omits 'automatic_copilot_code_review_enabled' (Free-plan API rejects it)
...
1..18   (all ok)
```

**End-to-end — validated live against `petry-projects/incubator`:**
```
[apply-rulesets] repo=petry-projects/incubator dir=.../standards/rulesets dry_run=false
  update ruleset 'pr-quality' (id 18834182) on petry-projects/incubator
[apply-rulesets] done (1 ruleset(s))

pr-quality active
copilot param absent ✓
```
Before the fix the same POST returned `422`; after, the applier PUTs cleanly and the live ruleset is active with the param gone.

## Scope note

This is the only defect that survived verification. A **second** suspected bug — a fatal `GET check-suites/preferences` in `apply-repo-settings.sh` — turned out to **already be handled in canonical `.github`** (`apply_check_suite_prefs`: *"GET 404s when prefs have never been set — treat as needing PATCH, don't bail"*). The fatal version exists only in a **stale, superseded `.github-private` copy** (pre-#1013/#1128 relocation) that a parked branch still carries; nothing to fix here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Juznz5V6su81ffSND8fg7s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated pull request quality rules to no longer include the automatic Copilot code review setting.
  * All other review and merge enforcement settings remain unchanged.

* **Tests**
  * Added coverage to verify the removed setting does not return in the pull request rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->