### PR TITLE
fix(scorecard): exempt first-party channel-tag refs from Pinned-Dependencies (#709)

### DIFF
--- a/.github/workflows/org-scorecard.yml
+++ b/.github/workflows/org-scorecard.yml
@@ -136,15 +136,20 @@ jobs:
               # enforced by compliance-audit.sh check_action_pinning (which exempts
               # first-party) — so an Actions-only Pinned-Dependencies finding is
               # fully covered elsewhere and is pure noise. Scorecard's detail lines
-              # name the dependency type, so suppress the issue only when EVERY
-              # "not pinned" detail is a GitHubAction; keep it whenever there is a
-              # non-Actions gap (containerImage / pip / npm / go) that nothing else
-              # tracks. Errs toward keeping the issue if the wording is unexpected.
+              # name the dependency type, so suppress the issue only when ALL of
+              # these hold: (1) at least one "not pinned" detail exists, confirming
+              # the expected detail format is present, and (2) every such detail is a
+              # GitHubAction. Keep it whenever there is a non-Actions gap
+              # (containerImage / pip / npm / go) or when no recognisable detail
+              # lines are found (format changed — errs toward keeping the issue).
               if [ "$CHECK_NAME" = "Pinned-Dependencies" ] && [ "$SCORE" != "10" ]; then
+                TOTAL_WARN=$(echo "$ROW" | jq -r \
+                  '[.details[]? | select(test("not pinned by hash"; "i"))] | length' \
+                  2>/dev/null || echo "0")
                 NON_ACTION_WARN=$(echo "$ROW" | jq -r \
                   '[.details[]? | select(test("not pinned by hash"; "i")) | select(test("GitHubAction"; "i") | not)] | length' \
                   2>/dev/null || echo "1")
-                if [ "${NON_ACTION_WARN:-1}" -eq 0 ]; then
+                if [ "${TOTAL_WARN:-0}" -gt 0 ] && [ "${NON_ACTION_WARN:-1}" -eq 0 ]; then
                   echo "Pinned-Dependencies for $REPO is Actions-only — covered by compliance-audit + deliberate first-party channel tags; suppressing issue (#709)"
                   if [ -n "$EXISTING_ISSUE" ]; then
                     EXEMPT_MSG="Auto-closing (accepted exception, #709): this Pinned-Dependencies finding is limited to GitHub Actions refs."

--- a/.github/workflows/org-scorecard.yml
+++ b/.github/workflows/org-scorecard.yml
@@ -128,6 +128,35 @@ jobs:
                 -q ".[] | select(.title | startswith(\"$ISSUE_TITLE\")) | .number" \
                 | head -1)
 
+              # First-party channel-tag exemption for Pinned-Dependencies (#709).
+              # Our first-party reusable refs deliberately use mutable channel tags
+              # (<agent>/v<M>-<tier>) per ci-standards.md#action-pinning-policy, so
+              # Scorecard permanently docks Pinned-Dependencies and this issue never
+              # reached 10/10 or closed. Third-party ACTION pinning is already
+              # enforced by compliance-audit.sh check_action_pinning (which exempts
+              # first-party) — so an Actions-only Pinned-Dependencies finding is
+              # fully covered elsewhere and is pure noise. Scorecard's detail lines
+              # name the dependency type, so suppress the issue only when EVERY
+              # "not pinned" detail is a GitHubAction; keep it whenever there is a
+              # non-Actions gap (containerImage / pip / npm / go) that nothing else
+              # tracks. Errs toward keeping the issue if the wording is unexpected.
+              if [ "$CHECK_NAME" = "Pinned-Dependencies" ] && [ "$SCORE" != "10" ]; then
+                NON_ACTION_WARN=$(echo "$ROW" | jq -r \
+                  '[.details[]? | select(test("not pinned by hash"; "i")) | select(test("GitHubAction"; "i") | not)] | length' \
+                  2>/dev/null || echo "1")
+                if [ "${NON_ACTION_WARN:-1}" -eq 0 ]; then
+                  echo "Pinned-Dependencies for $REPO is Actions-only — covered by compliance-audit + deliberate first-party channel tags; suppressing issue (#709)"
+                  if [ -n "$EXISTING_ISSUE" ]; then
+                    EXEMPT_MSG="Auto-closing (accepted exception, #709): this Pinned-Dependencies finding is limited to GitHub Actions refs."
+                    EXEMPT_MSG="$EXEMPT_MSG Third-party action pinning is enforced by \`compliance-audit.sh\` (which exempts first-party),"
+                    EXEMPT_MSG="$EXEMPT_MSG and our first-party reusable refs deliberately use mutable channel tags per \`ci-standards.md#action-pinning-policy\`. No action needed."
+                    gh issue close "$EXISTING_ISSUE" --repo "$ORG/$REPO" --comment "$EXEMPT_MSG"
+                    CLOSED_COUNT=$((CLOSED_COUNT + 1))
+                  fi
+                  continue
+                fi
+              fi
+
               if [ "$SCORE" -eq 10 ]; then
                 # Check passed - close existing issue if any
                 if [ -n "$EXISTING_ISSUE" ]; then

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pr-681",
+  "name": "pr-716",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pr-681",
+  "name": "pr-716",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -1644,6 +1644,15 @@ org-level workflows that run across all repositories:
   to list repositories in the organization.
 - **Behavior:** Creates/updates GitHub Issues with findings, auto-closes resolved findings
 - **Skip list:** CII-Best-Practices, Contributors, Fuzzing, Maintained, Packaging, Signed-Releases
