### PR TITLE
fix(org-status): close prior daily digests instead of accumulating (32 stale)

### DIFF
--- a/.github/workflows/daily-org-status.yml
+++ b/.github/workflows/daily-org-status.yml
@@ -52,17 +52,18 @@ jobs:
           # This digest embeds the date in its title, so a fresh issue is created
           # every day — 32 had accumulated open. Close prior open Org Status
           # digests before opening today's so only the current snapshot stays open.
-          gh issue list --repo petry-projects/.github --label daily-report --state open \
+          gh issue list --repo "$GITHUB_REPOSITORY" --label daily-report --state open \
             --search "Org Status — in:title" --limit 200 \
             --json number,title \
             -q '.[] | select(.title | startswith("Org Status — ")) | .number' \
           | while read -r prev; do
               [ -n "$prev" ] || continue
-              gh issue close "$prev" --repo petry-projects/.github \
-                --comment "Superseded by the newer daily Org Status snapshot." >/dev/null 2>&1 || true
+              gh issue close "$prev" --repo "$GITHUB_REPOSITORY" \
+                --comment "Superseded by the newer daily Org Status snapshot." \
+                || echo "::warning::Failed to close issue #$prev — it may remain open until the next daily run."
             done
           gh issue create \
-            --repo petry-projects/.github \
+            --repo "$GITHUB_REPOSITORY" \
             --title "Org Status — $DATE" \
             --body-file /tmp/report.md \
             --label daily-report

--- a/.github/workflows/daily-org-status.yml
+++ b/.github/workflows/daily-org-status.yml
@@ -49,6 +49,18 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
         run: |
           DATE=$(date -u +%Y-%m-%d)
+          # This digest embeds the date in its title, so a fresh issue is created
+          # every day — 32 had accumulated open. Close prior open Org Status
+          # digests before opening today's so only the current snapshot stays open.
+          gh issue list --repo petry-projects/.github --label daily-report --state open \
+            --search "Org Status — in:title" --limit 200 \
+            --json number,title \
+            -q '.[] | select(.title | startswith("Org Status — ")) | .number' \
+          | while read -r prev; do
+              [ -n "$prev" ] || continue
+              gh issue close "$prev" --repo petry-projects/.github \
+                --comment "Superseded by the newer daily Org Status snapshot." >/dev/null 2>&1 || true
+            done
           gh issue create \
             --repo petry-projects/.github \
             --title "Org Status — $DATE" \


### PR DESCRIPTION
`daily-org-status.yml` creates an `Org Status — <date>` issue every day with no close path — **32** open had accumulated. Close prior open digests (label `daily-report`, matching title prefix) before opening today's snapshot. Same pattern as the fleet-monitor (#1204), pr-review-health (#1212) digest fixes. `bash -n` + shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Juznz5V6su81ffSND8fg7s