### PR TITLE
docs: refresh org READMEs (automated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Organization-wide GitHub configuration and workflows for the `petry-projects` or
 
 | Path | Purpose |
 |------|---------|
-| `profile/` | Public org profile page shown on the org's GitHub landing |
-| `standards/` | Engineering standards and policy documents |
-| `standards/workflows/` | Reusable CI workflow templates called by org repositories |
+| [`profile/`](profile/) | Public org profile page shown on the org's GitHub landing |
+| [`standards/`](standards/) | Engineering standards and policy documents |
+| [`standards/workflows/`](standards/workflows/) | Reusable CI workflow templates called by org repositories |
 
 ## Engineering Standards
 
@@ -16,19 +16,19 @@ The `standards/` directory contains the authoritative policy documents for this 
 
 | Standard | Topic |
 |----------|-------|
-| `advanced-security` | GitHub Advanced Security configuration |
-| `agent-standards` | Copilot and agentic workflow standards |
-| `ci-standards` | CI pipeline conventions and enforcement |
-| `codeowners-standard` | CODEOWNERS file policy |
-| `copilot-instructions-standard` | Copilot instructions file conventions |
-| `dependabot-policy` | Dependabot configuration and auto-merge rules |
-| `feature-ideation-sources` | Sources and process for feature ideation |
-| `github-settings` | Repository settings policy |
-| `initiatives-project` | GitHub Projects board conventions |
-| `persona-standards` | Agent and persona definition standards |
-| `pr-limits` | Pull request size and scope limits |
-| `push-protection` | Secret push protection configuration |
-| `ruleset-remediation-runbook` | Runbook for resolving ruleset violations |
+| [`advanced-security`](standards/advanced-security.md) | GitHub Advanced Security configuration |
+| [`agent-standards`](standards/agent-standards.md) | Copilot and agentic workflow standards |
+| [`ci-standards`](standards/ci-standards.md) | CI pipeline conventions and enforcement |
+| [`codeowners-standard`](standards/codeowners-standard.md) | CODEOWNERS file policy |
+| [`copilot-instructions-standard`](standards/copilot-instructions-standard.md) | Copilot instructions file conventions |
+| [`dependabot-policy`](standards/dependabot-policy.md) | Dependabot configuration and auto-merge rules |
+| [`feature-ideation-sources`](standards/feature-ideation-sources.md) | Sources and process for feature ideation |
+| [`github-settings`](standards/github-settings.md) | Repository settings policy |
+| [`initiatives-project`](standards/initiatives-project.md) | GitHub Projects board conventions |
+| [`persona-standards`](standards/persona-standards.md) | Agent and persona definition standards |
+| [`pr-limits`](standards/pr-limits.md) | Pull request size and scope limits |
+| [`push-protection`](standards/push-protection.md) | Secret push protection configuration |
+| [`ruleset-remediation-runbook`](standards/ruleset-remediation-runbook.md) | Runbook for resolving ruleset violations |
 
 ## Related
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# petry-projects/.github
+
+Organization-wide GitHub configuration and workflows for the `petry-projects` org.
+
+## Contents
+
+| Path | Purpose |
+|------|---------|
+| `profile/` | Public org profile page shown on the org's GitHub landing |
+| `standards/` | Engineering standards and policy documents |
+| `standards/workflows/` | Reusable CI workflow templates called by org repositories |
+
+## Engineering Standards
+
+The `standards/` directory contains the authoritative policy documents for this org.
+
+| Standard | Topic |
+|----------|-------|
+| `advanced-security` | GitHub Advanced Security configuration |
+| `agent-standards` | Copilot and agentic workflow standards |
+| `ci-standards` | CI pipeline conventions and enforcement |
+| `codeowners-standard` | CODEOWNERS file policy |
+| `copilot-instructions-standard` | Copilot instructions file conventions |
+| `dependabot-policy` | Dependabot configuration and auto-merge rules |
+| `feature-ideation-sources` | Sources and process for feature ideation |
+| `github-settings` | Repository settings policy |
+| `initiatives-project` | GitHub Projects board conventions |
+| `persona-standards` | Agent and persona definition standards |
+| `pr-limits` | Pull request size and scope limits |
+| `push-protection` | Secret push protection configuration |
+| `ruleset-remediation-runbook` | Runbook for resolving ruleset violations |
+
+## Related
+
+The companion repository [`petry-projects/.github-private`](https://github.com/petry-projects/.github-private) holds private automation:
+Copilot custom agents, agentic workflow scripts, installed frameworks, and scheduled CI.

--- a/profile/README.md
+++ b/profile/README.md
@@ -11,10 +11,13 @@ A collection of open-source tools and experiments spanning terminal UX, market d
 | [TalkTerm](https://github.com/petry-projects/TalkTerm) | Terminal-based communication tool | HTML |
 | [markets](https://github.com/petry-projects/markets) | Market data and analysis tooling (dual-licensed AGPL / Commercial) | HTML |
 | [broodly](https://github.com/petry-projects/broodly) | Field-first beekeeping decision-support app — mobile-first (iOS, Android, web) via Expo + React Native with a Go GraphQL API on GCP | HTML |
+| [broodminder-export](https://github.com/petry-projects/broodminder-export) | Extract all of your data from the BroodMinder API into portable files — resumable, rate-limit-aware. | Python |
 | [ContentTwin](https://github.com/petry-projects/ContentTwin) | AI-powered Social Media Agent for small organizations — enterprise-quality social presence at non-profit pricing | Shell |
 | [bmad-bgreat-suite](https://github.com/petry-projects/bmad-bgreat-suite) | BMad Operations Suite — SRE and DevOps agents and workflows for the BMad Method ecosystem | Shell |
 | [google-app-scripts](https://github.com/petry-projects/google-app-scripts) | A collection of Google Apps Scripts for personal productivity automation | JavaScript |
-| [.github-private](https://github.com/petry-projects/.github-private) | Org-wide Copilot custom agents, Claude Code skills, and agentic workflow infrastructure | JavaScript |
+| [incubator](https://github.com/petry-projects/incubator) | Product incubator: pre-product idea Discussions, decision briefs/PRD-lite, and disposable POCs. Ideas graduate to their own product repo once a POC proves out. | Shell |
+| [repo-template](https://github.com/petry-projects/repo-template) | Org template repository: one-click scaffold for new petry-projects repos. Files via 'Use this template'; non-file standards via bootstrap. | Shell |
+| [.github-private](https://github.com/petry-projects/.github-private) | Org-wide Copilot custom agents, Claude Code skills, and agentic workflow infrastructure | Shell |
 | [.github](https://github.com/petry-projects/.github) | Organization-wide GitHub configuration, CI templates, and engineering standards | Shell |
 
 ---


### PR DESCRIPTION
## Automated README refresh

Regenerated the org meta-repo README(s) in `petry-projects/.github` from live org state
(repository list, standards docs, agent profiles, and installed frameworks).

Generated by the weekly `readme-refresh` workflow in `petry-projects/.github-private`.
Review the diff — curated prose is preserved; only missing/stale facts are corrected.

**Action needed:** these repos have empty GitHub descriptions — set them on the repo page so future refreshes can enrich the table: TalkTerm, markets