### PR TITLE
feat: implement issue #696 — F4: canary-rollout engine operates on v<major>-<tier> channels (fallback-safe) [#657]

### DIFF
--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -149,20 +149,66 @@ _gh_create_annotated_tag() {
   }
 }
 
-# channel_commit <agent> <channel> — commit the channel tag <agent>/<channel> resolves to
-# (empty if the tag does not exist). Agents hosted in THIS repo resolve against the local
-# checkout; a cross-repo agent's channel tags live on ITS host, so they are resolved there
-# via the GitHub API — reading local refs resolves empty and the frontier falsely reports
-# "fully rolled out" (#1049).
-channel_commit() {
-  local agent="$1" channel="$2" host
+# _looks_like_oid <s> — return 0 iff <s> is a bare git object id (7–64 lowercase hex).
+# The v-form-prefer guard (major-scoped-channels epic #657, Phase F4): an absent tag
+# resolves to empty (or a `{}` sentinel under stubs), so only a real commit id may be
+# preferred over the legacy bare form — that keeps today's bare-tier fleet byte-identical.
+_looks_like_oid() { [[ "$1" =~ ^[0-9a-f]{7,64}$ ]]; }
+
+# _agent_current_major <agent> — the MAJOR of the agent's highest vX.Y.Z release on its
+# host, empty if none (major-scoped-channels epic #657, Phase F4). This is the "current
+# major line" a v-scoped channel tag is derived against; there is no new registry field —
+# it is derived from the release tags already present (mirrors _next_release_version).
+_agent_current_major() {
+  local versions highest
+  versions="$(_host_release_versions "$1")"
+  # shellcheck disable=SC2086
+  highest="$(max_semver $versions)"
+  [ -z "$highest" ] && return 0
+  major_component "$highest"
+}
+
+# _channel_tag_commit <agent> <suffix> — commit the tag <agent>/<suffix> resolves to
+# (empty if absent). Same host-vs-local resolution as channel_commit, generalized to an
+# arbitrary channel suffix so a v-scoped `v<M>-<tier>` can be probed (epic #657 F4).
+_channel_tag_commit() {
+  local agent="$1" suffix="$2" host
   host="$(_agent_field "$agent" host)"
   if [ -n "$host" ] && [ "$host" != "$THIS_REPO" ]; then
-    _gh_tag_commit "$host" "$agent/$channel"
+    _gh_tag_commit "$host" "$agent/$suffix"
     return 0
   fi
-  git rev-parse -q --verify "refs/tags/$agent/$channel^{commit}" 2>/dev/null \
-    || git rev-parse -q --verify "$agent/$channel^{commit}" 2>/dev/null || true
+  git rev-parse -q --verify "refs/tags/$agent/$suffix^{commit}" 2>/dev/null \
+    || git rev-parse -q --verify "$agent/$suffix^{commit}" 2>/dev/null || true
+}
+
+# _resolved_channel <agent> <tier> — echo "<tag>\t<commit>" for the channel <agent> uses on
+# <tier>, fall-back-safe (major-scoped-channels epic #657, Phase F4): PREFER the v-scoped
+# `<agent>/v<M>-<tier>` when it exists (its commit is a real oid), else the legacy bare
+# `<agent>/<tier>`. On today's bare-tier fleet (no v-tags) this is byte-identical to pre-F4.
+_resolved_channel() {
+  local agent="$1" tier="$2" major tag suffix commit
+  major="$(_agent_current_major "$agent")"
+  if [ -n "$major" ]; then
+    tag="$(channel_tag "$agent" "$tier" "$major")"; suffix="${tag#"$agent"/}"
+    commit="$(_channel_tag_commit "$agent" "$suffix")"
+    if _looks_like_oid "$commit"; then printf '%s\t%s\n' "$tag" "$commit"; return 0; fi
+  fi
+  tag="$(channel_tag "$agent" "$tier")"; suffix="${tag#"$agent"/}"
+  printf '%s\t%s\n' "$tag" "$(_channel_tag_commit "$agent" "$suffix")"
+}
+
+# _resolved_channel_tag <agent> <tier> — just the resolved tag name (no commit).
+_resolved_channel_tag() { _resolved_channel "$1" "$2" | cut -f1; }
+
+# channel_commit <agent> <channel> — commit the channel <agent> uses on <channel> resolves
+# to (empty if the tag does not exist). Resolution is fall-back-safe on the major dimension
+# (epic #657 F4): prefer the v-scoped tag, else the bare tier. Agents hosted in THIS repo
+# resolve against the local checkout; a cross-repo agent's channel tags live on ITS host, so
+# they are resolved there via the GitHub API — reading local refs resolves empty and the
+# frontier falsely reports "fully rolled out" (#1049).
+channel_commit() {
+  _resolved_channel "$1" "$2" | cut -f2
 }
 
 # _gate_field <agent> <field> — read .agents[a].gate.<field> (empty if absent).
@@ -810,15 +856,17 @@ _frontier_state() {
 cmd_evaluate() {
   local agent="$1"
   echo "== canary-rollout evaluate: $agent (gate standard: .github#548) =="
-  local cand; cand="$(channel_commit "$agent" next)"
-  echo "candidate (next) = ${cand:0:12}  cut=$(candidate_cut_date "$agent" "$cand")"
+  local cand_tag cand
+  IFS=$'\t' read -r cand_tag cand < <(_resolved_channel "$agent" next)
+  echo "candidate (${cand_tag#"$agent"/}) = ${cand:0:12}  cut=$(candidate_cut_date "$agent" "$cand")"
   local chan_array=()
   IFS=, read -r -a chan_array <<< "$(ordered_channels "$agent")"
   local ch
   for ch in "${chan_array[@]}"; do
-    local c; c="$(channel_commit "$agent" "$ch")"
+    local ch_tag c
+    IFS=$'\t' read -r ch_tag c < <(_resolved_channel "$agent" "$ch")
     local mark="  "; [ -n "$cand" ] && [ "$c" = "$cand" ] && mark="* "
-    printf '  %s%-7s -> %s\n' "$mark" "$ch" "${c:0:12}"
+    printf '  %s%-7s -> %s\n' "$mark" "${ch_tag#"$agent"/}" "${c:0:12}"
   done
   read -r _cand frontier transition state dwell floor sample target cum_fail cum_startup cum_benign triage mix_shift downgrade dg_cand_rate dg_cand_sample dg_base_rate dg_base_sample < <(_frontier_state "$agent")
   echo "----"
@@ -924,14 +972,19 @@ cmd_promote() {
   local host
   host="$(_jq -r --arg a "$agent" '.agents[$a].host // "" | tostring')"
   host="${host:-$THIS_REPO}"
-  echo "advancing $agent/$frontier -> ${cand:0:12} on $host"
+  # Move the RESOLVED frontier tag (major-scoped-channels epic #657, F4): advance the
+  # v-scoped `<agent>/v<M>-<tier>` within its major line when it exists, else the legacy
+  # bare `<agent>/<tier>`. A v2 promotion never touches a v1 tag. The logical tier
+  # ($frontier) is unchanged — it still drives the gate + is reported as promoted_ring.
+  local frontier_tag; frontier_tag="$(_resolved_channel_tag "$agent" "$frontier")"
+  echo "advancing $frontier_tag -> ${cand:0:12} on $host"
   if [ "$dry" = true ]; then
-    echo "[DRY-RUN] would: gh api PATCH repos/$host/git/refs/tags/$agent/$frontier sha=$cand (force)"
+    echo "[DRY-RUN] would: gh api PATCH repos/$host/git/refs/tags/$frontier_tag sha=$cand (force)"
     return 0
   fi
-  _gh_move_tag "$host" "$agent/$frontier" "$cand" \
-    || { echo "::error::failed to move $agent/$frontier -> ${cand:0:12} on $host" >&2; return 1; }
-  echo "promoted $agent/$frontier -> ${cand:0:12}"
+  _gh_move_tag "$host" "$frontier_tag" "$cand" \
+    || { echo "::error::failed to move $frontier_tag -> ${cand:0:12} on $host" >&2; return 1; }
+  echo "promoted $frontier_tag -> ${cand:0:12}"
   # Expose the move for the workflow's GitHub Deployment (traceability, #502). The
   # deployment must be created on the repo that OWNS the moved commit: a cross-repo agent's
   # candidate SHA lives on its host, NOT on THIS_REPO — creating the deployment against
@@ -1443,10 +1496,21 @@ _autocut_agent() {
   fi
   bump="$(_autocut_bump "$agent")"
   newver="$(_next_release_version "$agent" "$bump")"
-  echo "autocut $agent: reusable changed on $host ($defbranch ${mainsha:0:12}) vs next ${next_commit:0:12} — cutting v$newver (bump=$bump), moving next."
+  # Seed/advance the correct `next` line on the major dimension (major-scoped-channels epic
+  # #657, F4): a MAJOR bump opens a FRESH `<agent>/v<newmajor>-next` line (a brand-new major
+  # never reuses the prior major's next), whereas a minor/patch bump advances the CURRENT
+  # major's `v<M>-next` — falling back to the legacy bare `<agent>/next` on today's bare-tier
+  # fleet where no v-line exists yet, so the move stays byte-identical until F5 migrates tags.
+  local next_tag newmajor; newmajor="$(major_component "$newver")"
+  if [ "$bump" = major ]; then
+    next_tag="$(channel_tag "$agent" next "$newmajor")"
+  else
+    next_tag="$(_resolved_channel_tag "$agent" next)"
+  fi
+  echo "autocut $agent: reusable changed on $host ($defbranch ${mainsha:0:12}) vs next ${next_commit:0:12} — cutting v$newver (bump=$bump), moving $next_tag."
   local relver="$agent/v$newver"
   if [ "$dry" = true ]; then
-    echo "[DRY-RUN] would: cut $relver at ${mainsha:0:12} on $host + move $agent/next (gh-api, App token)"
+    echo "[DRY-RUN] would: cut $relver at ${mainsha:0:12} on $host + move $next_tag (gh-api, App token)"
     return 0
   fi
   # Cut inline (no sibling cut-release.sh, #613): create the immutable annotated release tag,
@@ -1466,9 +1530,9 @@ _autocut_agent() {
   elif ! _gh_create_annotated_tag "$host" "$relver" "$mainsha" "$agent release v$newver"; then
     echo "::warning::autocut $agent: could not create $relver on $host (best-effort, continuing)"; return 0
   fi
-  _gh_move_tag "$host" "$agent/next" "$mainsha" \
-    || { echo "::warning::autocut $agent: could not move $agent/next on $host (best-effort, continuing)"; return 0; }
-  echo "autocut $agent: cut v$newver from ${mainsha:0:12} and moved next (on $host)."
+  _gh_move_tag "$host" "$next_tag" "$mainsha" \
+    || { echo "::warning::autocut $agent: could not move $next_tag on $host (best-effort, continuing)"; return 0; }
+  echo "autocut $agent: cut v$newver from ${mainsha:0:12} and moved $next_tag (on $host)."
 }
 
 # cmd_autocut [--dry-run] — the scheduled front end. Gated by CANARY_AUTO_CUT (the single

--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -159,27 +159,46 @@ _looks_like_oid() { [[ "$1" =~ ^[0-9a-f]{7,64}$ ]]; }
 # host, empty if none (major-scoped-channels epic #657, Phase F4). This is the "current
 # major line" a v-scoped channel tag is derived against; there is no new registry field —
 # it is derived from the release tags already present (mirrors _next_release_version).
+declare -A _AGENT_MAJOR_CACHE=()
+
 _agent_current_major() {
-  local versions highest
-  versions="$(_host_release_versions "$1")"
+  local agent="$1"
+  if [[ -v _AGENT_MAJOR_CACHE["$agent"] ]]; then
+    echo "${_AGENT_MAJOR_CACHE["$agent"]}"
+    return 0
+  fi
+  local versions highest major=""
+  versions="$(_host_release_versions "$agent")"
   # shellcheck disable=SC2086
   highest="$(max_semver $versions)"
-  [ -z "$highest" ] && return 0
-  major_component "$highest"
+  if [ -n "$highest" ]; then
+    major="$(major_component "$highest")"
+  fi
+  _AGENT_MAJOR_CACHE["$agent"]="$major"
+  echo "$major"
 }
 
 # _channel_tag_commit <agent> <suffix> — commit the tag <agent>/<suffix> resolves to
 # (empty if absent). Same host-vs-local resolution as channel_commit, generalized to an
 # arbitrary channel suffix so a v-scoped `v<M>-<tier>` can be probed (epic #657 F4).
+declare -A _CHANNEL_COMMIT_CACHE=()
+
 _channel_tag_commit() {
-  local agent="$1" suffix="$2" host
-  host="$(_agent_field "$agent" host)"
-  if [ -n "$host" ] && [ "$host" != "$THIS_REPO" ]; then
-    _gh_tag_commit "$host" "$agent/$suffix"
+  local agent="$1" suffix="$2" host key="${1}:${2}"
+  if [[ -v _CHANNEL_COMMIT_CACHE["$key"] ]]; then
+    echo "${_CHANNEL_COMMIT_CACHE["$key"]}"
     return 0
   fi
-  git rev-parse -q --verify "refs/tags/$agent/$suffix^{commit}" 2>/dev/null \
-    || git rev-parse -q --verify "$agent/$suffix^{commit}" 2>/dev/null || true
+  local commit=""
+  host="$(_agent_field "$agent" host)"
+  if [ -n "$host" ] && [ "$host" != "$THIS_REPO" ]; then
+    commit="$(_gh_tag_commit "$host" "$agent/$suffix")"
+  else
+    commit="$(git rev-parse -q --verify "refs/tags/$agent/$suffix^{commit}" 2>/dev/null \
+      || git rev-parse -q --verify "$agent/$suffix^{commit}" 2>/dev/null || true)"
+  fi
+  _CHANNEL_COMMIT_CACHE["$key"]="$commit"
+  echo "$commit"
 }
 
 # _resolved_channel <agent> <tier> — echo "<tag>\t<commit>" for the channel <agent> uses on

--- a/scripts/canary-rollout.sh
+++ b/scripts/canary-rollout.sh
@@ -149,12 +149,6 @@ _gh_create_annotated_tag() {
   }
 }
 
-# _looks_like_oid <s> — return 0 iff <s> is a bare git object id (7–64 lowercase hex).
-# The v-form-prefer guard (major-scoped-channels epic #657, Phase F4): an absent tag
-# resolves to empty (or a `{}` sentinel under stubs), so only a real commit id may be
-# preferred over the legacy bare form — that keeps today's bare-tier fleet byte-identical.
-_looks_like_oid() { [[ "$1" =~ ^[0-9a-f]{7,64}$ ]]; }
-
 # _agent_current_major <agent> — the MAJOR of the agent's highest vX.Y.Z release on its
 # host, empty if none (major-scoped-channels epic #657, Phase F4). This is the "current
 # major line" a v-scoped channel tag is derived against; there is no new registry field —
@@ -1504,7 +1498,8 @@ _autocut_agent() {
   if [ -z "$main_blob" ]; then
     echo "::warning::autocut $agent: reusable '$reusable' not found at $host@${mainsha:0:12} — skipping"; return 0
   fi
-  next_commit="$(channel_commit "$agent" next)"
+  local next_resolved_tag
+  IFS=$'\t' read -r next_resolved_tag next_commit < <(_resolved_channel "$agent" next)
   next_blob=""
   [ -n "$next_commit" ] && next_blob="$(_gh_blob_sha "$host" "$reusable" "$next_commit")"
   # Idempotency: nothing to cut when main HEAD already IS the candidate, or the reusable blob
@@ -1524,7 +1519,7 @@ _autocut_agent() {
   if [ "$bump" = major ]; then
     next_tag="$(channel_tag "$agent" next "$newmajor")"
   else
-    next_tag="$(_resolved_channel_tag "$agent" next)"
+    next_tag="$next_resolved_tag"
   fi
   echo "autocut $agent: reusable changed on $host ($defbranch ${mainsha:0:12}) vs next ${next_commit:0:12} — cutting v$newver (bump=$bump), moving $next_tag."
   local relver="$agent/v$newver"

--- a/scripts/lib/canary-rollout.sh
+++ b/scripts/lib/canary-rollout.sh
@@ -119,6 +119,22 @@ max_semver() {
   echo "$hi"
 }
 
+# major_component <version> — echo the MAJOR of a strict MAJOR.MINOR.PATCH, empty
+# otherwise. Pure. Used (major-scoped-channels epic #657, Phase F4) to derive an
+# agent's current major line from its highest vX.Y.Z release for v-form tagging.
+major_component() {
+  [[ "$1" =~ ^([0-9]+)\.[0-9]+\.[0-9]+$ ]] && printf '%s' "${BASH_REMATCH[1]}" || true
+}
+
+# channel_tag <agent> <tier> [major] — build a channel tag name. With a MAJOR the
+# v-scoped form `<agent>/v<major>-<tier>` (mirrors ring_canonical_ref in
+# ring-pins.sh); without it the legacy bare `<agent>/<tier>`. Pure. (Epic #657 F4.)
+channel_tag() {
+  local agent="$1" tier="$2" major="${3:-}"
+  if [ -n "$major" ]; then printf '%s/v%s-%s' "$agent" "$major" "$tier"
+  else printf '%s/%s' "$agent" "$tier"; fi
+}
+
 # dwell_met <dwell_hours> <floor_hours> — echo 1 if the candidate has dwelled at
 # least floor_hours on the source tier, else 0.
 dwell_met() {

--- a/scripts/lib/canary-rollout.sh
+++ b/scripts/lib/canary-rollout.sh
@@ -123,7 +123,9 @@ max_semver() {
 # otherwise. Pure. Used (major-scoped-channels epic #657, Phase F4) to derive an
 # agent's current major line from its highest vX.Y.Z release for v-form tagging.
 major_component() {
-  [[ "$1" =~ ^([0-9]+)\.[0-9]+\.[0-9]+$ ]] && printf '%s' "${BASH_REMATCH[1]}" || true
+  if [[ "$1" =~ ^([0-9]+)\.[0-9]+\.[0-9]+$ ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+  fi
 }
 
 # channel_tag <agent> <tier> [major] — build a channel tag name. With a MAJOR the
@@ -134,6 +136,9 @@ channel_tag() {
   if [ -n "$major" ]; then printf '%s/v%s-%s' "$agent" "$major" "$tier"
   else printf '%s/%s' "$agent" "$tier"; fi
 }
+
+# _looks_like_oid <s> — return 0 iff <s> is a bare git object id (7–64 lowercase hex). Pure.
+_looks_like_oid() { [[ "$1" =~ ^[0-9a-f]{7,64}$ ]]; }
 
 # dwell_met <dwell_hours> <floor_hours> — echo 1 if the candidate has dwelled at
 # least floor_hours on the source tier, else 0.

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -979,6 +979,9 @@ case "\$*" in
   *"/commits/"*) echo "$MAINSHA" ;;
   *"matching-refs/tags/$agent/v"*) printf '%s' "$refs" ;;
   *"git/ref/tags/$agent/next"*) printf '%s\tcommit\n' "$NEXTSHA" ;;
+  # bare-tier fleet: no v-scoped channel tags exist yet (v<M>-next), so a v-channel
+  # probe resolves absent — only the vX.Y.Z RELEASE existence probe returns tag_probe_resp.
+  *"git/ref/tags/$agent/v"*"-next"*) printf '\n' ;;
   *"git/ref/tags/$agent/v"*) printf '%s\n' "$tag_probe_resp" ;;
   *"run list"*) echo "[]" ;;
   *) echo "{}" ;;
@@ -2368,4 +2371,190 @@ GHEOF
   grep -q "skip-checks-pending" "$ISSUE_LOG"
   # SUSPECT → routed to a human (needs-human) as well as the dev-lead agent.
   grep -q -- "--add-label needs-human" "$ISSUE_LOG"
+}
+
+# ══ major-scoped channels: v<major>-<tier> resolution + promotion (epic #657, F4) ══
+# F4 makes the engine CAPABLE of operating on major-scoped `<agent>/v<M>-<tier>` channel tags
+# while remaining fall-back-safe on today's bare-tier fleet: resolution prefers the v-form when
+# that tag exists, else the legacy bare `<agent>/<tier>`. The transition-safety guard is that on
+# the bare fixture the engine is byte-identical to pre-F4 (F5, not F4, migrates the live tags).
+
+# ── pure name-builders (mirror F3 ring_canonical_ref convention) ────────────────
+@test "channel_tag: with a major builds the v-scoped form (matches ring-pins convention)" {
+  [ "$(channel_tag dev-lead next 2)" = "dev-lead/v2-next" ]
+  [ "$(channel_tag auto-rebase stable 3)" = "auto-rebase/v3-stable" ]
+}
+@test "channel_tag: without a major builds the legacy bare form" {
+  [ "$(channel_tag dev-lead next)" = "dev-lead/next" ]
+  [ "$(channel_tag dev-lead stable '')" = "dev-lead/stable" ]
+}
+@test "major_component: extracts the MAJOR of a strict semver" {
+  [ "$(major_component 2.3.1)" = "2" ]
+  [ "$(major_component 10.0.0)" = "10" ]
+}
+@test "major_component: a non-semver token yields empty (no false major)" {
+  [ -z "$(major_component 2-next)" ]
+  [ -z "$(major_component '')" ]
+  [ -z "$(major_component v2.0.0)" ]
+}
+
+# ── a fleet whose v2 major line EXISTS: v2-next=cand(cccc), v2-ring0/ring1/stable=old(bbbb) →
+#    frontier ring0, transition next->ring0. Bare tags resolve to a DIFFERENT sha (aaaa) so a test
+#    can prove the engine PREFERS the v-form. Ref mutations are logged to MOVE_LOG.
+_vline_stub() {
+  local cut_days="$1" run_days_ago="$2" conclusion="$3"
+  STUB_BIN="$(mktemp -d "$BATS_TEST_TMPDIR/stub.XXXXXX")"; export PATH="$STUB_BIN:$PATH"
+  export MOVE_LOG="$STUB_BIN/move.log"
+  local cand="cccccccccccccccccccccccccccccccccccccccc"
+  local old="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  local bare="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  local cut_iso run_iso
+  cut_iso="$(date -u -d "-${cut_days} days" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v"-${cut_days}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  run_iso="$(date -u -d "-${run_days_ago} days" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v"-${run_days_ago}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  cat > "$STUB_BIN/gh" <<GHEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"-X PATCH"*"git/refs/tags/"*) echo "\$*" >> "$MOVE_LOG"; echo "{}"; exit 0 ;;
+  *"-X POST"*"git/refs"*)        echo "\$*" >> "$MOVE_LOG"; echo "{}"; exit 0 ;;
+  *"git/ref/tags/dev-lead/v2-next"*)   echo "$cand commit" ;;
+  *"git/ref/tags/dev-lead/v2-ring0"*)  echo "$old commit" ;;
+  *"git/ref/tags/dev-lead/v2-ring1"*)  echo "$old commit" ;;
+  *"git/ref/tags/dev-lead/v2-stable"*) echo "$old commit" ;;
+  *"git/ref/tags/dev-lead/next"*)   echo "$bare commit" ;;
+  *"git/ref/tags/dev-lead/ring0"*)  echo "$bare commit" ;;
+  *"git/ref/tags/dev-lead/ring1"*)  echo "$bare commit" ;;
+  *"git/ref/tags/dev-lead/stable"*) echo "$bare commit" ;;
+  *"matching-refs/tags/dev-lead/v"*) printf 'refs/tags/dev-lead/v2.0.0\ttagobj\ttag\n' ;;
+  *"git/tags/tagobj"*) printf '%s\t%s\n' "$cand" "$cut_iso" ;;
+  *"ref=cccc"*) echo "reuseAAAA" ;;
+  *"ref=bbbb"*) echo "reuseAAAA" ;;
+  *"run list"*) jq -nc --arg d "$run_iso" --arg c "$conclusion" '[range(20)|{conclusion:\$c,createdAt:\$d}]' ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN/gh"
+  cat > "$STUB_BIN/git" <<'GITEOF'
+#!/usr/bin/env bash
+: # dev-lead is cross-repo; all tag/blob resolution goes via gh api above
+GITEOF
+  chmod +x "$STUB_BIN/git"
+}
+
+@test "orchestrator: resolution prefers the v2 line + evaluate reports the major line (#657 F4)" {
+  _vline_stub 3 2 success
+  run env CANARY_RINGS="$RINGS" bash "$ORCH" evaluate dev-lead
+  [ "$status" -eq 0 ]
+  # The candidate + ring listing report the major line, not the bare tier.
+  [[ "$output" == *"candidate (v2-next)"* ]]
+  [[ "$output" == *"v2-stable"* ]]
+  [[ "$output" != *"candidate (next) ="* ]]
+  # The v-form is PREFERRED: the candidate resolves to cccc (v2-next), never the bare aaaa.
+  [[ "$output" == *"cccccccccccc"* ]]
+  [[ "$output" != *"aaaaaaaaaaaa"* ]]
+  [[ "$output" == *"next->ring0"* ]]
+  [[ "$output" == *"PROMOTE"* ]]
+}
+
+@test "orchestrator: promote advances WITHIN a major line — moves v2-ring0, never a v1 tag (#657 F4)" {
+  _vline_stub 3 2 success
+  local out="$BATS_TEST_TMPDIR/gh_output"; : > "$out"
+  run env CANARY_RINGS="$RINGS" GITHUB_OUTPUT="$out" bash "$ORCH" promote dev-lead
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"promoted dev-lead/v2-ring0"* ]]
+  grep -q "PATCH repos/petry-projects/.github-private/git/refs/tags/dev-lead/v2-ring0" "$MOVE_LOG"
+  # A v2 promotion NEVER touches a v1-* tag.
+  ! grep -q "v1-" "$MOVE_LOG"
+  # promoted_ring stays the logical tier (ring0), not the major-scoped tag.
+  grep -q "promoted_ring=ring0" "$out"
+}
+
+@test "orchestrator: on the bare-tier fixture the verdict is byte-identical to pre-F4 (transition-safety) (#657 F4)" {
+  # No v-tags exist (the v-form probe resolves absent) → resolution falls back to the bare tier,
+  # so the candidate + verdict are exactly what pre-F4 produced on this fixture.
+  _graduated_stub 3 2 success 0
+  run env CANARY_RINGS="$RINGS" bash "$ORCH" evaluate dev-lead
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"candidate (next) ="* ]]
+  [[ "$output" != *"candidate (v"* ]]
+  [[ "$output" == *"next->ring0"* ]]
+  [[ "$output" == *"PROMOTE"* ]]
+}
+
+# ── autocut on the major dimension: a MAJOR bump seeds a fresh v<newmajor>-next line; a minor/
+#    patch bump advances the CURRENT major's v<M>-next (falling back to bare next on today's fleet).
+#    args: agent host reusable main_blob next_blob mainsha nextsha versions bump [v2next_sha]
+_f4_autocut_stub() {
+  local agent="$1" host="$2" reusable="$3" MAIN_BLOB="$4" NEXT_BLOB="$5" MAINSHA="$6" NEXTSHA="$7" versions="$8" bump="$9" V2NEXT="${10:-}"
+  STUB_BIN="$(mktemp -d "$BATS_TEST_TMPDIR/stub.XXXXXX")"; export PATH="$STUB_BIN:$PATH"
+  export GH_LOG="$STUB_BIN/gh-writes.log"; : > "$GH_LOG"
+  local refs="" v
+  for v in $versions; do refs+="refs/tags/$agent/v$v"$'\n'; done
+  local v2next_resp=""
+  [ -n "$V2NEXT" ] && v2next_resp="${V2NEXT}"$'\t'"commit"
+  cat > "$STUB_BIN/gh" <<GHEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *".default_branch"*) echo "main" ;;
+  *"contents/"*"ref=$MAINSHA"*) echo "$MAIN_BLOB" ;;
+  *"contents/"*"ref=$NEXTSHA"*) echo "$NEXT_BLOB" ;;
+  *"-X POST"*"git/tags"*) echo "\$*" >> "$GH_LOG"; echo "7a90000000000000000000000000000000000000" ;;
+  *"-X PATCH"*"git/refs/tags/"*) echo "\$*" >> "$GH_LOG"; exit 0 ;;
+  *"-X POST"*"git/refs"*) echo "\$*" >> "$GH_LOG"; echo "{}" ;;
+  *"/commits/"*) echo "$MAINSHA" ;;
+  *"matching-refs/tags/$agent/v"*) printf '%s' "$refs" ;;
+  *"git/ref/tags/$agent/v2-next"*) printf '%s\n' "$v2next_resp" ;;
+  *"git/ref/tags/$agent/next"*) printf '%s\tcommit\n' "$NEXTSHA" ;;
+  *"git/ref/tags/$agent/v"*) printf '\n' ;;
+  *"run list"*) echo "[]" ;;
+  *) echo "{}" ;;
+esac
+GHEOF
+  chmod +x "$STUB_BIN/gh"
+  cat > "$STUB_BIN/git" <<GITEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"rev-parse"*"$agent/next"*) echo "$NEXTSHA" ;;
+  *) : ;;
+esac
+GITEOF
+  chmod +x "$STUB_BIN/git"
+  AUTOCUT_RINGS="$BATS_TEST_TMPDIR/f4-autocut-rings.json"
+  jq --arg a "$agent" --arg b "$bump" \
+    '{version, description, org_infra_repos, member_tokens, agents: {($a): (.agents[$a] + {autocut: {bump: $b}})}}' \
+    "$RINGS" > "$AUTOCUT_RINGS"
+}
+
+@test "orchestrator: autocut of a MAJOR bump seeds a fresh v<newmajor>-next line, not the old next (#657 F4)" {
+  _f4_autocut_stub dev-lead petry-projects/.github-private .github/workflows/dev-lead-reusable.yml \
+    blobMAIN blobNEXT aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa cccccccccccccccccccccccccccccccccccccccc "2.1.0" major
+  run env CANARY_AUTO_CUT=true CANARY_RINGS="$AUTOCUT_RINGS" bash "$ORCH" autocut
+  [ "$status" -eq 0 ]
+  # major bump v2.1.0 → v3.0.0; the immutable release cut as usual, next seeded on the FRESH v3 line.
+  grep -q "git/tags .*tag=dev-lead/v3.0.0 .*object=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" "$GH_LOG"
+  grep -q "PATCH repos/petry-projects/.github-private/git/refs/tags/dev-lead/v3-next .*sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" "$GH_LOG"
+  # The fresh major line does NOT move the old bare next (that would break the running fleet).
+  ! grep -q "git/refs/tags/dev-lead/next " "$GH_LOG"
+}
+
+@test "orchestrator: autocut of a patch bump advances the current major's v2-next when that line exists (#657 F4)" {
+  _f4_autocut_stub dev-lead petry-projects/.github-private .github/workflows/dev-lead-reusable.yml \
+    blobMAIN blobNEXT aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa cccccccccccccccccccccccccccccccccccccccc "2.1.0" patch \
+    cccccccccccccccccccccccccccccccccccccccc
+  run env CANARY_AUTO_CUT=true CANARY_RINGS="$AUTOCUT_RINGS" bash "$ORCH" autocut
+  [ "$status" -eq 0 ]
+  # patch bump v2.1.0 → v2.1.1; the v2 line exists → next advances ON the major line, not bare next.
+  grep -q "git/tags .*tag=dev-lead/v2.1.1 .*object=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" "$GH_LOG"
+  grep -q "PATCH repos/petry-projects/.github-private/git/refs/tags/dev-lead/v2-next .*sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" "$GH_LOG"
+  ! grep -q "git/refs/tags/dev-lead/next " "$GH_LOG"
+}
+
+@test "orchestrator: autocut of a patch bump falls back to bare next when no v-line exists yet (#657 F4)" {
+  # Today's bare fleet: no v2-next tag → resolution falls back to bare next → byte-identical move.
+  _f4_autocut_stub dev-lead petry-projects/.github-private .github/workflows/dev-lead-reusable.yml \
+    blobMAIN blobNEXT aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa cccccccccccccccccccccccccccccccccccccccc "2.1.0" patch
+  run env CANARY_AUTO_CUT=true CANARY_RINGS="$AUTOCUT_RINGS" bash "$ORCH" autocut
+  [ "$status" -eq 0 ]
+  grep -q "git/tags .*tag=dev-lead/v2.1.1 .*object=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" "$GH_LOG"
+  grep -q "PATCH repos/petry-projects/.github-private/git/refs/tags/dev-lead/next .*sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" "$GH_LOG"
+  ! grep -q "git/refs/tags/dev-lead/v2-next" "$GH_LOG"
 }

