### PR TITLE
ci: add canary-rollout-tests.yml — enforce the engine's bats suite (CI gap from #613/#624)

### DIFF
--- a/.github/workflows/canary-rollout-tests.yml
+++ b/.github/workflows/canary-rollout-tests.yml
@@ -1,0 +1,73 @@
+# Quality gates for the canary-rollout release engine and its pure gate core.
+#
+# The engine + its bats suite were relocated into this repo by #613/#624 but no
+# CI runner came with them, so tests/canary_rollout.bats went unenforced. This
+# workflow closes that gap.
+#
+# Triggered on any PR (or push to main) that touches:
+#   - scripts/canary-rollout.sh          (orchestrator)
+#   - scripts/lib/canary-rollout.sh      (pure gate core)
+#   - tests/canary_rollout.bats          (the suite)
+#   - .github/workflows/canary-rollout-tests.yml (this file)
+#
+# Gates (all must pass before merge):
+#   1. shellcheck — static analysis for the orchestrator + pure core
+#   2. bats       — the full canary_rollout unit/behaviour suite
+#
+# Standard: the pure core (scripts/lib/canary-rollout.sh) is side-effect-free so
+# the suite can pin gate behaviour without network — the house pattern this
+# engine itself exemplifies.
+
+name: Canary-rollout Tests
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/canary-rollout.sh'
+      - 'scripts/lib/canary-rollout.sh'
+      - 'tests/canary_rollout.bats'
+      - '.github/workflows/canary-rollout-tests.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'scripts/canary-rollout.sh'
+      - 'scripts/lib/canary-rollout.sh'
+      - 'tests/canary_rollout.bats'
+      - '.github/workflows/canary-rollout-tests.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: canary-rollout-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Lint and bats
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: Install bats, shellcheck, and jq
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends bats shellcheck jq
+
+      - name: shellcheck
+        run: |
+          set -euo pipefail
+          shellcheck -x scripts/canary-rollout.sh scripts/lib/canary-rollout.sh
+
+      - name: Run bats suite
+        # The suite stubs gh/git via PATH; a dummy token satisfies the
+        # orchestrator's token precondition without any real API access.
+        env:
+          GH_TOKEN: dummy-token-for-stubbed-tests
+        run: bats --print-output-on-failure tests/canary_rollout.bats

--- a/.github/workflows/canary-rollout-tests.yml
+++ b/.github/workflows/canary-rollout-tests.yml
@@ -53,6 +53,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install bats, shellcheck, and jq
         run: |

--- a/.github/workflows/canary-rollout-tests.yml
+++ b/.github/workflows/canary-rollout-tests.yml
@@ -63,7 +63,7 @@ jobs:
       - name: shellcheck
         run: |
           set -euo pipefail
-          shellcheck -x scripts/canary-rollout.sh scripts/lib/canary-rollout.sh
+          shellcheck --severity=warning -x scripts/canary-rollout.sh scripts/lib/canary-rollout.sh
 
       - name: Run bats suite
         # The suite stubs gh/git via PATH; a dummy token satisfies the


### PR DESCRIPTION
## Why
The canary-rollout engine (`scripts/canary-rollout.sh`, `scripts/lib/canary-rollout.sh`) and its 149+ test `tests/canary_rollout.bats` were relocated into `.github` by #613/#624, but **no CI runner came with them**. Result: the suite has been unenforced — every #668 increment (#672/#676/#678, and #684 in flight) merged **without its bats tests running in CI**. Discovered while shepherding #684.

## What
A `Canary-rollout Tests` workflow mirroring the house `*-tests.yml` pattern (see `auto-rebase-tests.yml`): on any PR/push touching the engine, pure core, suite, or this workflow, it runs `shellcheck -x` + `bats --print-output-on-failure tests/canary_rollout.bats`.

## The point
**This PR's own CI run is the verification** — it will show, for the first time in Actions, whether the suite is green. If red, we've surfaced real breakage (or stale test stubs) that the missing runner had been hiding.

Follow-ups gated on this:
- Rebase #684 (increment 4) onto this so it becomes test-gated before merge.
- If the suite is red, fix it before resuming #668 increments 5–6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated quality checks for canary rollout changes.
  * Added shell script validation and BATS test execution for pull requests and main-branch updates.
  * Configured runs to cancel outdated in-progress checks and use read-only repository access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->