### PR TITLE
feat: implement issue #698 — F5: migration tooling — emit v<major>-tier pins, fleet-drift prefix, migrate-major-channels helper [#657]

### DIFF
--- a/.github/workflows/migration-tooling-tests.yml
+++ b/.github/workflows/migration-tooling-tests.yml
@@ -1,0 +1,68 @@
+# Quality gates for the major-scoped-channels migration tooling (epic #657 F5).
+#
+# Triggered on any PR that touches:
+#   - scripts/migrate-major-channels.sh
+#   - scripts/lib/ring-pins.sh          (the shared pin model it builds on)
+#   - test/scripts/migrate-major-channels/**
+#
+# Gates (all must pass before merge):
+#   1. shellcheck — static analysis for the migration helper + shared lib
+#   2. bats       — DRY_RUN v-tag planning, idempotency, and the guarded
+#                   bare-tier retirement path
+#
+# Standard: the migration helper is DRY_RUN-aware and mutates only through the gh
+# Git-refs API (never a direct push). See petry-projects/.github#698.
+
+name: Migration Tooling Tests
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/migrate-major-channels.sh'
+      - 'scripts/lib/ring-pins.sh'
+      - 'test/scripts/migrate-major-channels/**'
+      - '.github/workflows/migration-tooling-tests.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'scripts/migrate-major-channels.sh'
+      - 'scripts/lib/ring-pins.sh'
+      - 'test/scripts/migrate-major-channels/**'
+      - '.github/workflows/migration-tooling-tests.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: migration-tooling-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Lint and bats
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: Install bats, shellcheck, and jq
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends bats shellcheck jq
+
+      - name: shellcheck
+        run: |
+          set -euo pipefail
+          shellcheck --severity=warning -x \
+            scripts/migrate-major-channels.sh \
+            scripts/lib/ring-pins.sh
+
+      - name: Run bats suite
+        run: |
+          bats --print-output-on-failure \
+            test/scripts/migrate-major-channels/

--- a/.github/workflows/migration-tooling-tests.yml
+++ b/.github/workflows/migration-tooling-tests.yml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install bats, shellcheck, and jq
         run: |

--- a/.github/workflows/standards-deploy-tests.yml
+++ b/.github/workflows/standards-deploy-tests.yml
@@ -20,8 +20,10 @@ on:
     paths:
       - 'scripts/deploy-standard-workflows.sh'
       - 'scripts/lib/standards-deploy.sh'
+      - 'scripts/lib/ring-pins.sh'
       - 'test/scripts/deploy-standard-workflows/**'
       - 'test/scripts/lib/standards-deploy.bats'
+      - 'test/scripts/lib/ring-pins.bats'
       - '.github/workflows/standards-deploy-tests.yml'
   push:
     branches:
@@ -29,8 +31,10 @@ on:
     paths:
       - 'scripts/deploy-standard-workflows.sh'
       - 'scripts/lib/standards-deploy.sh'
+      - 'scripts/lib/ring-pins.sh'
       - 'test/scripts/deploy-standard-workflows/**'
       - 'test/scripts/lib/standards-deploy.bats'
+      - 'test/scripts/lib/ring-pins.bats'
       - '.github/workflows/standards-deploy-tests.yml'
 
 permissions:
@@ -62,10 +66,12 @@ jobs:
           set -euo pipefail
           shellcheck --severity=warning -x \
             scripts/deploy-standard-workflows.sh \
-            scripts/lib/standards-deploy.sh
+            scripts/lib/standards-deploy.sh \
+            scripts/lib/ring-pins.sh
 
       - name: Run bats suite
         run: |
           bats --print-output-on-failure \
             test/scripts/lib/standards-deploy.bats \
+            test/scripts/lib/ring-pins.bats \
             test/scripts/deploy-standard-workflows/