--- a/tests/canary_rollout.bats
+++ b/tests/canary_rollout.bats
@@ -2397,6 +2397,21 @@ GHEOF
   [ -z "$(major_component '')" ]
   [ -z "$(major_component v2.0.0)" ]
 }
+@test "_looks_like_oid: accepts valid 7-char and 40-char lowercase hex" {
+  _looks_like_oid "a1b2c3d"
+  _looks_like_oid "abc1234def5678901234567890123456789012345678901234567890123456"
+  _looks_like_oid "0000000000000000000000000000000000000000"
+}
+@test "_looks_like_oid: accepts 64-char hex (max length)" {
+  _looks_like_oid "$(printf '%064x' 255)"
+}
+@test "_looks_like_oid: rejects uppercase hex, short ids, and non-hex tokens" {
+  run _looks_like_oid "A1B2C3D"; [ "$status" -ne 0 ]
+  run _looks_like_oid "abc123"; [ "$status" -ne 0 ]
+  run _looks_like_oid ""; [ "$status" -ne 0 ]
+  run _looks_like_oid "{}"; [ "$status" -ne 0 ]
+  run _looks_like_oid "dev-lead/next"; [ "$status" -ne 0 ]
+}
 
 # ── a fleet whose v2 major line EXISTS: v2-next=cand(cccc), v2-ring0/ring1/stable=old(bbbb) →
 #    frontier ring0, transition next->ring0. Bare tags resolve to a DIFFERENT sha (aaaa) so a test


### PR DESCRIPTION
Closes #696

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added major-version-scoped canary channels for more precise rollout tracking.
  * Rollouts now prefer version-specific channel tags when available and retain legacy fallback behavior.
  * Promotions and candidate creation advance the appropriate major-version channel.

* **Bug Fixes**
  * Improved channel resolution and evaluation across major release lines.
  * Preserved existing behavior when version-specific channels are unavailable.

* **Tests**
  * Added coverage for major-scoped channels, promotions, major bumps, patch updates, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->