### PR TITLE
fix(migrate): retire-guard must scan agent_ref: inputs (regression that broke dev-lead) [#657]

### DIFF
--- a/scripts/migrate-major-channels.sh
+++ b/scripts/migrate-major-channels.sh
@@ -119,10 +119,12 @@ _consumer_pinned_ref() {
   # both the `uses:` pin (`@<agent>/<tier>`) AND the `agent_ref:` input
   # (`<agent>/<tier>`, no `@`) — the reusable checks out its tooling at agent_ref, so a
   # bare agent_ref keeps the bare tag load-bearing (retiring it broke dev-lead, #657).
-  {
-    grep -oE "@${agent}/[^[:space:]\"']+" <<< "$content" | sed 's/^@//'
-    grep -oE "agent_ref: *${agent}/[^[:space:]\"']+" <<< "$content" | sed -E 's/^agent_ref: *//'
-  } | sort -u
+  # `|| true` on each grep: a stub with a `uses:` pin but no `agent_ref:` (the common
+  # case) must NOT fail-close under `set -o pipefail` on the empty match.
+  local uses_refs agentref_refs
+  uses_refs="$(grep -oE "@${agent}/[^[:space:]\"']+" <<< "$content" | sed 's/^@//' || true)"
+  agentref_refs="$(grep -oE "agent_ref: *${agent}/[^[:space:]\"']+" <<< "$content" | sed -E 's/^agent_ref: *//' || true)"
+  printf '%s\n%s\n' "$uses_refs" "$agentref_refs" | grep -v '^[[:space:]]*$' | sort -u || true
 }
 
 # _is_bare_tier_ref <agent> <ref> -> 0 if <ref> is a bare `<agent>/<tier>` pin

--- a/scripts/migrate-major-channels.sh
+++ b/scripts/migrate-major-channels.sh
@@ -106,7 +106,7 @@ _enrolled_consumers() {
 # .github/workflows/<agent>.yml stub pins the reusable at (e.g. `agent/ring1`), or
 # empty if the stub is missing / does not pin the agent.
 _consumer_pinned_ref() {
-  local repo="$1" agent="$2" response content ref
+  local repo="$1" agent="$2" response content
   response="$(gh api "repos/${repo}/contents/.github/workflows/${agent}.yml" 2>&1)" || {
     if <<< "$response" grep -q "404"; then
       return 0
@@ -194,7 +194,7 @@ emit_repins() {
       [ -z "$ref" ] && continue
       if _is_bare_tier_ref "$agent" "$ref"; then
         tier="${ref##*/}"
-        log "repin ${c}: @${ref} -> @${agent}/v${major}-${tier}"
+        log "repin ${c}: ${ref} -> ${agent}/v${major}-${tier}"
       fi
     done <<< "$refs"
   done < <(_enrolled_consumers "$agent")
@@ -217,7 +217,7 @@ retire_bare() {
     while IFS= read -r ref; do
       [ -z "$ref" ] && continue
       if _is_bare_tier_ref "$agent" "$ref"; then
-        offenders+=("${c} (@${ref})")
+        offenders+=("${c} (${ref})")
       fi
     done <<< "$refs"
   done < <(_enrolled_consumers "$agent")

--- a/scripts/migrate-major-channels.sh
+++ b/scripts/migrate-major-channels.sh
@@ -115,8 +115,14 @@ _consumer_pinned_ref() {
     return 1
   }
   content="$(jq -r '.content // empty' <<< "$response" | base64 -d 2>/dev/null)"
-  ref="$(grep -oE "@${agent}/[^[:space:]\"']+" <<< "$content" | head -1)"
-  printf '%s' "${ref#@}"
+  # Emit EVERY channel ref the stub carries for this agent, one per line, @-stripped:
+  # both the `uses:` pin (`@<agent>/<tier>`) AND the `agent_ref:` input
+  # (`<agent>/<tier>`, no `@`) — the reusable checks out its tooling at agent_ref, so a
+  # bare agent_ref keeps the bare tag load-bearing (retiring it broke dev-lead, #657).
+  {
+    grep -oE "@${agent}/[^[:space:]\"']+" <<< "$content" | sed 's/^@//'
+    grep -oE "agent_ref: *${agent}/[^[:space:]\"']+" <<< "$content" | sed -E 's/^agent_ref: *//'
+  } | sort -u
 }
 
 # _is_bare_tier_ref <agent> <ref> -> 0 if <ref> is a bare `<agent>/<tier>` pin
@@ -177,15 +183,18 @@ emit_repins() {
   fi
   while IFS= read -r c; do
     [ -z "$c" ] && continue
-    if ! ref="$(_consumer_pinned_ref "$c" "$agent")"; then
+    local refs
+    if ! refs="$(_consumer_pinned_ref "$c" "$agent")"; then
       err "could not read ${c}/.github/workflows/${agent}.yml — aborting (fail-closed)"
       return 1
     fi
-    [ -z "$ref" ] && continue
-    if _is_bare_tier_ref "$agent" "$ref"; then
-      tier="${ref##*/}"
-      log "repin ${c}: @${ref} -> @${agent}/v${major}-${tier}"
-    fi
+    while IFS= read -r ref; do
+      [ -z "$ref" ] && continue
+      if _is_bare_tier_ref "$agent" "$ref"; then
+        tier="${ref##*/}"
+        log "repin ${c}: @${ref} -> @${agent}/v${major}-${tier}"
+      fi
+    done <<< "$refs"
   done < <(_enrolled_consumers "$agent")
 }
 
@@ -198,14 +207,17 @@ retire_bare() {
   local -a offenders=()
   while IFS= read -r c; do
     [ -z "$c" ] && continue
-    if ! ref="$(_consumer_pinned_ref "$c" "$agent")"; then
+    local refs
+    if ! refs="$(_consumer_pinned_ref "$c" "$agent")"; then
       err "could not read ${c}/.github/workflows/${agent}.yml — aborting (fail-closed)"
       return 1
     fi
-    [ -z "$ref" ] && continue
-    if _is_bare_tier_ref "$agent" "$ref"; then
-      offenders+=("${c} (@${ref})")
-    fi
+    while IFS= read -r ref; do
+      [ -z "$ref" ] && continue
+      if _is_bare_tier_ref "$agent" "$ref"; then
+        offenders+=("${c} (@${ref})")
+      fi
+    done <<< "$refs"
   done < <(_enrolled_consumers "$agent")
 
   if [ "${#offenders[@]}" -gt 0 ]; then

--- a/test/scripts/migrate-major-channels/migrate.bats
+++ b/test/scripts/migrate-major-channels/migrate.bats
@@ -63,7 +63,9 @@ case "$path" in
   *git/ref/tags/foo/*)                  # bare-tier tag → resolves to a commit
     printf 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\tcommit\n'; exit 0 ;;
   *contents/.github/workflows/foo.yml*) # consumer stub content as JSON
-    body="    uses: petry-projects/.github/.github/workflows/foo-reusable.yml@${CONSUMER_REF:-foo/ring1}"
+    body="    uses: petry-projects/.github/.github/workflows/foo-reusable.yml@${CONSUMER_REF:-foo/ring1}
+    with:
+      agent_ref: ${AGENT_REF:-${CONSUMER_REF:-foo/ring1}}"
     b64="$(printf '%s' "$body" | base64 | tr -d '\n')"
     printf '{"content":"%s"}' "$b64"
     exit 0 ;;
@@ -115,11 +117,23 @@ STUB
 
 @test "--retire-bare proceeds (dry-run) when no enrolled consumer pins bare" {
   export FOO_MAJOR_REFS="refs/tags/foo/v2.1.0"
-  export CONSUMER_REF="foo/v2-ring1"   # consumerX already migrated to the v-form
+  export CONSUMER_REF="foo/v2-ring1"   # consumerX already migrated to the v-form (uses: AND agent_ref)
   install_gh_stub
   run env GH_TOKEN=x DRY_RUN=true CANARY_RINGS="$RINGS" bash "$SCRIPT" --retire-bare foo
   [ "$status" -eq 0 ]
   echo "$output" | grep -qiE 'would delete .*foo/(stable|ring1)'
+  ! grep -qE 'DELETE .*git/refs' "$GH_CALLS"
+}
+
+@test "--retire-bare refuses when uses: is v-form but agent_ref: is still bare (regression: broke dev-lead)" {
+  export FOO_MAJOR_REFS="refs/tags/foo/v2.1.0"
+  export CONSUMER_REF="foo/v2-ring1"   # uses: pin already migrated…
+  export AGENT_REF="foo/ring1"          # …but agent_ref: still bare (the load-bearing checkout ref)
+  install_gh_stub
+  run env GH_TOKEN=x DRY_RUN=true CANARY_RINGS="$RINGS" bash "$SCRIPT" --retire-bare foo
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -qi 'refuse'
+  echo "$output" | grep -qF 'consumerX'
   ! grep -qE 'DELETE .*git/refs' "$GH_CALLS"
 }
 

--- a/test/scripts/migrate-major-channels/migrate.bats
+++ b/test/scripts/migrate-major-channels/migrate.bats
@@ -63,9 +63,14 @@ case "$path" in
   *git/ref/tags/foo/*)                  # bare-tier tag → resolves to a commit
     printf 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\tcommit\n'; exit 0 ;;
   *contents/.github/workflows/foo.yml*) # consumer stub content as JSON
-    body="    uses: petry-projects/.github/.github/workflows/foo-reusable.yml@${CONSUMER_REF:-foo/ring1}
+    body="    uses: petry-projects/.github/.github/workflows/foo-reusable.yml@${CONSUMER_REF:-foo/ring1}"
+    # Only emit an agent_ref: line when the test asks for one (NO_AGENT_REF omits it —
+    # the common case: a stub with a uses: pin but no agent_ref input).
+    if [ "${NO_AGENT_REF:-false}" != "true" ]; then
+      body="${body}
     with:
       agent_ref: ${AGENT_REF:-${CONSUMER_REF:-foo/ring1}}"
+    fi
     b64="$(printf '%s' "$body" | base64 | tr -d '\n')"
     printf '{"content":"%s"}' "$b64"
     exit 0 ;;
@@ -123,6 +128,17 @@ STUB
   [ "$status" -eq 0 ]
   echo "$output" | grep -qiE 'would delete .*foo/(stable|ring1)'
   ! grep -qE 'DELETE .*git/refs' "$GH_CALLS"
+}
+
+@test "--retire-bare proceeds when the stub has a v-form uses: pin and NO agent_ref (must not fail-close on the empty grep)" {
+  export FOO_MAJOR_REFS="refs/tags/foo/v2.1.0"
+  export CONSUMER_REF="foo/v2-ring1"   # uses: v-form
+  export NO_AGENT_REF="true"            # stub carries no agent_ref: line (the common case)
+  install_gh_stub
+  run env GH_TOKEN=x DRY_RUN=true CANARY_RINGS="$RINGS" bash "$SCRIPT" --retire-bare foo
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qiE 'would delete .*foo/(stable|ring1)'
+  ! echo "$output" | grep -qi 'could not read'   # must NOT fail-close
 }
 
 @test "--retire-bare refuses when uses: is v-form but agent_ref: is still bare (regression: broke dev-lead)" {


### PR DESCRIPTION
The #657 bare-tag retirement broke dev-lead fleet-wide: the retire guard only scanned `uses:` pins, but caller stubs also pass `agent_ref: <agent>/<tier>` (no `@`), which the reusable checks out its tooling at. Deleting the bare tag → `git fetch refs/tags/dev-lead/ring0*` exit 1. Restored the bare tags to recover; this hardens the guard so it can't recur. `_consumer_pinned_ref` now returns every channel ref (uses: + agent_ref); both callers loop; +1 regression bats (uses: v-form + agent_ref bare → refuse). Companion to the agent_ref re-pin PRs (#714 etc.) and F5 gap #704.