--- a/scripts/deploy-standard-workflows.sh
+++ b/scripts/deploy-standard-workflows.sh
@@ -262,6 +262,7 @@ deploy_repo() {
   local -a paths=() templates=() names=() emits=() tmpfiles=()
   local workflow template target_path raw existing_sha existing_content emit deploy_template base
   for workflow in "${WORKFLOWS[@]}"; do
+    base=""
     if is_skipped_repo "$repo" && ! repo_opts_into "$repo" "$workflow"; then
       skip "$repo/$workflow (exempt)"
       continue

--- a/scripts/deploy-standard-workflows.sh
+++ b/scripts/deploy-standard-workflows.sh
@@ -177,11 +177,59 @@ is_already_compliant() {
       while IFS= read -r ref; do
         [[ -n "$ref" ]] && grep -qF "${prefix}@${ref}" <<< "$existing_content" && return 0
       done < <(ring_accepted_refs "$base" "$repo")
+      # Transition to major-scoped channels (#657 F5): a stub already pinned to the
+      # repo's tier-correct `v<M>-<tier>` form (any major) is compliant too, so the
+      # sweep accepts both the bare and the v-form during migration. A WRONG-tier
+      # v-form is not accepted here and stays drift.
+      local existing_ref
+      existing_ref=$(grep -oE "@${base}/[^[:space:]\"']+" <<< "$existing_content" | head -1)
+      existing_ref="${existing_ref#@}"
+      if [[ -n "$existing_ref" ]] && ring_vform_tier_aligned "$existing_ref" "$base" "$repo"; then
+        return 0
+      fi
       return 1
     fi
   fi
 
   grep -qF "$expected_uses" <<< "$existing_content" && return 0 || return 1
+}
+
+# reusable_uses_of <template> -> the template's first reusable `uses:` value
+# (org/repo/…/<base>-reusable.yml@<ref>), comment/CR stripped, or empty.
+reusable_uses_of() {
+  grep -E '^[[:space:]]*uses:' "$1" | head -1 \
+    | sed 's/^[[:space:]]*uses:[[:space:]]*//' | sed 's/[[:space:]]*#.*//' | tr -d '\r'
+}
+
+# reusable_base_of <template> -> the ring channel base (e.g. `auto-rebase`) of the
+# template's reusable, or empty if the template does not call a `-reusable.yml`.
+reusable_base_of() {
+  local prefix; prefix="$(reusable_uses_of "$1")"; prefix="${prefix%@*}"
+  [[ "$prefix" =~ /([a-z0-9-]+)-reusable\.yml$ ]] && printf '%s' "${BASH_REMATCH[1]}"
+  return 0
+}
+
+# reusable_host_of <template> -> the org/repo that HOSTS the reusable (and thus
+# carries its release tags), e.g. `petry-projects/.github-private` for dev-lead.
+reusable_host_of() {
+  local prefix; prefix="$(reusable_uses_of "$1")"; prefix="${prefix%@*}"
+  cut -d/ -f1-2 <<< "$prefix"
+  return 0
+}
+
+# emit_ref_for <template> <repo> -> the channel ref a (re)deployed stub in <repo>
+# should pin (#657 F5). For a ring-managed reusable it is the repo's tier channel,
+# major-scoped `v<M>-<tier>` when the agent has a release, else the bare `<tier>`
+# form. Empty for a non-ring template (deployed verbatim). Requires GH_TOKEN.
+emit_ref_for() {
+  local template="$1" repo="$2" base host major
+  base="$(reusable_base_of "$template")"
+  [[ -z "$base" ]] && return 0
+  ring_is_ring_reusable "$base" || return 0
+  host="$(reusable_host_of "$template")"
+  major="$(ring_host_current_major "$host" "$base")"
+  ring_canonical_ref "$base" "$repo" "$major"
+  return 0
 }
 
 # Build the PR body for a batched stub deployment (one PR per repo).
@@ -207,9 +255,12 @@ deploy_repo() {
     if [[ "$opts_in_any" == "false" ]]; then skip "$repo (exempt)"; return; fi
   fi
 
-  # Collect the drifted stubs for this repo (path/template pairs + names).
-  local -a paths=() templates=() names=()
-  local workflow template target_path raw existing_sha existing_content
+  # Collect the drifted stubs for this repo (path/template pairs + names). For
+  # ring-managed reusables the deployed template is REWRITTEN to pin the repo's
+  # tier channel (major-scoped `v<M>-<tier>` when the agent has a release) — the
+  # emit ref (#657 F5). Rewritten templates land in temp files cleaned up below.
+  local -a paths=() templates=() names=() emits=() tmpfiles=()
+  local workflow template target_path raw existing_sha existing_content emit deploy_template base
   for workflow in "${WORKFLOWS[@]}"; do
     if is_skipped_repo "$repo" && ! repo_opts_into "$repo" "$workflow"; then
       skip "$repo/$workflow (exempt)"
@@ -228,7 +279,15 @@ deploy_repo() {
       skip "$repo/$target_path already compliant"
       continue
     fi
-    paths+=("$target_path"); templates+=("$template"); names+=("$workflow")
+    emit="$(emit_ref_for "$template" "$repo")"
+    deploy_template="$template"
+    if [[ -n "$emit" ]] && [[ "$DRY_RUN" != "true" ]]; then
+      base="$(reusable_base_of "$template")"
+      deploy_template="$(mktemp)"
+      ring_repin_uses "$base" "$emit" < "$template" > "$deploy_template"
+      tmpfiles+=("$deploy_template")
+    fi
+    paths+=("$target_path"); templates+=("$deploy_template"); names+=("$workflow"); emits+=("$emit")
   done
 
   [[ "${#names[@]}" -eq 0 ]] && return  # nothing drifted for this repo
@@ -239,6 +298,10 @@ deploy_repo() {
   local title="chore: sync ${n} org-standard workflow stub(s) from ${ORG}/.github"
 
   if [[ "$DRY_RUN" == "true" ]]; then
+    local i
+    for (( i = 0; i < n; i++ )); do
+      [[ -n "${emits[i]}" ]] && dry "$repo/${names[i]} would pin @${emits[i]}"
+    done
     dry "Would open PR for $repo (branch $branch) — ${n} stub(s): $list"
     return
   fi
@@ -250,6 +313,8 @@ deploy_repo() {
   local body outcome
   body=$(batch_pr_body "${names[@]}")
   outcome=$(sd_deploy_files_via_pr "$ORG/$repo" "$branch" "$SYNC_LABEL" "$title" "$body" "${filepairs[@]}") || true
+
+  [[ "${#tmpfiles[@]}" -gt 0 ]] && rm -f "${tmpfiles[@]}"
 
   case "$outcome" in
     "OPENED "*)       ok   "$repo — opened ${outcome#OPENED } (${n} stub(s): $list)" ;;

--- a/scripts/lib/ring-pins.sh
+++ b/scripts/lib/ring-pins.sh
@@ -149,7 +149,10 @@ ring_host_current_major() {
   local host="$1" base="$2" refs
   refs="$(gh api "repos/${host}/git/matching-refs/tags/${base}/v" \
             --jq '.[]?.ref' 2>/dev/null \
-          | sed -n "s#^refs/tags/${base}/v##p")" || return 0
+          | sed -n "s#^refs/tags/${base}/v##p")" || {
+    echo "Warning: failed to fetch matching refs for ${host}/${base}" >&2
+    return 0
+  }
   # shellcheck disable=SC2086
   ring_highest_major $refs
   return 0

--- a/scripts/lib/ring-pins.sh
+++ b/scripts/lib/ring-pins.sh
@@ -120,3 +120,59 @@ ring_legacy_csv() {
   ring_accepted_refs "$1" "$2" | tail -n +2 | paste -sd, -
   return 0
 }
+
+# ══ major-scoped channels tooling — F5 shared helpers (epic #657) ══════════════
+
+# ring_highest_major <version>... -> the MAJOR of the highest strict semver among
+# the arguments, or empty if none is a valid `[v]X.Y.Z`. Tolerates a leading `v`
+# on a token; non-semver tokens are ignored. Pure; always returns 0.
+ring_highest_major() {
+  local v major best=""
+  for v in "$@"; do
+    v="${v#v}"
+    [[ "$v" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]] || continue
+    major="${BASH_REMATCH[1]}"
+    if [ -z "$best" ] || [ "$major" -gt "$best" ]; then
+      best="$major"
+    fi
+  done
+  [ -n "$best" ] && printf '%s' "$best"
+  return 0
+}
+
+# ring_host_current_major <host-repo> <channel-base> -> the current major line for
+# an agent, derived from its release tags `<base>/vX.Y.Z` on the host repo, or
+# empty if the agent has no release (so callers fall back to the bare-tier form).
+# gh-backed: reads matching-refs for `<base>/v` and feeds the semver tokens to
+# ring_highest_major. Requires GH_TOKEN in the environment.
+ring_host_current_major() {
+  local host="$1" base="$2" refs
+  refs="$(gh api "repos/${host}/git/matching-refs/tags/${base}/v" \
+            --jq '.[]?.ref' 2>/dev/null \
+          | sed -n "s#^refs/tags/${base}/v##p")" || return 0
+  # shellcheck disable=SC2086
+  ring_highest_major $refs
+  return 0
+}
+
+# ring_repin_uses <channel-base> <newref> -> rewrite a workflow stub read on stdin
+# so its reusable `uses:` ref (and any matching `agent_ref:`) points at <newref>.
+# Only lines referencing THIS agent's reusable are touched; the trailing comment
+# on a `uses:` line is preserved. Pure (sed only).
+ring_repin_uses() {
+  local base="$1" newref="$2"
+  sed -E \
+    -e "s#^([[:space:]]*uses:[[:space:]]*petry-projects/[^@[:space:]]*/${base}-reusable\.yml)@[^[:space:]]+#\1@${newref}#" \
+    -e "s#^([[:space:]]*agent_ref:[[:space:]]*[\"']?)${base}/[^\"'[:space:]]+#\1${newref}#"
+  return 0
+}
+
+# ring_vform_tier_aligned <pinned-ref> <channel-base> <repo> -> 0 iff <pinned-ref>
+# is a major-scoped v-form `<base>/v<M>-<tier>` whose tier matches <repo>'s ring
+# tier (any major). A bare-tier ref (no `v<M>-`) or a wrong-tier v-form is not
+# aligned. Pure.
+ring_vform_tier_aligned() {
+  local ref="$1" base="$2" repo="$3" tier
+  tier="$(ring_tier_for_repo "$repo")"
+  [[ "$ref" =~ ^${base}/v[0-9]+-${tier}$ ]]
+}

--- a/scripts/migrate-major-channels.sh
+++ b/scripts/migrate-major-channels.sh
@@ -55,8 +55,14 @@ _tag_exists() {
 # _tag_commit <host> <tag> -> the commit sha the tag resolves to (first field of
 # the ref object's sha), or empty if the tag does not exist.
 _tag_commit() {
-  local out
-  out="$(gh api "repos/$1/git/ref/tags/$2" --jq '.object.sha' 2>/dev/null)" || return 0
+  local host="$1" tag="$2" out
+  out="$(gh api "repos/${host}/git/ref/tags/${tag}" --jq '.object.sha' 2>&1)" || {
+    if <<< "$out" grep -q "404"; then
+      return 0
+    fi
+    echo "Error fetching tag commit for ${host}/${tag}: ${out}" >&2
+    return 1
+  }
   printf '%s' "${out%%[[:space:]]*}"
 }
 
@@ -73,8 +79,8 @@ _delete_tag_ref() {
 
 # ── registry helpers ──────────────────────────────────────────────────────────
 
-_agent_host()  { jq -r --arg a "$1" '.agents[$a].host'            "$CANARY_RINGS"; }
-_agent_tiers() { jq -r --arg a "$1" '.agents[$a].rings[].channel' "$CANARY_RINGS"; }
+_agent_host()  { jq -r --arg a "$1" '.agents[$a]?.host?'            "$CANARY_RINGS"; }
+_agent_tiers() { jq -r --arg a "$1" '.agents[$a]?.rings[]?.channel?' "$CANARY_RINGS"; }
 _agent_names() { jq -r '.agents | keys[]'                         "$CANARY_RINGS"; }
 
 # _enrolled_consumers <agent> -> the concrete repos enrolled in <agent>'s rings,
@@ -93,16 +99,22 @@ _enrolled_consumers() {
       '$org_infra') [ "${#org_infra[@]}" -gt 0 ] && printf '%s\n' "${org_infra[@]}" ;;
       *)            printf '%s\n' "$m" ;;
     esac
-  done < <(jq -r --arg a "$agent" '.agents[$a].rings[].members[]' "$CANARY_RINGS") | sort -u
+  done < <(jq -r --arg a "$agent" '.agents[$a]?.rings[]?.members[]?' "$CANARY_RINGS") | sort -u
 }
 
 # _consumer_pinned_ref <repo> <agent> -> the channel ref the repo's
 # .github/workflows/<agent>.yml stub pins the reusable at (e.g. `agent/ring1`), or
 # empty if the stub is missing / does not pin the agent.
 _consumer_pinned_ref() {
-  local repo="$1" agent="$2" content ref
-  content="$(gh api "repos/${repo}/contents/.github/workflows/${agent}.yml" 2>/dev/null \
-             | base64 -d 2>/dev/null)" || return 0
+  local repo="$1" agent="$2" response content ref
+  response="$(gh api "repos/${repo}/contents/.github/workflows/${agent}.yml" 2>&1)" || {
+    if <<< "$response" grep -q "404"; then
+      return 0
+    fi
+    echo "Error fetching workflow for ${repo}: ${response}" >&2
+    return 1
+  }
+  content="$(jq -r '.content // empty' <<< "$response" | base64 -d 2>/dev/null)"
   ref="$(grep -oE "@${agent}/[^[:space:]\"']+" <<< "$content" | head -1)"
   printf '%s' "${ref#@}"
 }
@@ -120,6 +132,7 @@ _is_bare_tier_ref() {
 create_vtags() {
   local agent="$1" host major tier bare vtag commit
   host="$(_agent_host "$agent")"
+  [[ -z "$host" ]] && { log "skip $agent — host not found"; return 0; }
   major="$(ring_host_current_major "$host" "$agent")"
   if [ -z "$major" ]; then
     log "skip $agent — no release major (nothing to major-scope)"
@@ -208,9 +221,19 @@ main() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --dry-run)     DRY_RUN=true; shift ;;
-      --agent)       agent_filter="$2"; shift 2 ;;
+      --agent)
+        if [[ $# -lt 2 ]]; then
+          err "--agent requires an argument"
+          exit 1
+        fi
+        agent_filter="$2"; shift 2 ;;
       --emit-repins) mode="emit-repins"; shift ;;
-      --retire-bare) mode="retire-bare"; retire_agent="$2"; shift 2 ;;
+      --retire-bare)
+        if [[ $# -lt 2 ]]; then
+          err "--retire-bare requires an argument"
+          exit 1
+        fi
+        mode="retire-bare"; retire_agent="$2"; shift 2 ;;
       -h|--help)     sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
       *) err "Unknown option: $1"; exit 1 ;;
     esac

--- a/scripts/migrate-major-channels.sh
+++ b/scripts/migrate-major-channels.sh
@@ -122,7 +122,11 @@ _consumer_pinned_ref() {
 # _is_bare_tier_ref <agent> <ref> -> 0 if <ref> is a bare `<agent>/<tier>` pin
 # (i.e. carries no `v<M>-` major scope).
 _is_bare_tier_ref() {
-  [[ "$2" =~ ^$1/(next|ring0|ring1|stable)$ ]]
+  local agent="$1" ref="$2" tier
+  while IFS= read -r tier; do
+    [ "$ref" = "${agent}/${tier}" ] && return 0
+  done < <(_agent_tiers "$agent")
+  return 1
 }
 
 # ── operations ────────────────────────────────────────────────────────────────
@@ -173,7 +177,10 @@ emit_repins() {
   fi
   while IFS= read -r c; do
     [ -z "$c" ] && continue
-    ref="$(_consumer_pinned_ref "$c" "$agent")"
+    if ! ref="$(_consumer_pinned_ref "$c" "$agent")"; then
+      err "could not read ${c}/.github/workflows/${agent}.yml — aborting (fail-closed)"
+      return 1
+    fi
     [ -z "$ref" ] && continue
     if _is_bare_tier_ref "$agent" "$ref"; then
       tier="${ref##*/}"
@@ -187,10 +194,14 @@ emit_repins() {
 retire_bare() {
   local agent="$1" host c ref tier
   host="$(_agent_host "$agent")"
+  [[ -z "$host" ]] && { err "unknown agent: $agent"; return 1; }
   local -a offenders=()
   while IFS= read -r c; do
     [ -z "$c" ] && continue
-    ref="$(_consumer_pinned_ref "$c" "$agent")"
+    if ! ref="$(_consumer_pinned_ref "$c" "$agent")"; then
+      err "could not read ${c}/.github/workflows/${agent}.yml — aborting (fail-closed)"
+      return 1
+    fi
     [ -z "$ref" ] && continue
     if _is_bare_tier_ref "$agent" "$ref"; then
       offenders+=("${c} (@${ref})")
@@ -234,7 +245,7 @@ main() {
           exit 1
         fi
         mode="retire-bare"; retire_agent="$2"; shift 2 ;;
-      -h|--help)     sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+      -h|--help)     sed -n '2,34p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
       *) err "Unknown option: $1"; exit 1 ;;
     esac
   done

--- a/scripts/migrate-major-channels.sh
+++ b/scripts/migrate-major-channels.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# migrate-major-channels.sh — tooling to roll the canary-ring fleet from the bare
+# `<agent>/<tier>` channel tags onto the major-scoped `<agent>/v<M>-<tier>` form
+# (major-scoped-channels epic #657, Phase F5). This script is TOOLING ONLY: it is
+# DRY_RUN-aware and, when it mutates, does so exclusively through the gh Git-refs
+# API under an App token — it NEVER direct-pushes and NEVER force-moves a tag.
+#
+# Three operations (default = create):
+#   (default)          For every ring tier of each agent, create
+#                      `<agent>/v<M>-<tier>` pointing at the SAME commit as the
+#                      bare `<agent>/<tier>` tag. Idempotent: a v-tag that already
+#                      exists is skipped. <M> is the agent's current release major
+#                      (from its `<agent>/vX.Y.Z` release tags on the host repo);
+#                      an agent with no release is skipped (nothing to major-scope).
+#   --emit-repins      List the enrolled-consumer stubs still pinned to a bare tier
+#                      and the `v<M>-<tier>` ref each should be re-pinned to. Read
+#                      only — never edits a consumer (deploy-standard-workflows.sh
+#                      owns the re-pin PRs).
+#   --retire-bare <a>  Delete the bare `<agent>/<tier>` tags — but ONLY once no
+#                      enrolled consumer still pins a bare tier. If any does, it
+#                      REFUSES (non-zero) and names the offenders, deleting nothing.
+#
+# Options:
+#   --dry-run          Print intended mutations without performing them. Also
+#                      honored via the DRY_RUN env var (DRY_RUN=true).
+#   --agent <name>     Restrict create/--emit-repins to a single agent.
+#   --retire-bare <a>  Run the guarded bare-tag retirement for agent <a>.
+#
+# Registry: CANARY_RINGS (default standards/canary-rings.json) — the same ring
+# registry the canary-rollout engine reads.
+#
+# Requirements: GH_TOKEN (App token) with contents+ refs scope on the host and the
+# enrolled consumer repos; jq.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=scripts/lib/ring-pins.sh
+source "$SCRIPT_DIR/lib/ring-pins.sh"
+
+CANARY_RINGS="${CANARY_RINGS:-$REPO_ROOT/standards/canary-rings.json}"
+DRY_RUN="${DRY_RUN:-false}"
+
+log()  { echo "[migrate] $*"; }
+err()  { echo "[migrate] ERROR $*" >&2; }
+
+# ── gh Git-refs wrappers ──────────────────────────────────────────────────────
+
+# _tag_exists <host> <tag> -> 0 if refs/tags/<tag> exists on <host>.
+_tag_exists() {
+  gh api "repos/$1/git/ref/tags/$2" >/dev/null 2>&1
+}
+
+# _tag_commit <host> <tag> -> the commit sha the tag resolves to (first field of
+# the ref object's sha), or empty if the tag does not exist.
+_tag_commit() {
+  local out
+  out="$(gh api "repos/$1/git/ref/tags/$2" --jq '.object.sha' 2>/dev/null)" || return 0
+  printf '%s' "${out%%[[:space:]]*}"
+}
+
+# _create_tag_ref <host> <tag> <sha> -> create refs/tags/<tag> at <sha> (POST).
+_create_tag_ref() {
+  gh api --method POST "repos/$1/git/refs" \
+    -f "ref=refs/tags/$2" -f "sha=$3" >/dev/null
+}
+
+# _delete_tag_ref <host> <tag> -> delete refs/tags/<tag> (DELETE).
+_delete_tag_ref() {
+  gh api --method DELETE "repos/$1/git/refs/tags/$2" >/dev/null
+}
+
+# ── registry helpers ──────────────────────────────────────────────────────────
+
+_agent_host()  { jq -r --arg a "$1" '.agents[$a].host'            "$CANARY_RINGS"; }
+_agent_tiers() { jq -r --arg a "$1" '.agents[$a].rings[].channel' "$CANARY_RINGS"; }
+_agent_names() { jq -r '.agents | keys[]'                         "$CANARY_RINGS"; }
+
+# _enrolled_consumers <agent> -> the concrete repos enrolled in <agent>'s rings,
+# expanding the `$host` and `$org_infra` member tokens. The `*` fleet wildcard is
+# not enumerable and is skipped (bare retirement only guards the explicitly
+# enrolled canaries).
+_enrolled_consumers() {
+  local agent="$1" host m
+  host="$(_agent_host "$agent")"
+  local -a org_infra=()
+  mapfile -t org_infra < <(jq -r '.org_infra_repos[]?' "$CANARY_RINGS")
+  while IFS= read -r m; do
+    case "$m" in
+      '*')          ;;
+      '$host')      printf '%s\n' "$host" ;;
+      '$org_infra') [ "${#org_infra[@]}" -gt 0 ] && printf '%s\n' "${org_infra[@]}" ;;
+      *)            printf '%s\n' "$m" ;;
+    esac
+  done < <(jq -r --arg a "$agent" '.agents[$a].rings[].members[]' "$CANARY_RINGS") | sort -u
+}
+
+# _consumer_pinned_ref <repo> <agent> -> the channel ref the repo's
+# .github/workflows/<agent>.yml stub pins the reusable at (e.g. `agent/ring1`), or
+# empty if the stub is missing / does not pin the agent.
+_consumer_pinned_ref() {
+  local repo="$1" agent="$2" content ref
+  content="$(gh api "repos/${repo}/contents/.github/workflows/${agent}.yml" 2>/dev/null \
+             | base64 -d 2>/dev/null)" || return 0
+  ref="$(grep -oE "@${agent}/[^[:space:]\"']+" <<< "$content" | head -1)"
+  printf '%s' "${ref#@}"
+}
+
+# _is_bare_tier_ref <agent> <ref> -> 0 if <ref> is a bare `<agent>/<tier>` pin
+# (i.e. carries no `v<M>-` major scope).
+_is_bare_tier_ref() {
+  [[ "$2" =~ ^$1/(next|ring0|ring1|stable)$ ]]
+}
+
+# ── operations ────────────────────────────────────────────────────────────────
+
+# create_vtags <agent>: cut <agent>/v<M>-<tier> at the bare tier tag's commit for
+# every ring tier, idempotent.
+create_vtags() {
+  local agent="$1" host major tier bare vtag commit
+  host="$(_agent_host "$agent")"
+  major="$(ring_host_current_major "$host" "$agent")"
+  if [ -z "$major" ]; then
+    log "skip $agent — no release major (nothing to major-scope)"
+    return 0
+  fi
+  log "$agent — major line v${major} (host $host)"
+  while IFS= read -r tier; do
+    [ -z "$tier" ] && continue
+    bare="${agent}/${tier}"
+    vtag="${agent}/v${major}-${tier}"
+    if _tag_exists "$host" "$vtag"; then
+      log "skip ${vtag} — already exists"
+      continue
+    fi
+    commit="$(_tag_commit "$host" "$bare")"
+    if [ -z "$commit" ]; then
+      log "skip ${vtag} — bare tag ${bare} not found"
+      continue
+    fi
+    if [ "$DRY_RUN" = "true" ]; then
+      log "would create ${vtag} at ${commit} (same commit as ${bare})"
+    else
+      _create_tag_ref "$host" "$vtag" "$commit"
+      log "created ${vtag} at ${commit} (same commit as ${bare})"
+    fi
+  done < <(_agent_tiers "$agent")
+}
+
+# emit_repins <agent>: list enrolled consumers still on a bare tier and the v-form
+# they should move to. Read only.
+emit_repins() {
+  local agent="$1" host major c ref tier
+  host="$(_agent_host "$agent")"
+  major="$(ring_host_current_major "$host" "$agent")"
+  if [ -z "$major" ]; then
+    log "skip $agent — no release major"
+    return 0
+  fi
+  while IFS= read -r c; do
+    [ -z "$c" ] && continue
+    ref="$(_consumer_pinned_ref "$c" "$agent")"
+    [ -z "$ref" ] && continue
+    if _is_bare_tier_ref "$agent" "$ref"; then
+      tier="${ref##*/}"
+      log "repin ${c}: @${ref} -> @${agent}/v${major}-${tier}"
+    fi
+  done < <(_enrolled_consumers "$agent")
+}
+
+# retire_bare <agent>: delete the bare tier tags, but only once no enrolled
+# consumer still pins a bare tier. Refuses (non-zero) otherwise.
+retire_bare() {
+  local agent="$1" host c ref tier
+  host="$(_agent_host "$agent")"
+  local -a offenders=()
+  while IFS= read -r c; do
+    [ -z "$c" ] && continue
+    ref="$(_consumer_pinned_ref "$c" "$agent")"
+    [ -z "$ref" ] && continue
+    if _is_bare_tier_ref "$agent" "$ref"; then
+      offenders+=("${c} (@${ref})")
+    fi
+  done < <(_enrolled_consumers "$agent")
+
+  if [ "${#offenders[@]}" -gt 0 ]; then
+    err "refuse to retire bare ${agent} tiers — still pinned by an enrolled consumer:"
+    printf '[migrate]   - %s\n' "${offenders[@]}" >&2
+    return 1
+  fi
+
+  while IFS= read -r tier; do
+    [ -z "$tier" ] && continue
+    if [ "$DRY_RUN" = "true" ]; then
+      log "would delete ${agent}/${tier}"
+    else
+      _delete_tag_ref "$host" "${agent}/${tier}"
+      log "deleted ${agent}/${tier}"
+    fi
+  done < <(_agent_tiers "$agent")
+}
+
+# ── entrypoint ────────────────────────────────────────────────────────────────
+
+main() {
+  local mode="create" agent_filter="" retire_agent=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dry-run)     DRY_RUN=true; shift ;;
+      --agent)       agent_filter="$2"; shift 2 ;;
+      --emit-repins) mode="emit-repins"; shift ;;
+      --retire-bare) mode="retire-bare"; retire_agent="$2"; shift 2 ;;
+      -h|--help)     sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+      *) err "Unknown option: $1"; exit 1 ;;
+    esac
+  done
+
+  [ "$DRY_RUN" = "true" ] && log "DRY RUN — no tags will be created or deleted"
+
+  if [ ! -f "$CANARY_RINGS" ]; then
+    err "canary-rings registry not found: $CANARY_RINGS"
+    exit 1
+  fi
+
+  case "$mode" in
+    retire-bare)
+      retire_bare "$retire_agent"
+      ;;
+    emit-repins)
+      if [ -n "$agent_filter" ]; then
+        emit_repins "$agent_filter"
+      else
+        while IFS= read -r a; do emit_repins "$a"; done < <(_agent_names)
+      fi
+      ;;
+    create)
+      if [ -n "$agent_filter" ]; then
+        create_vtags "$agent_filter"
+      else
+        while IFS= read -r a; do create_vtags "$a"; done < <(_agent_names)
+      fi
+      ;;
+  esac
+}
+
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+  main "$@"
+fi

