### PR TITLE
fix(apply-repo-settings): don't fail the whole run on a check-suites 403 (#1209)

### DIFF
--- a/scripts/apply-repo-settings.sh
+++ b/scripts/apply-repo-settings.sh
@@ -280,6 +280,17 @@ apply_check_suite_prefs() {
        --input - <<< "$payload" 2>&1 >/dev/null); then
     ok "  auto-trigger disabled for app_ids: ${CHECK_SUITE_APP_IDS[*]}"
   else
+    # The check-suites/preferences endpoint is legacy: it only accepts a CLASSIC
+    # PAT (or GitHub App) with repo-admin. Fine-grained PATs and GITHUB_TOKEN get
+    # a 403 here. When the configured token lacks that capability we cannot apply
+    # this preference — skip it (loudly) rather than failing the whole settings
+    # run, which was reporting apply-repo-settings as 100%-failed fleet-wide while
+    # every other setting applied fine. The token-config fix is tracked in
+    # petry-projects/.github-private#1209; until then this preference is not applied.
+    if grep -qiE '"status": *"403"|HTTP 403|authenticate with a personal access token' <<< "$api_err"; then
+      warn "  Skipping check-suite prefs for $repo — token lacks repo-admin for the check-suites API (403). Tracking: petry-projects/.github-private#1209"
+      return 0
+    fi
     err "  PATCH failed for $repo. API response: $api_err"
     return 1
   fi

--- a/scripts/apply-repo-settings.sh
+++ b/scripts/apply-repo-settings.sh
@@ -287,7 +287,8 @@ apply_check_suite_prefs() {
     # run, which was reporting apply-repo-settings as 100%-failed fleet-wide while
     # every other setting applied fine. The token-config fix is tracked in
     # petry-projects/.github-private#1209; until then this preference is not applied.
-    if grep -qiE '"status": *"403"|HTTP 403|authenticate with a personal access token' <<< "$api_err"; then
+    local re_403='"status":[[:space:]]*"?403'
+    if [[ "${api_err,,}" =~ $re_403 || "${api_err,,}" =~ "http 403" || "${api_err,,}" =~ "authenticate with a personal access token" ]]; then
       warn "  Skipping check-suite prefs for $repo — token lacks repo-admin for the check-suites API (403). Tracking: petry-projects/.github-private#1209"
       return 0
     fi


### PR DESCRIPTION
## Problem
`apply-repo-settings.yml` fails **100%** on every repo that has it (bmad-bgreat-suite, TalkTerm, markets — 5/5 recent runs) at the check-suites step:
```
gh: You must authenticate with a personal access token ... to change check suite permissions. (HTTP 403)
```
The legacy `check-suites/preferences` endpoint only accepts a **classic PAT / GitHub App with repo-admin**; `GH_PAT_WORKFLOWS` is rejected. Under `set -e` the `return 1` aborted the entire run even though labels / merge config / code-scanning applied fine.

## This PR (defense-in-depth)
Treat a **403** on that PATCH as a non-fatal skip with a loud `WARN` instead of a hard failure. Stops the workflow reporting as fully broken (and the fleet-monitor 100%-failure alert). Other PATCH errors stay fatal. **The preference is not applied until the token is fixed.**

## The real fix (config — can't do in code)
Tracked in **petry-projects/.github-private#1209**: make `GH_PAT_WORKFLOWS` a classic PAT with repo-admin (or use a GitHub App token / drop the setting).

## Notes
- Canonical script only; consumer copies (bmad/TalkTerm/markets) need re-sync, or the #1209 token fix makes this moot.
- `bash -n` + shellcheck clean; no dedicated bats harness for this script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Juznz5V6su81ffSND8fg7s