### PR TITLE
feat: implement issue #688 — canary #668 increment 6: SUSPECT→PRE_EXISTING auto-downgrade (decide_suspect_downgrade) — closes #668

### DIFF
--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -288,6 +288,54 @@ _suspect_patterns() {
      | .[] | [(.workflow // ""), (.step // "")] | @tsv'
 }
 
+# _suspect_downgrade_patterns <agent> — emit the per-reusable SUSPECT classes that OPT INTO
+# auto_downgrade (#668 increment 6) as TSV
+# "<workflow_regex>\t<step_regex>\t<min_baseline_sample>\t<margin_permille>", one per line;
+# empty when no suspect class carries `auto_downgrade` (byte-identical increment-2 behaviour:
+# an un-flagged SUSPECT is never downgraded). The knobs travel WITH the pattern so the
+# orchestrator feeds decide_suspect_downgrade per class without a second registry read.
+_suspect_downgrade_patterns() {
+  _jq -r --arg a "$1" \
+    '.agents[$a]?.gate?.suspect_failure_classes? // []
+     | .[] | select(.auto_downgrade != null)
+     | [(.workflow // ""), (.step // ""),
+        (.auto_downgrade.min_baseline_sample // 0), (.auto_downgrade.margin_permille // 0)]
+     | @tsv'
+}
+
+# _suspect_class_counts <agent> <since_z> <before_z|-> <wf_re> <step_re> <repo...> — over the
+# window [since_z, before_z) on the given tier repos, echo "<matched_failures> <executed>":
+# executed = success+failure runs; matched = the failures whose failed-step signature matches
+# THIS one suspect class (via benign_match, the same matcher triage uses). before_z="-" means
+# no upper bound. Powers the candidate-vs-baseline SUSPECT-class failure RATE that the
+# auto-downgrade core compares (#668 increment 6). Reuses _run_json / _run_signature (the
+# signature cache is warm from the cumulative-health pass on the candidate window).
+_suspect_class_counts() {
+  local agent="$1" since="$2" before="$3" wf_re="$4" step_re="$5"; shift 5
+  local wf repo json rid rwf sig matched=0 executed=0
+  wf="$(_agent_field "$agent" run_workflow)"
+  local exec_filter='.[]?|select(.conclusion=="success" or .conclusion=="failure")'
+  local fail_filter='.[]?|select(.conclusion=="failure")'
+  if [ "$before" != "-" ]; then
+    exec_filter="$exec_filter|select(.createdAt < \"$before\")"
+    fail_filter="$fail_filter|select(.createdAt < \"$before\")"
+  fi
+  for repo in "$@"; do
+    { [ -z "$repo" ] || [ "$repo" = '*' ]; } && continue
+    json="$(_run_json "$repo" "$wf" "$since")"
+    executed=$(( executed + $(jq "[${exec_filter}]|length" 2>/dev/null <<< "$json" || echo 0) ))
+    while IFS=$'\t' read -r rid rwf; do
+      [ -z "$rid" ] && continue
+      sig="$(_run_signature "$repo" "$rid")"
+      [ -z "$sig" ] && continue
+      if [ "$(benign_match "$rwf" "$sig" "$wf_re" "$step_re")" = "yes" ]; then
+        matched=$(( matched + 1 ))
+      fi
+    done < <(jq -r "[${fail_filter}]|.[]|[(.databaseId // \"\"|tostring),(.workflowName // \"\")]|@tsv" 2>/dev/null <<< "$json")
+  done
+  echo "$matched $executed"
+}
+
 # Memoization cache for _run_signature: keyed by "repo:run_id".
 # Avoids duplicate gh run view calls for the same (repo, run_id) across agents
 # in evaluate-all (where multiple agents can share repos).
@@ -565,10 +613,13 @@ _decision_mix_table() {
 }
 
 # _frontier_state <agent> — compute the rollout frontier and graduated gate, echoing:
-#   "<cand> <frontier> <transition> <state> <dwell_h> <dwell_floor> <sample> <target> <cum_fail> <cum_startup> <cum_benign> <triage> <mix_shift>"
+#   "<cand> <frontier> <transition> <state> <dwell_h> <dwell_floor> <sample> <target> <cum_fail> <cum_startup> <cum_benign> <triage> <mix_shift> <downgrade> <dg_cand_rate> <dg_cand_sample> <dg_base_rate> <dg_base_sample>"
 # frontier = first ring (after next) not yet on the candidate commit; triage is "-"
 # unless state is BLOCKED (then REGRESSION | PRE_EXISTING | SUSPECT). mix_shift is "SHIFT"
 # when a gate.correctness decision-mix shift is holding the promotion (#668 L2), else "-".
+# downgrade is "DOWNGRADE" when a SUSPECT was auto-downgraded to PRE_EXISTING (#668 inc6) —
+# then triage already reads PRE_EXISTING and dg_* carry the candidate-vs-baseline permille
+# rates + sample sizes that drove it; "-"/0 otherwise.
 _frontier_state() {
   local agent="$1"
   local cand chans frontier=""
@@ -692,7 +743,40 @@ _frontier_state() {
     triage="$(classify_failure "$differs" "${CANARY_FAILURE_CATEGORY:-unknown}" "$cum_suspect")"
   fi
 
-  echo "$cand $frontier $transition $state $dwell_h $dwell_floor $sample $target $cum_fail $cum_startup $cum_benign $triage $mix_shift"
+  # SUSPECT → PRE_EXISTING auto-downgrade (#668 increment 6, opt-in per suspect class). Only the
+  # failure-class SUSPECT variant is eligible — mix_shift="-" excludes the correctness variant,
+  # which is never rate-comparable. For each suspect class carrying `auto_downgrade`, compare the
+  # candidate's failure RATE for that class (matched/executed over the per-candidate window) with
+  # the prior version's over the trailing baseline window; the pure decide_suspect_downgrade
+  # decides. DOWNGRADE re-triages PRE_EXISTING (report-only: no needs-human, advances with
+  # --allow-pre-existing); HOLD stays SUSPECT (increment-2 behaviour — worse/ambiguous/thin cases
+  # keep the human). Byte-identical for a suspect class with no auto_downgrade (empty set → skip).
+  local downgrade="-" dg_cand_rate=0 dg_cand_sample=0 dg_base_rate=0 dg_base_sample=0
+  if [ "$triage" = "SUSPECT" ] && [ "$mix_shift" = "-" ]; then
+    local dg_patterns; dg_patterns="$(_suspect_downgrade_patterns "$agent")"
+    if [ -n "$dg_patterns" ]; then
+      local dg_win dg_base_since dwf dsr dmin dmargin cm ce bm be crate brate knobs decision
+      dg_win="${SOAK_WINDOW_DAYS:-$(_gate_field "$agent" baseline_window_days)}"; dg_win="${dg_win:-14}"
+      dg_base_since="$(_iso_now_minus_days "$dg_win")"
+      while IFS=$'\t' read -r dwf dsr dmin dmargin || [ -n "$dwf" ]; do
+        dwf="${dwf%$'\r'}"; dsr="${dsr%$'\r'}"; dmin="${dmin%$'\r'}"; dmargin="${dmargin%$'\r'}"
+        [ -z "$dsr" ] && continue
+        read -r cm ce < <(_suspect_class_counts "$agent" "$cut_z" "-" "$dwf" "$dsr" "${src_repos[@]}")
+        read -r bm be < <(_suspect_class_counts "$agent" "$dg_base_since" "$cut_z" "$dwf" "$dsr" "${src_repos[@]}")
+        if [ "$ce" -gt 0 ]; then crate="$(round_div $(( cm * 1000 )) "$ce")"; else crate=0; fi
+        if [ "$be" -gt 0 ]; then brate="$(round_div $(( bm * 1000 )) "$be")"; else brate=0; fi
+        knobs="$(printf '{"min_baseline_sample":%s,"margin_permille":%s}' "${dmin:-0}" "${dmargin:-0}")"
+        decision="$(decide_suspect_downgrade "$crate" "$brate" "$be" "$knobs")"
+        if [ "$decision" = "DOWNGRADE" ]; then
+          triage="PRE_EXISTING"; downgrade="DOWNGRADE"
+          dg_cand_rate="$crate"; dg_cand_sample="$ce"; dg_base_rate="$brate"; dg_base_sample="$be"
+          break
+        fi
+      done <<< "$dg_patterns"
+    fi
+  fi
+
+  echo "$cand $frontier $transition $state $dwell_h $dwell_floor $sample $target $cum_fail $cum_startup $cum_benign $triage $mix_shift $downgrade $dg_cand_rate $dg_cand_sample $dg_base_rate $dg_base_sample"
 }
 
 cmd_evaluate() {
@@ -708,7 +792,7 @@ cmd_evaluate() {
     local mark="  "; [ -n "$cand" ] && [ "$c" = "$cand" ] && mark="* "
     printf '  %s%-7s -> %s\n' "$mark" "$ch" "${c:0:12}"
   done
-  read -r _cand frontier transition state dwell floor sample target cum_fail cum_startup cum_benign triage mix_shift < <(_frontier_state "$agent")
+  read -r _cand frontier transition state dwell floor sample target cum_fail cum_startup cum_benign triage mix_shift downgrade dg_cand_rate dg_cand_sample dg_base_rate dg_base_sample < <(_frontier_state "$agent")
   echo "----"
   if [ "$frontier" = "-" ]; then
     echo "frontier: none — fully rolled out (all rings on candidate)."
@@ -722,6 +806,8 @@ cmd_evaluate() {
         echo "::warning::triage=SUSPECT (decision-mix shift, #668 Layer 2) — the candidate's decision distribution moved ≥ threshold vs the prior-version baseline. HOLDS the promotion; review the decision-mix table in the blocker issue. Composition drift (e.g. a draft-PR burst) is the usual false positive → promote --override to dismiss; a genuine always/never shift → roll back."
       elif [ "$triage" = "SUSPECT" ]; then
         echo "::warning::triage=SUSPECT — failure matches a suspect class (possibly candidate-caused). BLOCKS + needs a human; see the blocker issue's discriminating question, then promote --override if unrelated or roll back if a real regression."
+      elif [ "$downgrade" = "DOWNGRADE" ]; then
+        echo "::notice::triage=PRE_EXISTING (auto-downgraded from SUSPECT, #668 increment 6) — the candidate's suspect-class failure rate (${dg_cand_rate}‰ over ${dg_cand_sample} runs) is no worse than the prior version's (${dg_base_rate}‰ over ${dg_base_sample} runs), so the timeout is environmental, not a candidate regression. Report only; the SUSPECT hold auto-cleared (no human needed). Advances with --allow-pre-existing once dwell/sample pass."
       else
         echo "::warning::triage=PRE_EXISTING — failure is pre-existing/environmental. Report only; do NOT rollback, do NOT advance."
       fi
@@ -762,7 +848,7 @@ cmd_promote() {
       *) echo "::error::unknown promote flag: $1" >&2; return 2 ;;
     esac; shift
   done
-  read -r cand frontier transition state _dwell _floor _sample _target cum_fail _cum_startup _cum_benign triage _mix_shift < <(_frontier_state "$agent")
+  read -r cand frontier transition state _dwell _floor _sample _target cum_fail _cum_startup _cum_benign triage _mix_shift _dg _dgcr _dgcs _dgbr _dgbs < <(_frontier_state "$agent")
   if [ "$frontier" = "-" ]; then
     echo "nothing to promote — $agent is fully rolled out."; return 0
   fi
@@ -957,9 +1043,10 @@ _suspect_guidance() {
      | "- **\(.id):** \(.guidance)"'
 }
 
-# _blocker_body <agent> <transition> <cand> <cum_fail> <cum_startup> <triage> <host> <evidence> [<mix_shift>] [<mix_table>]
+# _blocker_body <agent> <transition> <cand> <cum_fail> <cum_startup> <triage> <host> <evidence> [<mix_shift>] [<mix_table>] [<downgrade>] [<dg_cand_rate>] [<dg_cand_sample>] [<dg_base_rate>] [<dg_base_sample>]
 _blocker_body() {
   local agent="$1" transition="$2" cand="$3" cum_fail="$4" cum_startup="$5" triage="$6" host="$7" evidence="$8" mix_shift="${9:--}" mix_table="${10:-}" note
+  local downgrade="${11:--}" dg_cand_rate="${12:-0}" dg_cand_sample="${13:-0}" dg_base_rate="${14:-0}" dg_base_sample="${15:-0}"
   # Correctness variant (#668 L2): a decision-mix SHIFT holds as SUSPECT but is NOT a reliability
   # failure — the candidate exited green yet its decision distribution moved. Distinct note + a
   # candidate-vs-baseline mix table replace the failing-runs evidence (there are none).
@@ -995,6 +1082,15 @@ EOF
 >
 > **Discriminating question:**
 $(printf '%s\n' "$guidance" | sed 's/^/> /')"
+  elif [ "$downgrade" = "DOWNGRADE" ]; then
+    note="> ℹ️ **PRE_EXISTING** — *auto-downgraded from SUSPECT (#668 increment 6).* This failure matched a suspect class that opts into data-driven auto-downgrade, and the candidate's failure rate for that class is **no worse** than the prior version's on comparable traffic — so it is environmental, not a candidate regression. The SUSPECT hold auto-cleared: report only, **no human needed**, and the frontier advances with \`--allow-pre-existing\` once dwell/sample pass. (A materially-worse or thin-baseline case would have stayed SUSPECT.)
+>
+> **Suspect-class failure rate (candidate vs prior-version baseline):**
+>
+> | version | rate (‰) | runs |
+> |---|---|---|
+> | candidate | \`$dg_cand_rate\` | $dg_cand_sample |
+> | baseline | \`$dg_base_rate\` | $dg_base_sample |"
   else
     note="> ⚠️ **PRE_EXISTING** — the failure is pre-existing/environmental (reusable byte-identical to the prior channel). Report only; the gate will not roll back or advance. Fix-forward, and the armed timer auto-promotes once clean."
   fi
@@ -1114,7 +1210,8 @@ cmd_sync_issues() {
   while IFS= read -r agent; do
     [ -z "$agent" ] && continue
     local cand frontier transition state _d _f _s _t cum_fail cum_startup _cb triage mix_shift host
-    read -r cand frontier transition state _d _f _s _t cum_fail cum_startup _cb triage mix_shift < <(_frontier_state "$agent")
+    local downgrade dg_cand_rate dg_cand_sample dg_base_rate dg_base_sample
+    read -r cand frontier transition state _d _f _s _t cum_fail cum_startup _cb triage mix_shift downgrade dg_cand_rate dg_cand_sample dg_base_rate dg_base_sample < <(_frontier_state "$agent")
     host="$(_agent_field "$agent" host)"
     local blk="—" num_state num istate
     # Best-effort (#1081): these substitutions call gh/jq. Under `set -euo pipefail`
@@ -1127,7 +1224,7 @@ cmd_sync_issues() {
       local evidence body title mix_table=""
       evidence="$(_blocker_evidence "$agent" "$cand" || true)"
       [ "$mix_shift" = "SHIFT" ] && mix_table="$(_decision_mix_table "$agent" "$cand" || true)"
-      body="$(_blocker_body "$agent" "$transition" "$cand" "$cum_fail" "$cum_startup" "$triage" "$host" "$evidence" "$mix_shift" "$mix_table")"
+      body="$(_blocker_body "$agent" "$transition" "$cand" "$cum_fail" "$cum_startup" "$triage" "$host" "$evidence" "$mix_shift" "$mix_table" "$downgrade" "$dg_cand_rate" "$dg_cand_sample" "$dg_base_rate" "$dg_base_sample")"
       if [ "$mix_shift" = "SHIFT" ]; then
         title="Canary blocker: $agent $transition (decision-mix shift, SUSPECT)"
       else

--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -297,9 +297,9 @@ _suspect_patterns() {
 _suspect_downgrade_patterns() {
   _jq -r --arg a "$1" \
     '.agents[$a]?.gate?.suspect_failure_classes? // []
-     | .[] | select(.auto_downgrade != null)
+     | .[] | select(.auto_downgrade? != null)
      | [(.workflow // ""), (.step // ""),
-        (.auto_downgrade.min_baseline_sample // 0), (.auto_downgrade.margin_permille // 0)]
+        (.auto_downgrade?.min_baseline_sample? // 0), (.auto_downgrade?.margin_permille? // 0)]
      | @tsv'
 }
 
@@ -312,7 +312,7 @@ _suspect_downgrade_patterns() {
 # signature cache is warm from the cumulative-health pass on the candidate window).
 _suspect_class_counts() {
   local agent="$1" since="$2" before="$3" wf_re="$4" step_re="$5"; shift 5
-  local wf repo json rid rwf sig matched=0 executed=0
+  local wf repo json rid rwf sig matched=0 executed=0 count
   wf="$(_agent_field "$agent" run_workflow)"
   local exec_filter='.[]?|select(.conclusion=="success" or .conclusion=="failure")'
   local fail_filter='.[]?|select(.conclusion=="failure")'
@@ -323,8 +323,11 @@ _suspect_class_counts() {
   for repo in "$@"; do
     { [ -z "$repo" ] || [ "$repo" = '*' ]; } && continue
     json="$(_run_json "$repo" "$wf" "$since")"
-    executed=$(( executed + $(jq "[${exec_filter}]|length" 2>/dev/null <<< "$json" || echo 0) ))
-    while IFS=$'\t' read -r rid rwf; do
+    count="$(jq "[${exec_filter}]|length" 2>/dev/null <<< "$json" || echo 0)"
+    executed=$(( executed + ${count:-0} ))
+    while IFS=$'\t' read -r rid rwf || [ -n "$rid" ]; do
+      rid="${rid%$'\r'}"
+      rwf="${rwf%$'\r'}"
       [ -z "$rid" ] && continue
       sig="$(_run_signature "$repo" "$rid")"
       [ -z "$sig" ] && continue
@@ -763,8 +766,8 @@ _frontier_state() {
         [ -z "$dsr" ] && continue
         read -r cm ce < <(_suspect_class_counts "$agent" "$cut_z" "-" "$dwf" "$dsr" "${src_repos[@]}")
         read -r bm be < <(_suspect_class_counts "$agent" "$dg_base_since" "$cut_z" "$dwf" "$dsr" "${src_repos[@]}")
-        if [ "$ce" -gt 0 ]; then crate="$(round_div $(( cm * 1000 )) "$ce")"; else crate=0; fi
-        if [ "$be" -gt 0 ]; then brate="$(round_div $(( bm * 1000 )) "$be")"; else brate=0; fi
+        if [ "${ce:-0}" -gt 0 ]; then crate="$(round_div $(( ${cm:-0} * 1000 )) "$ce")"; else crate=0; fi
+        if [ "${be:-0}" -gt 0 ]; then brate="$(round_div $(( ${bm:-0} * 1000 )) "$be")"; else brate=0; fi
         knobs="$(printf '{"min_baseline_sample":%s,"margin_permille":%s}' "${dmin:-0}" "${dmargin:-0}")"
         decision="$(decide_suspect_downgrade "$crate" "$brate" "$be" "$knobs")"
         if [ "$decision" = "DOWNGRADE" ]; then

--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -304,15 +304,18 @@ _suspect_downgrade_patterns() {
 }
 
 # _suspect_class_counts <agent> <since_z> <before_z|-> <wf_re> <step_re> <repo...> — over the
-# window [since_z, before_z) on the given tier repos, echo "<matched_failures> <executed>":
+# window [since_z, before_z) on the given tier repos, echo "<matched_failures> <executed> <incomplete>":
 # executed = success+failure runs; matched = the failures whose failed-step signature matches
-# THIS one suspect class (via benign_match, the same matcher triage uses). before_z="-" means
-# no upper bound. Powers the candidate-vs-baseline SUSPECT-class failure RATE that the
-# auto-downgrade core compares (#668 increment 6). Reuses _run_json / _run_signature (the
-# signature cache is warm from the cumulative-health pass on the candidate window).
+# THIS one suspect class (via benign_match, the same matcher triage uses); incomplete = the
+# count of failure runs whose signature could not be retrieved (gh run view error — callers
+# treat incomplete>0 as HOLD, not DOWNGRADE, since an unreadable run could be a non-match).
+# before_z="-" means no upper bound. Powers the candidate-vs-baseline SUSPECT-class failure
+# RATE that the auto-downgrade core compares (#668 increment 6). Reuses _run_json /
+# _run_signature (the signature cache is warm from the cumulative-health pass on the
+# candidate window).
 _suspect_class_counts() {
   local agent="$1" since="$2" before="$3" wf_re="$4" step_re="$5"; shift 5
-  local wf repo json rid rwf sig matched=0 executed=0 count
+  local wf repo json rid rwf sig sig_rc matched=0 executed=0 incomplete=0 count
   wf="$(_agent_field "$agent" run_workflow)"
   local exec_filter='.[]?|select(.conclusion=="success" or .conclusion=="failure")'
   local fail_filter='.[]?|select(.conclusion=="failure")'
@@ -329,14 +332,18 @@ _suspect_class_counts() {
       rid="${rid%$'\r'}"
       rwf="${rwf%$'\r'}"
       [ -z "$rid" ] && continue
-      sig="$(_run_signature "$repo" "$rid")"
-      [ -z "$sig" ] && continue
+      sig_rc=0
+      sig="$(_run_signature "$repo" "$rid")" || sig_rc=$?  # || prevents set -e on lookup failure
+      if [ -z "$sig" ]; then
+        [ "$sig_rc" -ne 0 ] && incomplete=$(( incomplete + 1 ))  # lookup failed; genuine empty sig is fine
+        continue
+      fi
       if [ "$(benign_match "$rwf" "$sig" "$wf_re" "$step_re")" = "yes" ]; then
         matched=$(( matched + 1 ))
       fi
     done < <(jq -r "[${fail_filter}]|.[]|[(.databaseId // \"\"|tostring),(.workflowName // \"\")]|@tsv" 2>/dev/null <<< "$json")
   done
-  echo "$matched $executed"
+  echo "$matched $executed $incomplete"
 }
 
 # Memoization cache for _run_signature: keyed by "repo:run_id".
@@ -346,16 +353,28 @@ declare -A _RUN_SIG_CACHE=()
 
 # _run_signature <repo> <run_id> — the failed step names of a run, joined by newlines
 # (the "step/error signature" the allowlist matches against). Empty repo/wildcard/id or
-# any gh error → "" (fail-closed: an unknown signature is never treated as benign).
+# any gh error → "" with exit 1 (fail-closed: an unknown signature is never treated as
+# benign, and callers that need to distinguish a lookup failure from a genuine empty
+# signature check the exit code). A successful lookup with no failed steps → "" exit 0.
+# The $'\x01' sentinel in the cache marks a prior lookup failure so it is not retried.
 _run_signature() {
   local repo="$1" id="$2" cache_key sig json
   { [ -z "$repo" ] || [ "$repo" = '*' ] || [ -z "$id" ]; } && { echo ""; return 0; }
   cache_key="${repo}:${id}"
   if [[ -v _RUN_SIG_CACHE["$cache_key"] ]]; then
+    if [ "${_RUN_SIG_CACHE[$cache_key]}" = $'\x01' ]; then
+      echo ""; return 1  # cached lookup failure — signal to caller
+    fi
     echo "${_RUN_SIG_CACHE[$cache_key]}"
     return 0
   fi
-  json="$(gh run view "$id" --repo "$repo" --json jobs 2>/dev/null || echo '{}')"
+  # Use || { } so set -e does not trigger on a failing gh run view; the block caches the
+  # sentinel and returns 1 to signal the lookup failure to callers that care (e.g.
+  # _suspect_class_counts tracks incomplete evidence and HOLDs the downgrade).
+  json="$(gh run view "$id" --repo "$repo" --json jobs 2>/dev/null)" || {
+    _RUN_SIG_CACHE["$cache_key"]=$'\x01'
+    echo ""; return 1
+  }
   sig="$(jq -r '[.jobs[]?|.steps[]?|select(.conclusion=="failure")|.name] | join("\n")' \
     2>/dev/null <<< "$json" || echo "")"
   _RUN_SIG_CACHE["$cache_key"]="$sig"
@@ -401,7 +420,7 @@ _failure_suspect() {
 # benign) failure that matches a `suspect_failure_classes` entry sets the suspect flag
 # (#668 increment 2) — it still counts toward the blocking total (SUSPECT blocks like
 # REGRESSION), but downstream triage renders SUSPECT + guidance instead of a bare
-# REGRESSION. Prints "<failures> <startup_failures> <benign_excluded> <suspect 0|1>".
+# REGRESSION. Prints "<failures> <startup_failures> <benign_excluded> <suspect_count>".
 _cumulative_health() {
   local agent="$1" since="$2" differs="$3"; shift 3
   local wf repo json fail=0 startup=0 benign=0 suspect=0 patterns="" suspect_patterns="" rid rwf
@@ -422,7 +441,7 @@ _cumulative_health() {
         else
           fail=$(( fail + 1 ))
           if [ -n "$suspect_patterns" ] && _failure_suspect "$repo" "$rid" "$rwf" "$suspect_patterns"; then
-            suspect=1
+            suspect=$(( suspect + 1 ))
           fi
         fi
       done < <(jq -r '.[]?|select(.conclusion=="failure")|[(.databaseId // "" | tostring),(.workflowName // "")]|@tsv' 2>/dev/null <<< "$json")
@@ -757,15 +776,21 @@ _frontier_state() {
   local downgrade="-" dg_cand_rate=0 dg_cand_sample=0 dg_base_rate=0 dg_base_sample=0
   if [ "$triage" = "SUSPECT" ] && [ "$mix_shift" = "-" ]; then
     local dg_patterns; dg_patterns="$(_suspect_downgrade_patterns "$agent")"
-    if [ -n "$dg_patterns" ]; then
-      local dg_win dg_base_since dwf dsr dmin dmargin cm ce bm be crate brate knobs decision
+    # Guard (Thread 1): only attempt per-class rate comparison when EVERY blocking failure
+    # has been attributed to a suspect class. If any failure had no matching suspect class,
+    # that unrelated failure is an independent regression and must keep the gate blocked.
+    if [ -n "$dg_patterns" ] && [ "${cum_suspect:-0}" -ge "$cum_fail" ]; then
+      local dg_win dg_base_since dwf dsr dmin dmargin cm ce cmi bm be bei crate brate knobs decision
       dg_win="${SOAK_WINDOW_DAYS:-$(_gate_field "$agent" baseline_window_days)}"; dg_win="${dg_win:-14}"
       dg_base_since="$(_iso_now_minus_days "$dg_win")"
       while IFS=$'\t' read -r dwf dsr dmin dmargin || [ -n "$dwf" ]; do
         dwf="${dwf%$'\r'}"; dsr="${dsr%$'\r'}"; dmin="${dmin%$'\r'}"; dmargin="${dmargin%$'\r'}"
         [ -z "$dsr" ] && continue
-        read -r cm ce < <(_suspect_class_counts "$agent" "$cut_z" "-" "$dwf" "$dsr" "${src_repos[@]}")
-        read -r bm be < <(_suspect_class_counts "$agent" "$dg_base_since" "$cut_z" "$dwf" "$dsr" "${src_repos[@]}")
+        read -r cm ce cmi < <(_suspect_class_counts "$agent" "$cut_z" "-" "$dwf" "$dsr" "${src_repos[@]}")
+        read -r bm be bei < <(_suspect_class_counts "$agent" "$dg_base_since" "$cut_z" "$dwf" "$dsr" "${src_repos[@]}")
+        # Guard (Thread 2): if any signature lookup failed, baseline class evidence is
+        # incomplete. A missing run could be a non-match; fail-closed and skip DOWNGRADE.
+        [ "${cmi:-0}" -gt 0 ] || [ "${bei:-0}" -gt 0 ] && continue
         if [ "${ce:-0}" -gt 0 ]; then crate="$(round_div $(( ${cm:-0} * 1000 )) "$ce")"; else crate=0; fi
         if [ "${be:-0}" -gt 0 ]; then brate="$(round_div $(( ${bm:-0} * 1000 )) "$be")"; else brate=0; fi
         knobs="$(printf '{"min_baseline_sample":%s,"margin_permille":%s}' "${dmin:-0}" "${dmargin:-0}")"
@@ -1248,7 +1273,11 @@ cmd_sync_issues() {
           gh issue edit "$num" --repo "$ISSUE_REPO" --title "$title" --body "$body" >/dev/null 2>&1 \
             || echo "::warning::could not update blocker issue #$num for $agent"
           gh issue edit "$num" --repo "$ISSUE_REPO" --add-label dev-lead >/dev/null 2>&1 || true
-          { [ "$triage" = "REGRESSION" ] || [ "$triage" = "SUSPECT" ]; } && gh issue edit "$num" --repo "$ISSUE_REPO" --add-label needs-human >/dev/null 2>&1 || true
+          if [ "$triage" = "REGRESSION" ] || [ "$triage" = "SUSPECT" ]; then
+            gh issue edit "$num" --repo "$ISSUE_REPO" --add-label needs-human >/dev/null 2>&1 || true
+          else
+            gh issue edit "$num" --repo "$ISSUE_REPO" --remove-label needs-human >/dev/null 2>&1 || true
+          fi
           echo "  updated blocker issue #$num for $agent"; blk="#$num"
         fi
       fi

--- a/scripts/lib/canary-rollout.sh
+++ b/scripts/lib/canary-rollout.sh
@@ -183,6 +183,35 @@ classify_failure() {
   if [ "$suspect" = "1" ]; then echo "SUSPECT"; else echo "REGRESSION"; fi
 }
 
+# decide_suspect_downgrade <cand_rate_permille> <base_rate_permille> <base_sample> <knobs_json>
+# Pure SUSPECT→PRE_EXISTING auto-downgrade core (#668 increment 6, optional 1c). Applied by the
+# orchestrator AFTER classify_failure returns SUSPECT (so the verdict core stays small and
+# unit-testable), for a suspect class that opts into `auto_downgrade`. Rates are per-mille failure
+# rates of the SAME suspect class: the candidate's over its in-window runs vs the prior version's
+# over the trailing baseline window. Echoes exactly one of:
+#   DOWNGRADE — the baseline has enough data (base_sample >= min_baseline_sample) AND the candidate
+#               is no worse than the baseline for this class (cand_rate <= base_rate + margin_permille)
+#               → the failure is environmental, not a candidate regression; the caller re-triages it
+#               PRE_EXISTING (report-only).
+#   HOLD      — thin baseline (base_sample < min_baseline_sample: NEVER downgrade on tiny-n — the
+#               conservative default keeps the human) OR the candidate is materially worse
+#               (cand_rate > base_rate + margin_permille) → stay SUSPECT (increment 2 behaviour).
+# Knobs object {min_baseline_sample, margin_permille}; absent knobs default to 0 (margin 0 = strict
+# no-worse; min_baseline_sample 0 = no tiny-n guard, though the orchestrator always sets it).
+decide_suspect_downgrade() {
+  local cand="${1:-0}" base="${2:-0}" base_sample="${3:-0}" knobs="$4"
+  [ -z "$knobs" ] && knobs='{}'
+  local min_base margin
+  min_base="$(jq -r '.min_baseline_sample // 0' <<< "$knobs" 2>/dev/null || echo 0)"
+  margin="$(jq -r '.margin_permille // 0' <<< "$knobs" 2>/dev/null || echo 0)"
+  case "$min_base" in ''|*[!0-9]*) min_base=0 ;; esac
+  case "$margin" in ''|*[!0-9]*) margin=0 ;; esac
+  # Tiny-n guard first: too little baseline data → keep the human (conservative), regardless of rate.
+  if [ "$base_sample" -lt "$min_base" ]; then echo "HOLD"; return 0; fi
+  if [ "$cand" -le $(( base + margin )) ]; then echo "DOWNGRADE"; return 0; fi
+  echo "HOLD"
+}
+
 # benign_match <workflow_name> <failure_signature> <workflow_regex> <step_regex>
 # Decide whether ONE in-window failure matches ONE known-benign failure-class allowlist
 # entry (#1025 P2). A match requires a non-empty <step_regex> (guards against a match-all

--- a/scripts/lib/canary-rollout.sh
+++ b/scripts/lib/canary-rollout.sh
@@ -180,7 +180,7 @@ classify_failure() {
     comment-cap|rate-limit|infra|data) echo "PRE_EXISTING"; return 0 ;;
   esac
   if [ "$differs" != "1" ]; then echo "PRE_EXISTING"; return 0; fi
-  if [ "$suspect" = "1" ]; then echo "SUSPECT"; else echo "REGRESSION"; fi
+  if [ "$suspect" -gt 0 ]; then echo "SUSPECT"; else echo "REGRESSION"; fi
 }
 
 # decide_suspect_downgrade <cand_rate_permille> <base_rate_permille> <base_sample> <knobs_json>

--- a/standards/canary-rings.json
+++ b/standards/canary-rings.json
@@ -76,7 +76,11 @@
             "workflow": "Dev-Lead Agent",
             "step": "Stage timeout|exit code 124|rebase-conflict-sentinel",
             "reason": "#664/#668 \u2014 a dev-lead run can exit 124 when a stage exceeds its time budget (large workload, or a rebase-conflict sentinel that never resolves). This is *possibly* candidate-caused (a candidate that changed execution-time-sensitive code could genuinely be slower), so unlike a version_independent benign class it is NOT auto-cleared \u2014 it BLOCKS as SUSPECT and carries a discriminating question for a fast human confirm.",
-            "guidance": "Did this candidate change execution-time-sensitive code, or is it a large-workload/rebase timeout unrelated to the diff? If unrelated \u2192 `promote --override`; if the candidate got materially slower \u2192 treat as a real regression and roll back."
+            "guidance": "Did this candidate change execution-time-sensitive code, or is it a large-workload/rebase timeout unrelated to the diff? If unrelated \u2192 `promote --override`; if the candidate got materially slower \u2192 treat as a real regression and roll back.",
+            "auto_downgrade": {
+              "min_baseline_sample": 10,
+              "margin_permille": 100
+            }
           }
         ],
         "_suspect_note": "suspect_failure_classes (#668 increment 2): same shape as benign classes (`id`, `workflow` ERE, `step` ERE) plus a `guidance` discriminating question. A counted (non-benign) failure that matches a suspect class at differs=1 is triaged SUSPECT instead of REGRESSION \u2014 it still BLOCKS and still needs a human (labelled `needs-human`, NOT auto-cleared like `version_independent`), but the blocker issue renders the `guidance` so the human confirm is a 30-second check rather than a from-scratch investigation. Default-absent (this key omitted) = today's behavior, byte-identical for agents that do not opt in.",

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -1707,6 +1707,176 @@ GHEOF
   ! grep -q -- "--add-label needs-human" "$ISSUE_LOG"
 }
 
+# _downgrade_sync_update_stub — like _downgrade_sync_stub but the issue list returns
+# an existing open blocker so the UPDATE path (not CREATE) is exercised.
+_downgrade_sync_update_stub() {
+  local cand_fail="$1" cand_total="$2" base_fail="$3" base_total="$4"
+  _downgrade_stub "$cand_fail" "$cand_total" "$base_fail" "$base_total"
+  export ISSUE_LOG="$STUB_BIN/issue.log"; : > "$ISSUE_LOG"
+  local cut_iso cand_iso base_iso
+  cut_iso="$(date -u -d '-3 days' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-3d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  cand_iso="$(date -u -d '-1 days' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-1d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  base_iso="$(date -u -d '-7 days' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-7d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  cat > "$STUB_BIN/gh" <<GHEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"git/ref/tags/dev-lead/next"*)   echo "cccccccccccccccccccccccccccccccccccccccc commit" ;;
+  *"git/ref/tags/dev-lead/ring0"*)  echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb commit" ;;
+  *"git/ref/tags/dev-lead/ring1"*)  echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb commit" ;;
+  *"git/ref/tags/dev-lead/stable"*) echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb commit" ;;
+  *"matching-refs/tags/dev-lead/v"*) printf 'refs/tags/dev-lead/v2.0.0\ttagobj\ttag\n' ;;
+  *"git/tags/tagobj"*) printf '%s\t%s\n' "cccccccccccccccccccccccccccccccccccccccc" "$cut_iso" ;;
+  *"ref=cccc"*) echo "reuseAAAA" ;;
+  *"ref=bbbb"*) echo "reuseBBBB" ;;
+  *"run view"*) echo '{"jobs":[{"steps":[{"name":"Stage timeout (exit code 124)","conclusion":"failure"}]}]}' ;;
+  *"run list"*)
+    since=""; prev=""
+    for a in "\$@"; do [ "\$prev" = "--created" ] && since="\$a"; prev="\$a"; done
+    since="\${since#>=}"
+    jq -nc --arg s "\$since" --arg cc "$cand_iso" --arg bb "$base_iso" \
+      --argjson cf "$cand_fail" --argjson ct "$cand_total" --argjson bf "$base_fail" --argjson bt "$base_total" '
+      ( [range(0;\$ct)|{databaseId:(2001+.),conclusion:(if . < \$cf then "failure" else "success" end),createdAt:\$cc,workflowName:"Dev-Lead Agent"}]
+      + [range(0;\$bt)|{databaseId:(1001+.),conclusion:(if . < \$bf then "failure" else "success" end),createdAt:\$bb,workflowName:"Dev-Lead Agent"}] )
+      | map(select(\$s=="" or .createdAt >= \$s))' ;;
+  "issue list"*)   echo '[{"number":501,"state":"OPEN","body":"<!-- canary-blocker:dev-lead -->"}]' ;;
+  "issue create"*) echo "CREATE|\$*" >> "$ISSUE_LOG"; echo "https://github.com/petry-projects/.github-private/issues/777" ;;
+  "issue edit"*)   echo "EDIT|\$*"   >> "$ISSUE_LOG" ;;
+  "issue close"*)  echo "CLOSE|\$*"  >> "$ISSUE_LOG" ;;
+  "issue reopen"*) echo "REOPEN|\$*" >> "$ISSUE_LOG" ;;
+  "label create"*) : ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN/gh"
+  DG_RINGS="$BATS_TEST_TMPDIR/dg-sync-update-rings.json"
+  jq '{org_infra_repos, agents: {"dev-lead": .agents["dev-lead"]}}' "$RINGS" > "$DG_RINGS"
+}
+
+@test "orchestrator: sync-issues UPDATE path removes needs-human when SUSPECT is auto-downgraded to PRE_EXISTING (#668 inc6)" {
+  # Existing open blocker #501 (was SUSPECT, has needs-human). Now auto-downgraded → PRE_EXISTING.
+  # The update path must explicitly REMOVE needs-human so stale routing is cleared.
+  _downgrade_sync_update_stub 1 10 1 10
+  run env CANARY_RINGS="$DG_RINGS" ISSUE_REPO="petry-projects/.github-private" bash "$ORCH" sync-issues
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"updated blocker issue #501 for dev-lead"* ]]
+  # PRE_EXISTING → must NOT add needs-human
+  ! grep -q -- "--add-label needs-human" "$ISSUE_LOG"
+  # PRE_EXISTING → must REMOVE needs-human (clear stale routing from the SUSPECT era)
+  grep -q -- "--remove-label needs-human" "$ISSUE_LOG"
+}
+
+# _downgrade_mixed_stub — two candidate failures: run 2001 is a workload-timeout (suspect
+# class match) and run 2002 is an unrelated failure. The baseline has 1 workload-timeout.
+# Used to verify that mixed-failure candidates are NOT auto-downgraded (#668 inc6 guard).
+_downgrade_mixed_stub() {
+  STUB_BIN="$(mktemp -d "$BATS_TEST_TMPDIR/stub.XXXXXX")"; export PATH="$STUB_BIN:$PATH"
+  local cut_iso cand_iso base_iso
+  cut_iso="$(date -u -d '-3 days' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-3d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  cand_iso="$(date -u -d '-1 days' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-1d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  base_iso="$(date -u -d '-7 days' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-7d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  cat > "$STUB_BIN/git" <<'GITEOF'
+#!/usr/bin/env bash
+: # dev-lead is cross-repo; all tag/blob resolution goes via gh api
+GITEOF
+  chmod +x "$STUB_BIN/git"
+  cat > "$STUB_BIN/gh" <<GHEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"git/ref/tags/dev-lead/next"*)   echo "cccccccccccccccccccccccccccccccccccccccc commit" ;;
+  *"git/ref/tags/dev-lead/ring0"*)  echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb commit" ;;
+  *"git/ref/tags/dev-lead/ring1"*)  echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb commit" ;;
+  *"git/ref/tags/dev-lead/stable"*) echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb commit" ;;
+  *"matching-refs/tags/dev-lead/v"*) printf 'refs/tags/dev-lead/v2.0.0\ttagobj\ttag\n' ;;
+  *"git/tags/tagobj"*) printf '%s\t%s\n' "cccccccccccccccccccccccccccccccccccccccc" "$cut_iso" ;;
+  *"ref=cccc"*) echo "reuseAAAA" ;;
+  *"ref=bbbb"*) echo "reuseBBBB" ;;
+  *"run view"*" 2002 "*) echo '{"jobs":[{"steps":[{"name":"Some unrelated test failure","conclusion":"failure"}]}]}' ;;
+  *"run view"*) echo '{"jobs":[{"steps":[{"name":"Stage timeout (exit code 124)","conclusion":"failure"}]}]}' ;;
+  *"run list"*)
+    since=""; prev=""
+    for a in "\$@"; do [ "\$prev" = "--created" ] && since="\$a"; prev="\$a"; done
+    since="\${since#>=}"
+    jq -nc --arg s "\$since" --arg cc "$cand_iso" --arg bb "$base_iso" '
+      ( [{databaseId:2001,conclusion:"failure",createdAt:\$cc,workflowName:"Dev-Lead Agent"},
+         {databaseId:2002,conclusion:"failure",createdAt:\$cc,workflowName:"Dev-Lead Agent"}]
+      + [range(0;8)|{databaseId:(2003+.),conclusion:"success",createdAt:\$cc,workflowName:"Dev-Lead Agent"}]
+      + [{databaseId:1001,conclusion:"failure",createdAt:\$bb,workflowName:"Dev-Lead Agent"}]
+      + [range(0;9)|{databaseId:(1002+.),conclusion:"success",createdAt:\$bb,workflowName:"Dev-Lead Agent"}] )
+      | map(select(\$s=="" or .createdAt >= \$s))' ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN/gh"
+}
+
+@test "orchestrator: mixed-failure (workload-timeout + unrelated) is NOT auto-downgraded — unrelated failures keep gate SUSPECT (#668 inc6 per-failure attribution guard)" {
+  # Candidate: 2 failures — run 2001 (workload-timeout, suspect class, rate OK) +
+  # run 2002 (unrelated failure, not suspect-attributed). Even though the workload-timeout
+  # rate compares no-worse to baseline, the unrelated failure must block downgrade.
+  _downgrade_mixed_stub
+  run env CANARY_RINGS="$RINGS" bash "$ORCH" evaluate dev-lead
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"BLOCKED"* ]]
+  [[ "$output" == *"SUSPECT"* ]]
+  [[ "$output" != *"auto-downgraded"* ]]
+  [[ "$output" != *"PRE_EXISTING"* ]]
+}
+
+# _downgrade_baseline_incomplete_stub — like _downgrade_stub 1 10 1 10 but the single
+# baseline failure (run 1001) returns a non-zero exit from `gh run view`, simulating an
+# API error. Used to verify fail-closed behaviour on incomplete baseline evidence (#668 inc6).
+_downgrade_baseline_incomplete_stub() {
+  STUB_BIN="$(mktemp -d "$BATS_TEST_TMPDIR/stub.XXXXXX")"; export PATH="$STUB_BIN:$PATH"
+  local cut_iso cand_iso base_iso
+  cut_iso="$(date -u -d '-3 days' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-3d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  cand_iso="$(date -u -d '-1 days' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-1d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  base_iso="$(date -u -d '-7 days' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-7d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  cat > "$STUB_BIN/git" <<'GITEOF'
+#!/usr/bin/env bash
+: # dev-lead is cross-repo; all tag/blob resolution goes via gh api
+GITEOF
+  chmod +x "$STUB_BIN/git"
+  cat > "$STUB_BIN/gh" <<GHEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"git/ref/tags/dev-lead/next"*)   echo "cccccccccccccccccccccccccccccccccccccccc commit" ;;
+  *"git/ref/tags/dev-lead/ring0"*)  echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb commit" ;;
+  *"git/ref/tags/dev-lead/ring1"*)  echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb commit" ;;
+  *"git/ref/tags/dev-lead/stable"*) echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb commit" ;;
+  *"matching-refs/tags/dev-lead/v"*) printf 'refs/tags/dev-lead/v2.0.0\ttagobj\ttag\n' ;;
+  *"git/tags/tagobj"*) printf '%s\t%s\n' "cccccccccccccccccccccccccccccccccccccccc" "$cut_iso" ;;
+  *"ref=cccc"*) echo "reuseAAAA" ;;
+  *"ref=bbbb"*) echo "reuseBBBB" ;;
+  *"run view"*" 1001 "*) exit 1 ;;  # simulate API failure for the only baseline failure
+  *"run view"*) echo '{"jobs":[{"steps":[{"name":"Stage timeout (exit code 124)","conclusion":"failure"}]}]}' ;;
+  *"run list"*)
+    since=""; prev=""
+    for a in "\$@"; do [ "\$prev" = "--created" ] && since="\$a"; prev="\$a"; done
+    since="\${since#>=}"
+    jq -nc --arg s "\$since" --arg cc "$cand_iso" --arg bb "$base_iso" '
+      ( [{databaseId:2001,conclusion:"failure",createdAt:\$cc,workflowName:"Dev-Lead Agent"}]
+      + [range(0;9)|{databaseId:(2002+.),conclusion:"success",createdAt:\$cc,workflowName:"Dev-Lead Agent"}]
+      + [{databaseId:1001,conclusion:"failure",createdAt:\$bb,workflowName:"Dev-Lead Agent"}]
+      + [range(0;9)|{databaseId:(1002+.),conclusion:"success",createdAt:\$bb,workflowName:"Dev-Lead Agent"}] )
+      | map(select(\$s=="" or .createdAt >= \$s))' ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN/gh"
+}
+
+@test "orchestrator: baseline signature lookup failure → stays SUSPECT (fail-closed on incomplete baseline evidence, #668 inc6)" {
+  # Candidate: 1 workload-timeout (rate OK). Baseline: 1 failure but gh run view returns
+  # exit 1 for it (API error). Incomplete baseline evidence → must HOLD, not DOWNGRADE.
+  _downgrade_baseline_incomplete_stub
+  run env CANARY_RINGS="$RINGS" bash "$ORCH" evaluate dev-lead
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"BLOCKED"* ]]
+  [[ "$output" == *"SUSPECT"* ]]
+  [[ "$output" != *"auto-downgraded"* ]]
+  [[ "$output" != *"PRE_EXISTING"* ]]
+}
+
 @test "_blocker_body: SUSPECT triage renders the class guidance (discriminating question)" {
   # The blocker body must surface the workload-timeout discriminating question prominently
   # so a human confirm is a fast check, and keep the SUSPECT label + needs-human routing.

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -168,6 +168,41 @@ setup() {
   [ "$(classify_failure 1 unknown)" = "REGRESSION" ]
 }
 
+# ── decide_suspect_downgrade (SUSPECT→PRE_EXISTING auto-downgrade, #668 increment 6) ─
+# args: <cand_rate_permille> <base_rate_permille> <base_sample> <knobs_json>
+# Applied AFTER classify_failure returns SUSPECT (keeps the verdict core small). DOWNGRADE only
+# when the candidate is statistically no-worse than the prior version AND the baseline is not
+# too thin (tiny-n guard); otherwise HOLD (stay SUSPECT, increment 2 behaviour).
+DG_KNOBS='{"min_baseline_sample":10,"margin_permille":100}'
+
+@test "decide_suspect_downgrade: cand no worse than base+margin, sample≥min → DOWNGRADE" {
+  [ "$(decide_suspect_downgrade 100 100 10 "$DG_KNOBS")" = "DOWNGRADE" ]
+  [ "$(decide_suspect_downgrade 50 100 25 "$DG_KNOBS")" = "DOWNGRADE" ]
+}
+@test "decide_suspect_downgrade: cand materially worse than base+margin → HOLD (stay SUSPECT)" {
+  [ "$(decide_suspect_downgrade 500 100 10 "$DG_KNOBS")" = "HOLD" ]
+  [ "$(decide_suspect_downgrade 201 100 10 "$DG_KNOBS")" = "HOLD" ]
+}
+@test "decide_suspect_downgrade: thin baseline (base_sample < min) → HOLD (tiny-n guard)" {
+  # Even a candidate rate of 0 must NOT downgrade on too little baseline data.
+  [ "$(decide_suspect_downgrade 0 100 9 "$DG_KNOBS")" = "HOLD" ]
+  [ "$(decide_suspect_downgrade 100 100 5 "$DG_KNOBS")" = "HOLD" ]
+}
+@test "decide_suspect_downgrade: boundary at exactly base+margin → DOWNGRADE (inclusive)" {
+  # margin 100, base 100 → threshold 200; cand==200 downgrades, cand==201 holds.
+  [ "$(decide_suspect_downgrade 200 100 10 "$DG_KNOBS")" = "DOWNGRADE" ]
+  [ "$(decide_suspect_downgrade 201 100 10 "$DG_KNOBS")" = "HOLD" ]
+}
+@test "decide_suspect_downgrade: sample exactly at min → not thin (DOWNGRADE when no worse)" {
+  [ "$(decide_suspect_downgrade 100 100 10 "$DG_KNOBS")" = "DOWNGRADE" ]
+}
+@test "decide_suspect_downgrade: absent/empty knobs default to margin 0 + no tiny-n guard" {
+  # margin 0 → strict no-worse; min_baseline_sample 0 → any sample passes the guard.
+  [ "$(decide_suspect_downgrade 100 100 0 '{}')" = "DOWNGRADE" ]
+  [ "$(decide_suspect_downgrade 101 100 0 '{}')" = "HOLD" ]
+  [ "$(decide_suspect_downgrade 100 100 0 '')" = "DOWNGRADE" ]
+}
+
 # ── _reusable_differs: cross-repo host-aware blob compare (#613) ───────────────
 # When an agent's host != THIS_REPO (e.g. dev-lead hosted in .github-private while the
 # engine runs from .github), the reusable blob is NOT in the local checkout — the compare
@@ -1495,6 +1530,181 @@ GITEOF
 @test "canary-rings.json: suspect_failure_classes is default-absent for opted-out agents (byte-identical)" {
   run jq -e '.agents["agent-shield"].gate | has("suspect_failure_classes") | not' "$RINGS"
   [ "$status" -eq 0 ]
+}
+
+# ── SUSPECT→PRE_EXISTING auto-downgrade (#668 increment 6) ────────────────────────
+# dev-lead's workload-timeout suspect class opts into auto_downgrade: a SUSPECT whose
+# candidate suspect-class failure RATE is statistically no-worse than the prior version's
+# on the baseline window is auto-cleared to PRE_EXISTING (report-only, no needs-human). The
+# genuinely worse case and the tiny-n baseline stay SUSPECT (increment 2). Classes without
+# auto_downgrade never downgrade (increment 2 byte-identical).
+
+@test "canary-rings.json: dev-lead workload-timeout opts into auto_downgrade (#668 increment 6)" {
+  run jq -e '.agents["dev-lead"].gate.suspect_failure_classes[]
+             | select(.id=="workload-timeout") | .auto_downgrade
+             | .min_baseline_sample==10 and .margin_permille==100' "$RINGS"
+  [ "$status" -eq 0 ]
+}
+
+@test "canary-rings.json: auto_downgrade is dev-lead workload-timeout ONLY (scope guard, #668 increment 6)" {
+  # No other agent/class opts in — the increment starts with dev-lead workload-timeout only.
+  run jq -e '[.agents[].gate.suspect_failure_classes? // [] | .[] | select(.auto_downgrade != null)] | length == 1' "$RINGS"
+  [ "$status" -eq 0 ]
+}
+
+# _downgrade_stub <cand_fail> <cand_total> <base_fail> <base_total> — dev-lead cross-repo,
+# reusable DIFFERS (reuseAAAA vs reuseBBBB → differs=1). Source-tier CANDIDATE runs (createdAt
+# 1d ago, ids ≥2001) and prior-version BASELINE runs (createdAt 7d ago, ids 1001+); in each
+# window the first <fail> runs are workload-timeout failures (run view → exit-124 signature)
+# and the rest are successes → controls the suspect-class failure RATE + sample per window.
+# The `run list` case honours `--created >=<since>` like the real gh, so the candidate window
+# (since cut) sees only candidate runs and the baseline window (createdAt < cut) only baseline.
+_downgrade_stub() {
+  local cand_fail="$1" cand_total="$2" base_fail="$3" base_total="$4"
+  STUB_BIN="$(mktemp -d "$BATS_TEST_TMPDIR/stub.XXXXXX")"; export PATH="$STUB_BIN:$PATH"
+  local cut_iso cand_iso base_iso
+  cut_iso="$(date -u -d '-3 days' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-3d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  cand_iso="$(date -u -d '-1 days' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-1d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  base_iso="$(date -u -d '-7 days' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-7d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  cat > "$STUB_BIN/git" <<'GITEOF'
+#!/usr/bin/env bash
+: # dev-lead is cross-repo; all tag/blob resolution goes via gh api
+GITEOF
+  chmod +x "$STUB_BIN/git"
+  cat > "$STUB_BIN/gh" <<GHEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"git/ref/tags/dev-lead/next"*)   echo "cccccccccccccccccccccccccccccccccccccccc commit" ;;
+  *"git/ref/tags/dev-lead/ring0"*)  echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb commit" ;;
+  *"git/ref/tags/dev-lead/ring1"*)  echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb commit" ;;
+  *"git/ref/tags/dev-lead/stable"*) echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb commit" ;;
+  *"matching-refs/tags/dev-lead/v"*) printf 'refs/tags/dev-lead/v2.0.0\ttagobj\ttag\n' ;;
+  *"git/tags/tagobj"*) printf '%s\t%s\n' "cccccccccccccccccccccccccccccccccccccccc" "$cut_iso" ;;
+  *"ref=cccc"*) echo "reuseAAAA" ;;
+  *"ref=bbbb"*) echo "reuseBBBB" ;;
+  *"run view"*) echo '{"jobs":[{"steps":[{"name":"Stage timeout (exit code 124)","conclusion":"failure"}]}]}' ;;
+  *"run list"*)
+    since=""; prev=""
+    for a in "\$@"; do [ "\$prev" = "--created" ] && since="\$a"; prev="\$a"; done
+    since="\${since#>=}"
+    jq -nc --arg s "\$since" --arg cc "$cand_iso" --arg bb "$base_iso" \
+      --argjson cf "$cand_fail" --argjson ct "$cand_total" --argjson bf "$base_fail" --argjson bt "$base_total" '
+      ( [range(0;\$ct)|{databaseId:(2001+.),conclusion:(if . < \$cf then "failure" else "success" end),createdAt:\$cc,workflowName:"Dev-Lead Agent"}]
+      + [range(0;\$bt)|{databaseId:(1001+.),conclusion:(if . < \$bf then "failure" else "success" end),createdAt:\$bb,workflowName:"Dev-Lead Agent"}] )
+      | map(select(\$s=="" or .createdAt >= \$s))' ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN/gh"
+}
+
+@test "orchestrator: SUSPECT + auto_downgrade + cand rate no worse than baseline → PRE_EXISTING (report-only) (#668 inc6)" {
+  # cand 1/10 = 100‰, baseline 1/10 = 100‰ (sample 10 ≥ min 10); 100 ≤ 100+100 → DOWNGRADE.
+  _downgrade_stub 1 10 1 10
+  run env CANARY_RINGS="$RINGS" bash "$ORCH" evaluate dev-lead
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"BLOCKED"* ]]
+  [[ "$output" == *"PRE_EXISTING"* ]]
+  [[ "$output" == *"auto-downgraded"* ]]
+}
+
+@test "orchestrator: SUSPECT + auto_downgrade + cand rate materially worse → stays SUSPECT (#668 inc6)" {
+  # cand 5/10 = 500‰, baseline 1/10 = 100‰; 500 > 100+100 → HOLD → still SUSPECT + needs a human.
+  _downgrade_stub 5 10 1 10
+  run env CANARY_RINGS="$RINGS" bash "$ORCH" evaluate dev-lead
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"BLOCKED"* ]]
+  [[ "$output" == *"SUSPECT"* ]]
+  [[ "$output" != *"auto-downgraded"* ]]
+  [[ "$output" != *"PRE_EXISTING"* ]]
+}
+
+@test "orchestrator: SUSPECT + auto_downgrade + thin baseline → stays SUSPECT (tiny-n guard) (#668 inc6)" {
+  # baseline sample 5 < min 10 → never downgrade on thin data, even though cand==baseline rate.
+  _downgrade_stub 1 10 1 5
+  run env CANARY_RINGS="$RINGS" bash "$ORCH" evaluate dev-lead
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"BLOCKED"* ]]
+  [[ "$output" == *"SUSPECT"* ]]
+  [[ "$output" != *"auto-downgraded"* ]]
+}
+
+@test "orchestrator: suspect class WITHOUT auto_downgrade → SUSPECT unchanged (increment 2 regression guard, #668 inc6)" {
+  # A no-worse baseline that WOULD downgrade if opted in; with auto_downgrade stripped it must
+  # stay SUSPECT — proving un-flagged classes are byte-identical to increment 2.
+  _downgrade_stub 1 10 1 10
+  local no_dg="$BATS_TEST_TMPDIR/no-downgrade-rings.json"
+  jq 'del(.agents["dev-lead"].gate.suspect_failure_classes[].auto_downgrade)' "$RINGS" > "$no_dg"
+  run env CANARY_RINGS="$no_dg" bash "$ORCH" evaluate dev-lead
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"BLOCKED"* ]]
+  [[ "$output" == *"SUSPECT"* ]]
+  [[ "$output" != *"auto-downgraded"* ]]
+  [[ "$output" != *"PRE_EXISTING"* ]]
+}
+
+@test "orchestrator: an auto-downgraded PRE_EXISTING advances with --allow-pre-existing (#668 inc6)" {
+  # Report-only, so --allow-pre-existing (not --override) advances it, exactly like any PRE_EXISTING.
+  _downgrade_stub 1 10 1 10
+  run env CANARY_RINGS="$RINGS" bash "$ORCH" promote dev-lead --allow-pre-existing --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY-RUN"* ]]
+}
+
+# _downgrade_sync_stub <cand_fail> <cand_total> <base_fail> <base_total> — _downgrade_stub plus
+# issue ops and a dev-lead-only registry, to exercise the sync-issues blocker path.
+_downgrade_sync_stub() {
+  _downgrade_stub "$1" "$2" "$3" "$4"
+  export ISSUE_LOG="$STUB_BIN/issue.log"; : > "$ISSUE_LOG"
+  local cut_iso cand_iso base_iso
+  cut_iso="$(date -u -d '-3 days' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-3d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  cand_iso="$(date -u -d '-1 days' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-1d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  base_iso="$(date -u -d '-7 days' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-7d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  cat > "$STUB_BIN/gh" <<GHEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"git/ref/tags/dev-lead/next"*)   echo "cccccccccccccccccccccccccccccccccccccccc commit" ;;
+  *"git/ref/tags/dev-lead/ring0"*)  echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb commit" ;;
+  *"git/ref/tags/dev-lead/ring1"*)  echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb commit" ;;
+  *"git/ref/tags/dev-lead/stable"*) echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb commit" ;;
+  *"matching-refs/tags/dev-lead/v"*) printf 'refs/tags/dev-lead/v2.0.0\ttagobj\ttag\n' ;;
+  *"git/tags/tagobj"*) printf '%s\t%s\n' "cccccccccccccccccccccccccccccccccccccccc" "$cut_iso" ;;
+  *"ref=cccc"*) echo "reuseAAAA" ;;
+  *"ref=bbbb"*) echo "reuseBBBB" ;;
+  *"run view"*) echo '{"jobs":[{"steps":[{"name":"Stage timeout (exit code 124)","conclusion":"failure"}]}]}' ;;
+  *"run list"*)
+    since=""; prev=""
+    for a in "\$@"; do [ "\$prev" = "--created" ] && since="\$a"; prev="\$a"; done
+    since="\${since#>=}"
+    jq -nc --arg s "\$since" --arg cc "$cand_iso" --arg bb "$base_iso" \
+      --argjson cf "$1" --argjson ct "$2" --argjson bf "$3" --argjson bt "$4" '
+      ( [range(0;\$ct)|{databaseId:(2001+.),conclusion:(if . < \$cf then "failure" else "success" end),createdAt:\$cc,workflowName:"Dev-Lead Agent"}]
+      + [range(0;\$bt)|{databaseId:(1001+.),conclusion:(if . < \$bf then "failure" else "success" end),createdAt:\$bb,workflowName:"Dev-Lead Agent"}] )
+      | map(select(\$s=="" or .createdAt >= \$s))' ;;
+  "issue list"*)   echo '[]' ;;
+  "issue create"*) echo "CREATE|\$*" >> "$ISSUE_LOG"; echo "https://github.com/petry-projects/.github-private/issues/777" ;;
+  "issue edit"*)   echo "EDIT|\$*"   >> "$ISSUE_LOG" ;;
+  "issue close"*)  echo "CLOSE|\$*"  >> "$ISSUE_LOG" ;;
+  "issue reopen"*) echo "REOPEN|\$*" >> "$ISSUE_LOG" ;;
+  "label create"*) : ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN/gh"
+  DG_RINGS="$BATS_TEST_TMPDIR/dg-sync-rings.json"
+  jq '{org_infra_repos, agents: {"dev-lead": .agents["dev-lead"]}}' "$RINGS" > "$DG_RINGS"
+}
+
+@test "orchestrator: sync-issues files a PRE_EXISTING blocker (no needs-human) for an auto-downgraded SUSPECT (#668 inc6)" {
+  _downgrade_sync_stub 1 10 1 10
+  run env CANARY_RINGS="$DG_RINGS" ISSUE_REPO="petry-projects/.github-private" bash "$ORCH" sync-issues
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"opened blocker issue #777 for dev-lead"* ]]
+  # Body carries the auto-downgrade note + the candidate-vs-baseline rate comparison.
+  grep -q "auto-downgraded" "$ISSUE_LOG"
+  grep -q "PRE_EXISTING" "$ISSUE_LOG"
+  # Report-only → NOT routed to a human (that is the whole point of the downgrade).
+  ! grep -q -- "--add-label needs-human" "$ISSUE_LOG"
 }
 
 @test "_blocker_body: SUSPECT triage renders the class guidance (discriminating question)" {


### PR DESCRIPTION
Closes #688

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic evaluation for eligible SUSPECT failures, allowing them to be reclassified as PRE_EXISTING when candidate failure rates are comparable to the baseline.
  * Added baseline sample safeguards and configurable rate margins.
  * Added downgrade status, rate comparisons, and sample counts to evaluation results and blocker issue details.
  * Auto-downgraded results can proceed through promotion when permitted.

* **Bug Fixes**
  * Improved blocker issue classification and messaging for downgraded failures, distinguishing them from reliability and correctness issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->