### PR TITLE
fix(auto-rebase): surface skipped-but-conflicting PRs instead of silent rot (#711 Part C)

### DIFF
--- a/.github/workflows/auto-rebase-reusable.yml
+++ b/.github/workflows/auto-rebase-reusable.yml
@@ -150,6 +150,33 @@ jobs:
             fi
             if [[ "$ELIG" -ne 0 ]]; then
               echo "PR #$PR_NUMBER ($HEAD_REF) not eligible under '$ELIGIBILITY' (draft=$IS_DRAFT approved=$IS_APPROVED label=$HAS_LABEL) — skipping"
+
+              # Escalate silently-rotting PRs (issue #711): a skipped PR that is
+              # already CONFLICTING will never be updated by auto-rebase and cannot
+              # be approved while red (pr-review skips red PRs) — a deadlock that
+              # rots the PR for weeks with no signal. Surface it exactly once so a
+              # human can act. mergeable_state comes free from PR_JSON (no extra
+              # API call); it may be "unknown" until GitHub computes it, in which
+              # case a later run catches it. Idempotent via the stuck sentinel.
+              MERGE_STATE=$(jq -r '.mergeable_state // "unknown"' <<< "$PR_JSON")
+              if [[ "$MERGE_STATE" == "dirty" ]]; then
+                STUCK_SENTINEL="<!-- auto-rebase-stuck -->"
+                STUCK_POSTED=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+                  --json comments --jq "[.comments[] | select(.body | contains(\"$STUCK_SENTINEL\"))] | length")
+                if [[ "$STUCK_POSTED" -eq 0 ]]; then
+                  echo "  Conflicting + not review-ready — posting one-time manual-attention notice"
+                  STUCK_BODY="$STUCK_SENTINEL"
+                  STUCK_BODY+=$'\n'"**Auto-rebase is skipping this PR.** It has merge conflicts with \`$BASE_BRANCH\` but is not review-ready (draft=$IS_DRAFT, approved=$IS_APPROVED, \`$READY_LABEL\`=$HAS_LABEL), so auto-rebase will not update it — and it cannot be approved while red. Left alone it will not progress."
+                  STUCK_BODY+=$'\n\n'"To unblock, do one of:"
+                  STUCK_BODY+=$'\n'"- add the \`$READY_LABEL\` label (opts it into auto-rebase without an approval), or"
+                  STUCK_BODY+=$'\n'"- get it approved, or"
+                  STUCK_BODY+=$'\n'"- resolve manually:"
+                  STUCK_BODY+=$'\n'"\`\`\`"$'\n'"git fetch origin"$'\n'"git merge origin/$BASE_BRANCH"$'\n'"# resolve conflicts, then:"$'\n'"git add . && git commit && git push"$'\n'"\`\`\`"
+                  # Best-effort: a comment-side failure (e.g. the 2500-comment cap)
+                  # must not abort the step or starve other PRs — logged and swallowed.
+                  auto_rebase_post_comment_best_effort "$PR_NUMBER" "$REPO" "$STUCK_BODY"
+                fi
+              fi
               continue
             fi
 

--- a/.github/workflows/auto-rebase-reusable.yml
+++ b/.github/workflows/auto-rebase-reusable.yml
@@ -166,7 +166,10 @@ jobs:
                 if [[ "$STUCK_POSTED" -eq 0 ]]; then
                   echo "  Conflicting + not review-ready — posting one-time manual-attention notice"
                   STUCK_BODY="$STUCK_SENTINEL"
-                  STUCK_BODY+=$'\n'"**Auto-rebase is skipping this PR.** It has merge conflicts with \`$BASE_BRANCH\` but is not review-ready (draft=$IS_DRAFT, approved=$IS_APPROVED, \`$READY_LABEL\`=$HAS_LABEL), so auto-rebase will not update it — and it cannot be approved while red. Left alone it will not progress."
+                  STUCK_BODY+=$'\n'"**Auto-rebase is skipping this PR.** It has merge conflicts with \`$BASE_BRANCH\`"
+                  STUCK_BODY+=" but is not review-ready (draft=$IS_DRAFT, approved=$IS_APPROVED,"
+                  STUCK_BODY+=" \`$READY_LABEL\`=$HAS_LABEL), so auto-rebase will not update it — and it cannot be"
+                  STUCK_BODY+=" approved while red. Left alone it will not progress."
                   STUCK_BODY+=$'\n\n'"To unblock, do one of:"
                   STUCK_BODY+=$'\n'"- add the \`$READY_LABEL\` label (opts it into auto-rebase without an approval), or"
                   STUCK_BODY+=$'\n'"- get it approved, or"

--- a/.github/workflows/auto-rebase-reusable.yml
+++ b/.github/workflows/auto-rebase-reusable.yml
@@ -164,7 +164,7 @@ jobs:
               if [[ "$MERGE_STATE" == "dirty" ]]; then
                 STUCK_SENTINEL="<!-- auto-rebase-stuck -->"
                 STUCK_POSTED=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
-                  --json comments --jq "[.comments[] | select(.body | contains(\"$STUCK_SENTINEL\"))] | length")
+                  --json comments --jq "[.comments[] | select(.body | contains(\"$STUCK_SENTINEL\"))] | length" 2>/dev/null || echo "-1")
                 if [[ "$STUCK_POSTED" -eq 0 ]]; then
                   echo "  Conflicting + not review-ready — posting one-time manual-attention notice"
                   STUCK_BODY="$STUCK_SENTINEL"


### PR DESCRIPTION
## Problem
The auto-rebase `review-ready` eligibility gate (#465) skips any PR that isn't approved or ready-labeled. A skipped PR that is **also conflicting** is in a silent deadlock: auto-rebase won't update it, and `pr-review` won't approve a red PR — so it never progresses and emits **no signal**. This is the root of the fleet's weeks-stale `CONFLICTING + REVIEW_REQUIRED` cohort (full diagnosis: petry-projects/.github#711).

## Change
When a PR is skipped by the gate **and** `mergeable_state == "dirty"`, post a **one-time** manual-attention notice (idempotent via the `<!-- auto-rebase-stuck -->` sentinel) listing the three ways to unblock it:
- add the `auto-rebase:ready` label (opts it into auto-rebase without approval),
- get it approved, or
- resolve manually.

Design notes:
- **No extra API cost** — `mergeable_state` is read from the `PR_JSON` already fetched per PR.
- **No new permissions** — posting reuses `auto_rebase_post_comment_best_effort`, so a comment-cap/API failure is logged and swallowed (can't abort the step or starve other PRs, per #594).
- **Narrow + idempotent** — fires only for skipped **and** dirty PRs, once each. `mergeable_state` may be `unknown` until GitHub computes it; a later run catches those.

## Validation
- YAML parses; extracted run-script `bash -n` clean; shellcheck clean.
- `comments.bats` + `eligibility.bats` green (unchanged libs).

## Relationship
Complements **Part A** ([.github-private#1201](https://github.com/petry-projects/.github-private/pull/1201)) which labels new dev-lead PRs `auto-rebase:ready` so they never reach this deadlock. Part C is the safety net for PRs that slip through (e.g. legacy PRs, or ones at the comment cap). Remaining #711 follow-ups: standardize `auto-rebase:ready` in label management, and apply it in the other PR-opening agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Juznz5V6su81ffSND8fg7s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notifications for pull requests that are skipped while experiencing merge conflicts.
  * Provides guidance on resolving conflicts or meeting eligibility requirements.
  * Prevents duplicate notifications for the same stuck pull request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->