--- a/test/scripts/deploy-standard-workflows/emit-vform.bats
+++ b/test/scripts/deploy-standard-workflows/emit-vform.bats
@@ -71,7 +71,7 @@ refs/tags/auto-rebase/v1.0.0"
   run env GH_TOKEN=x bash "$SCRIPT" --dry-run --repo markets --workflow auto-rebase.yml
   [ "$status" -eq 0 ]
   echo "$output" | grep -qF '@auto-rebase/stable'
-  echo "$output" | grep -vqF '@auto-rebase/v'
+  ! echo "$output" | grep -qF '@auto-rebase/v'
 }
 
 @test "drift check treats a tier-correct v<M>-tier stub as compliant (no PR)" {
@@ -81,7 +81,7 @@ refs/tags/auto-rebase/v1.0.0"
   run env GH_TOKEN=x bash "$SCRIPT" --dry-run --repo TalkTerm --workflow auto-rebase.yml
   [ "$status" -eq 0 ]
   echo "$output" | grep -q 'already compliant'
-  echo "$output" | grep -vq 'Would open PR'
+  ! echo "$output" | grep -q 'Would open PR'
 }
 
 @test "drift check still flags a WRONG-tier v<M>-tier stub" {

--- a/test/scripts/deploy-standard-workflows/emit-vform.bats
+++ b/test/scripts/deploy-standard-workflows/emit-vform.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+# F5 (epic #657) tests for scripts/deploy-standard-workflows.sh:
+#   - a (re)deployed RING stub is pinned to the major-scoped `@<agent>/v<M>-<tier>`
+#     form when the agent has a release; the bare `@<agent>/<tier>` form otherwise.
+#   - the deploy sweep's drift check (is_already_compliant) honors the `v<M>-` prefix
+#     the same way compliance-audit does: a tier-correct v-form stub is compliant,
+#     a wrong-tier v-form is still drift.
+#
+# All runs are --dry-run (no mutating gh calls) against a single --repo/--workflow so
+# they are deterministic. A fake `gh` returns the reusable's release tags (for the
+# major derivation) and the target repo's existing stub content.
+
+setup() {
+  TT_TMP="$(mktemp -d)"
+  REPO_ROOT="$(cd -- "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  SCRIPT="${REPO_ROOT}/scripts/deploy-standard-workflows.sh"
+}
+
+teardown() { rm -rf "$TT_TMP"; }
+
+# Install a fake gh.
+#   GH_RELEASE_REFS  newline-separated `refs/tags/<agent>/vX.Y.Z` for matching-refs
+#                    (unset/empty → the agent has no release → bare form expected).
+#   GH_CONTENT_B64   base64 of the existing stub (unset → contents 404 = missing stub).
+install_gh_stub() {
+  local bin="${TT_TMP}/bin"
+  mkdir -p "$bin"
+  cat > "$bin/gh" <<'STUB'
+#!/usr/bin/env bash
+if [ "${1:-}" = "api" ]; then
+  case "$2" in
+    *matching-refs/tags/*)
+      [ -n "${GH_RELEASE_REFS:-}" ] && printf '%s\n' "${GH_RELEASE_REFS}"
+      exit 0 ;;
+    *contents*)
+      if [ -n "${GH_CONTENT_B64:-}" ]; then
+        printf '{"sha":"abc123","content":"%s"}' "$GH_CONTENT_B64"
+        exit 0
+      fi
+      exit 1 ;;   # simulate 404 — stub absent
+  esac
+fi
+exit 0
+STUB
+  chmod +x "$bin/gh"
+  PATH="${bin}:${PATH}"; export PATH
+}
+
+stub_pinning() {  # <ref> → base64 of a minimal auto-rebase stub pinning the reusable at <ref>
+  local body="jobs:
+  auto-rebase:
+    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@$1
+    secrets: inherit"
+  base64 -w 0 <<<"$body" 2>/dev/null || base64 -b 0 <<<"$body"
+}
+
+@test "emits @<agent>/v<M>-<tier> when the reusable has a release" {
+  export GH_RELEASE_REFS="refs/tags/auto-rebase/v2.3.1
+refs/tags/auto-rebase/v1.0.0"
+  install_gh_stub   # no GH_CONTENT_B64 → missing stub → deploy plans a (re)pin
+  run env GH_TOKEN=x bash "$SCRIPT" --dry-run --repo markets --workflow auto-rebase.yml
+  [ "$status" -eq 0 ]
+  # markets is a stable-tier repo → v2 major line → @auto-rebase/v2-stable
+  echo "$output" | grep -qF '@auto-rebase/v2-stable'
+  echo "$output" | grep -qE 'Would open PR for markets .* auto-rebase.yml'
+}
+
+@test "emits the bare @<agent>/<tier> form when the reusable has no release" {
+  unset GH_RELEASE_REFS   # matching-refs empty → no major
+  install_gh_stub
+  run env GH_TOKEN=x bash "$SCRIPT" --dry-run --repo markets --workflow auto-rebase.yml
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qF '@auto-rebase/stable'
+  echo "$output" | grep -vqF '@auto-rebase/v'
+}
+
+@test "drift check treats a tier-correct v<M>-tier stub as compliant (no PR)" {
+  export GH_RELEASE_REFS="refs/tags/auto-rebase/v2.0.0"
+  GH_CONTENT_B64="$(stub_pinning auto-rebase/v2-ring1)"; export GH_CONTENT_B64
+  install_gh_stub
+  run env GH_TOKEN=x bash "$SCRIPT" --dry-run --repo TalkTerm --workflow auto-rebase.yml
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'already compliant'
+  echo "$output" | grep -vq 'Would open PR'
+}
+
+@test "drift check still flags a WRONG-tier v<M>-tier stub" {
+  export GH_RELEASE_REFS="refs/tags/auto-rebase/v2.0.0"
+  # v2-ring0 on TalkTerm (a ring1 repo) is the wrong tier → drift.
+  GH_CONTENT_B64="$(stub_pinning auto-rebase/v2-ring0)"; export GH_CONTENT_B64
+  install_gh_stub
+  run env GH_TOKEN=x bash "$SCRIPT" --dry-run --repo TalkTerm --workflow auto-rebase.yml
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qE 'Would open PR for TalkTerm .* auto-rebase.yml'
+}

--- a/test/scripts/deploy-standard-workflows/emit-vform.bats
+++ b/test/scripts/deploy-standard-workflows/emit-vform.bats
@@ -11,7 +11,7 @@
 # major derivation) and the target repo's existing stub content.
 
 setup() {
-  TT_TMP="$(mktemp -d)"
+  TT_TMP="$(mktemp -d "$BATS_TEST_TMPDIR/stub.XXXXXX")"
   REPO_ROOT="$(cd -- "${BATS_TEST_DIRNAME}/../../.." && pwd)"
   SCRIPT="${REPO_ROOT}/scripts/deploy-standard-workflows.sh"
 }

--- a/test/scripts/lib/ring-pins.bats
+++ b/test/scripts/lib/ring-pins.bats
@@ -78,3 +78,48 @@ setup() {
   [[ "$output" != *"v1"* ]]
   [[ "$output" != *"v2"* ]]
 }
+
+# ══ major-scoped channels tooling: F5 shared helpers (epic #657) ═══════════════
+
+@test "ring_highest_major: picks the MAJOR of the highest strict semver" {
+  [ "$(ring_highest_major 1.2.3 2.0.1 1.9.9)" = "2" ]
+  [ "$(ring_highest_major 10.0.0 9.9.9)" = "10" ]
+  # tolerate a leading v on the token
+  [ "$(ring_highest_major v3.1.0 v2.9.9)" = "3" ]
+}
+
+@test "ring_highest_major: ignores non-semver tokens; empty when none valid" {
+  [ "$(ring_highest_major 2.0.0 not-a-version 1.0.0)" = "2" ]
+  [ -z "$(ring_highest_major)" ]
+  [ -z "$(ring_highest_major 2-next latest '')" ]
+}
+
+@test "ring_repin_uses: rewrites the reusable uses: ref, preserving the trailing comment" {
+  local stub="jobs:
+  auto-rebase:
+    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@auto-rebase/stable  # NOSONAR keep
+    secrets: inherit"
+  run bash -c 'source "'"$REPO_ROOT"'/scripts/lib/ring-pins.sh"; ring_repin_uses auto-rebase auto-rebase/v2-stable <<<"$1"' _ "$stub"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"auto-rebase-reusable.yml@auto-rebase/v2-stable  # NOSONAR keep"* ]]
+  [[ "$output" != *"@auto-rebase/stable "* ]]
+}
+
+@test "ring_repin_uses: also rewrites a matching agent_ref (dev-lead stub)" {
+  local stub="    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable
+    with:
+      agent_ref: dev-lead/stable"
+  run bash -c 'source "'"$REPO_ROOT"'/scripts/lib/ring-pins.sh"; ring_repin_uses dev-lead dev-lead/v4-ring1 <<<"$1"' _ "$stub"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dev-lead-reusable.yml@dev-lead/v4-ring1"* ]]
+  [[ "$output" == *"agent_ref: dev-lead/v4-ring1"* ]]
+}
+
+@test "ring_vform_tier_aligned: true only for the repo's tier v-form (any major)" {
+  ring_vform_tier_aligned auto-rebase/v2-ring1 auto-rebase TalkTerm    # ring1 repo
+  ring_vform_tier_aligned auto-rebase/v9-stable auto-rebase markets    # stable repo
+  # wrong tier for the repo → not aligned
+  ! ring_vform_tier_aligned auto-rebase/v2-ring0 auto-rebase TalkTerm
+  # bare tier (no v<M>-) → not a v-form
+  ! ring_vform_tier_aligned auto-rebase/ring1 auto-rebase TalkTerm
+}

--- a/test/scripts/migrate-major-channels/migrate.bats
+++ b/test/scripts/migrate-major-channels/migrate.bats
@@ -98,7 +98,7 @@ STUB
   [ "$status" -eq 0 ]
   echo "$output" | grep -qiE 'foo/v2-stable.*(exist|skip)'
   # nothing planned for creation since all exist
-  echo "$output" | grep -viq 'would create'
+  ! grep -qi 'would create' <<< "$output"
 }
 
 @test "--retire-bare refuses while an enrolled consumer still pins bare" {
@@ -121,4 +121,14 @@ STUB
   [ "$status" -eq 0 ]
   echo "$output" | grep -qiE 'would delete .*foo/(stable|ring1)'
   ! grep -qE 'DELETE .*git/refs' "$GH_CALLS"
+}
+
+@test "--emit-repins lists enrolled consumers still on a bare tier with the v-form to move to" {
+  export FOO_MAJOR_REFS="refs/tags/foo/v2.1.0"
+  export CONSUMER_REF="foo/ring1"   # consumerX still on the bare tier
+  install_gh_stub
+  run env GH_TOKEN=x CANARY_RINGS="$RINGS" bash "$SCRIPT" --emit-repins --agent foo
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qF 'consumerX'
+  echo "$output" | grep -qF 'foo/v2-ring1'
 }

--- a/test/scripts/migrate-major-channels/migrate.bats
+++ b/test/scripts/migrate-major-channels/migrate.bats
@@ -1,0 +1,123 @@
+#!/usr/bin/env bats
+# F5 (epic #657) tests for scripts/migrate-major-channels.sh — the DRY_RUN-aware,
+# App-token gh-api migration helper (never direct-push):
+#   (a) create <agent>/v<M>-<tier> for every ring tier at the SAME commit as the
+#       bare <agent>/<tier>, idempotent (skip if the v-tag already exists);
+#   (b) --retire-bare <agent> deletes the bare-tier tags ONLY when no enrolled
+#       consumer still pins them — it refuses otherwise.
+#
+# A fake `gh` supplies the reusable's release tags (for the major), the bare-tier
+# tag commits, v-tag existence, and consumer stub contents. Mutating calls are
+# logged to GH_CALLS so a DRY_RUN can be proven side-effect-free.
+
+setup() {
+  TT_TMP="$(mktemp -d)"
+  REPO_ROOT="$(cd -- "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  SCRIPT="${REPO_ROOT}/scripts/migrate-major-channels.sh"
+  GH_CALLS="${TT_TMP}/gh-calls.log"; export GH_CALLS
+  : > "$GH_CALLS"
+  RINGS="${TT_TMP}/canary-rings.json"; export RINGS
+  cat > "$RINGS" <<'JSON'
+{
+  "org_infra_repos": ["petry-projects/.github", "petry-projects/.github-private"],
+  "agents": {
+    "foo": {
+      "host": "petry-projects/repoA",
+      "reusable": ".github/workflows/foo-reusable.yml",
+      "rings": [
+        { "channel": "next",   "order": 0, "members": ["$host"] },
+        { "channel": "ring0",  "order": 1, "members": ["$org_infra"] },
+        { "channel": "ring1",  "order": 2, "members": ["petry-projects/consumerX"] },
+        { "channel": "stable", "order": 3, "members": ["*"] }
+      ]
+    }
+  }
+}
+JSON
+}
+
+teardown() { rm -rf "$TT_TMP"; }
+
+# Fake gh. Env knobs:
+#   FOO_MAJOR_REFS  matching-refs output for foo's release tags (empty → no major)
+#   VTAG_EXISTS     if "true", every foo/v<M>-<tier> lookup reports the tag exists
+#   CONSUMER_REF    the ref the consumerX stub pins (e.g. foo/ring1 or foo/v2-ring1)
+install_gh_stub() {
+  local bin="${TT_TMP}/bin"; mkdir -p "$bin"
+  cat > "$bin/gh" <<'STUB'
+#!/usr/bin/env bash
+{ printf 'gh'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >> "$GH_CALLS"
+[ "${1:-}" = "api" ] || { exit 0; }
+# find the path arg (first non-flag after 'api')
+path=""
+for a in "$@"; do case "$a" in -*|api) ;; *) path="$a"; break ;; esac; done
+case "$path" in
+  *matching-refs/tags/foo/v*)
+    [ -n "${FOO_MAJOR_REFS:-}" ] && printf '%s\n' "${FOO_MAJOR_REFS}"
+    exit 0 ;;
+  *git/ref/tags/foo/v*)                 # v-tag existence / commit lookup
+    if [ "${VTAG_EXISTS:-false}" = "true" ]; then
+      printf 'ccccccccccccccccccccccccccccccccccccccc\tcommit\n'; exit 0
+    fi
+    exit 1 ;;                           # v-tag absent
+  *git/ref/tags/foo/*)                  # bare-tier tag → resolves to a commit
+    printf 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\tcommit\n'; exit 0 ;;
+  *contents/.github/workflows/foo.yml*) # consumer stub content (base64)
+    body="    uses: petry-projects/.github/.github/workflows/foo-reusable.yml@${CONSUMER_REF:-foo/ring1}"
+    printf '%s' "$(printf '%s' "$body" | base64 | tr -d '\n')"
+    exit 0 ;;
+  *git/refs*) exit 0 ;;                 # create/delete ref (mutating)
+esac
+exit 0
+STUB
+  chmod +x "$bin/gh"
+  PATH="${bin}:${PATH}"; export PATH
+}
+
+@test "DRY_RUN plans same-commit v-tag creation for every tier, no mutating calls" {
+  export FOO_MAJOR_REFS="refs/tags/foo/v2.1.0"
+  install_gh_stub
+  run env GH_TOKEN=x DRY_RUN=true CANARY_RINGS="$RINGS" bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  # all four tiers planned against the SAME bare commit (deadbeef…)
+  echo "$output" | grep -qF 'foo/v2-next'
+  echo "$output" | grep -qF 'foo/v2-ring0'
+  echo "$output" | grep -qF 'foo/v2-ring1'
+  echo "$output" | grep -qF 'foo/v2-stable'
+  echo "$output" | grep -qF 'deadbeefdeadbeef'
+  # DRY_RUN must not create any ref
+  ! grep -qE 'POST .*git/refs' "$GH_CALLS"
+}
+
+@test "idempotent — skips a tier whose v-tag already exists" {
+  export FOO_MAJOR_REFS="refs/tags/foo/v2.1.0"
+  export VTAG_EXISTS=true
+  install_gh_stub
+  run env GH_TOKEN=x DRY_RUN=true CANARY_RINGS="$RINGS" bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qiE 'foo/v2-stable.*(exist|skip)'
+  # nothing planned for creation since all exist
+  echo "$output" | grep -viq 'would create'
+}
+
+@test "--retire-bare refuses while an enrolled consumer still pins bare" {
+  export FOO_MAJOR_REFS="refs/tags/foo/v2.1.0"
+  export CONSUMER_REF="foo/ring1"   # consumerX still on the bare tier
+  install_gh_stub
+  run env GH_TOKEN=x DRY_RUN=true CANARY_RINGS="$RINGS" bash "$SCRIPT" --retire-bare foo
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -qi 'refuse'
+  echo "$output" | grep -qF 'consumerX'
+  # guard must not delete any tag
+  ! grep -qE 'DELETE .*git/refs' "$GH_CALLS"
+}
+
+@test "--retire-bare proceeds (dry-run) when no enrolled consumer pins bare" {
+  export FOO_MAJOR_REFS="refs/tags/foo/v2.1.0"
+  export CONSUMER_REF="foo/v2-ring1"   # consumerX already migrated to the v-form
+  install_gh_stub
+  run env GH_TOKEN=x DRY_RUN=true CANARY_RINGS="$RINGS" bash "$SCRIPT" --retire-bare foo
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qiE 'would delete .*foo/(stable|ring1)'
+  ! grep -qE 'DELETE .*git/refs' "$GH_CALLS"
+}

--- a/test/scripts/migrate-major-channels/migrate.bats
+++ b/test/scripts/migrate-major-channels/migrate.bats
@@ -11,7 +11,7 @@
 # logged to GH_CALLS so a DRY_RUN can be proven side-effect-free.
 
 setup() {
-  TT_TMP="$(mktemp -d)"
+  TT_TMP="$(mktemp -d "$BATS_TEST_TMPDIR/stub.XXXXXX")"
   REPO_ROOT="$(cd -- "${BATS_TEST_DIRNAME}/../../.." && pwd)"
   SCRIPT="${REPO_ROOT}/scripts/migrate-major-channels.sh"
   GH_CALLS="${TT_TMP}/gh-calls.log"; export GH_CALLS
@@ -62,9 +62,10 @@ case "$path" in
     exit 1 ;;                           # v-tag absent
   *git/ref/tags/foo/*)                  # bare-tier tag → resolves to a commit
     printf 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\tcommit\n'; exit 0 ;;
-  *contents/.github/workflows/foo.yml*) # consumer stub content (base64)
+  *contents/.github/workflows/foo.yml*) # consumer stub content as JSON
     body="    uses: petry-projects/.github/.github/workflows/foo-reusable.yml@${CONSUMER_REF:-foo/ring1}"
-    printf '%s' "$(printf '%s' "$body" | base64 | tr -d '\n')"
+    b64="$(printf '%s' "$body" | base64 | tr -d '\n')"
+    printf '{"content":"%s"}' "$b64"
     exit 0 ;;
   *git/refs*) exit 0 ;;                 # create/delete ref (mutating)
 esac


### PR DESCRIPTION
Closes #698

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tooling to migrate channel references to major-scoped version formats.
  - Added safeguards for retiring legacy channel tags when active references remain.
  - Deployment checks now select and apply tier-aligned channel references, with clearer dry-run output.

- **Tests**
  - Added automated coverage for migration, repinning, version detection, and safety checks.
  - Expanded deployment quality checks to validate shared channel-pinning behavior.

- **Chores**
  - Added automated workflow checks for migration scripts, including shell validation and test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->