+- **Pinned-Dependencies — first-party exemption:** Our first-party reusable refs
+  deliberately use mutable channel tags (see [Action Pinning Policy](#action-pinning-policy)),
+  so Scorecard permanently docks `Pinned-Dependencies` and that finding can never
+  reach 10/10. Third-party **action** pinning is already enforced by
+  `check_action_pinning` in `scripts/compliance-audit.sh` (which exempts first-party),
+  so an Actions-only Pinned-Dependencies finding is fully covered elsewhere and is
+  suppressed (no issue) rather than looping forever. A finding is **still raised**
+  when it includes a non-Actions gap (container image / pip / npm / go) that nothing
+  else tracks — the suppression keys off Scorecard's per-detail dependency type.
 
 ---
 

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -1645,7 +1645,7 @@ org-level workflows that run across all repositories:
 - **Behavior:** Creates/updates GitHub Issues with findings, auto-closes resolved findings
 - **Skip list:** CII-Best-Practices, Contributors, Fuzzing, Maintained, Packaging, Signed-Releases
 - **Pinned-Dependencies — first-party exemption:** Our first-party reusable refs
-  deliberately use mutable channel tags (see [Action Pinning Policy](#action-pinning-policy)),
+  deliberately use moving channel tags (see [Action Pinning Policy](#action-pinning-policy)),
   so Scorecard permanently docks `Pinned-Dependencies` and that finding can never
   reach 10/10. Third-party **action** pinning is already enforced by
   `check_action_pinning` in `scripts/compliance-audit.sh` (which exempts first-party),


### PR DESCRIPTION
## Problem
`org-scorecard.yml` creates a `Scorecard: Pinned-Dependencies` issue per repo scoring <10/10 and only closes it at **10/10**. Our first-party reusable refs deliberately use **mutable channel tags** ([ci-standards#action-pinning-policy](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#action-pinning-policy)), so that check can *never* reach 10/10 — the issue never self-closes and **recreates after any manual close** (the 11 closed on 2026-07-13 would reappear on the next Monday scan). Full write-up: #709.

## Why not just skip the check
Scorecard `Pinned-Dependencies` also covers **non-Actions** deps (container images, pip/npm/go), which nothing else tracks — so a blanket `SKIP_CHECKS` entry would lose real signal. And third-party **action** pinning is *already* enforced by `check_action_pinning` in `compliance-audit.sh` (which exempts first-party), so the Actions portion is pure noise.

## Fix
Scorecard's per-detail messages name the dependency type (`GitHubAction`, `containerImage`, `pipCommand`, …). For `Pinned-Dependencies`:
- **Suppress** the issue (and close any existing one) when **every** `not pinned by hash` detail is a `GitHubAction` → covered by compliance-audit (third-party) + deliberate (first-party).
- **Keep** the issue whenever there's a non-Actions gap (container/pip/npm/go).
- Errs toward **keeping** if the wording is unexpected (safe failure mode).

Documented the exemption in `ci-standards.md`.

## Validation
- YAML parses; extracted run-script `bash -n` clean; yamllint clean (repo config, max 200); markdown lines well under MD013 (200).
- No scorecard bats suite exists (workflow-embedded script, matches existing untested pattern).

## Effect
Next Monday's scan will not recreate the 11 closed Pinned-Dependencies issues (unless a repo has a genuine non-Actions pinning gap, which is correctly surfaced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Juznz5V6su81ffSND8fg7s