### PR TITLE
feat(release): pinned-version report — Safe Release SC8 (#502)

### DIFF
--- a/.github/workflows/pinned-version-report-tests.yml
+++ b/.github/workflows/pinned-version-report-tests.yml
@@ -1,0 +1,63 @@
+# Quality gate for scripts/pinned-version-report.sh and its bats suite.
+#
+# Triggered on any PR (or push to main) that touches:
+#   - scripts/pinned-version-report.sh
+#   - test/scripts/pinned-version-report/**
+#   - .github/workflows/pinned-version-report-tests.yml (this file)
+#
+# Gates (all must pass before merge):
+#   1. shellcheck — static analysis for the report script
+#   2. bats       — pin-resolution, drift-detection, and fan-out table tests
+
+name: Pinned-version-report Tests
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/pinned-version-report.sh'
+      - 'test/scripts/pinned-version-report/**'
+      - '.github/workflows/pinned-version-report-tests.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'scripts/pinned-version-report.sh'
+      - 'test/scripts/pinned-version-report/**'
+      - '.github/workflows/pinned-version-report-tests.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pinned-version-report-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Lint and bats
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install bats, shellcheck, and jq
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends bats shellcheck jq
+
+      - name: shellcheck
+        run: |
+          set -euo pipefail
+          shellcheck --severity=warning -x scripts/pinned-version-report.sh
+
+      - name: Run bats suite
+        # The suite stubs gh via PATH; a dummy token satisfies the script's
+        # GH_TOKEN precondition without any real API access.
+        env:
+          GH_TOKEN: dummy-token-for-stubbed-tests
+        run: bats --print-output-on-failure test/scripts/pinned-version-report/

--- a/.github/workflows/pinned-version-report.yml
+++ b/.github/workflows/pinned-version-report.yml
@@ -1,0 +1,28 @@
+name: Pinned-version report
+
+# Safe Release SC8 (#495/#502): publish "who is on what version" across the fleet.
+# Reports each ring consumer's pinned channel + the immutable release it resolves
+# to, for every ring-released reusable, and flags ring-tier drift. Read-only.
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'   # Mondays 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Generate pinned-version report
+        env:
+          # Needs cross-repo read on consumers + tag read on the host repos; the
+          # default token only sees this repo, so use the org PAT.
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS || github.token }}
+          ORG: petry-projects
+        run: bash scripts/pinned-version-report.sh

--- a/.github/workflows/pinned-version-report.yml
+++ b/.github/workflows/pinned-version-report.yml
@@ -19,10 +19,17 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+      - name: Guard — PAT present
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::GH_PAT_WORKFLOWS is required — cross-repo reads need the org PAT, not github.token."
+            exit 1
+          fi
       - name: Generate pinned-version report
         env:
-          # Needs cross-repo read on consumers + tag read on the host repos; the
-          # default token only sees this repo, so use the org PAT.
-          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS || github.token }}
+          # Needs cross-repo read on consumers + tag read on the host repos.
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
           ORG: petry-projects
         run: bash scripts/pinned-version-report.sh

--- a/scripts/pinned-version-report.sh
+++ b/scripts/pinned-version-report.sh
@@ -24,7 +24,7 @@ source "$SCRIPT_DIR/lib/ring-pins.sh"
 REUSABLES=("${RING_REUSABLES[@]}")
 
 # Fleet repos to scan (non-archived). Enumerated live so new repos are covered.
-mapfile -t REPOS < <(gh repo list "$ORG" --no-archived --limit 100 --json name --jq '.[].name' | sort)
+mapfile -t REPOS < <(gh repo list "$ORG" --no-archived --limit 500 --json name --jq '.[].name' | sort)
 
 # --- channel -> version resolution -----------------------------------------
 # Cache each host repo's tags (name -> commit sha) once; resolve a channel tag to
@@ -119,10 +119,13 @@ done
   echo "|----------|-----------------------|"
   # Group SEEN_VERSION by agent.
   for agent in "${REUSABLES[@]}"; do
-    vers=""
+    vers_arr=()
     for k in "${!SEEN_VERSION[@]}"; do
-      [[ "$k" == "$agent"$'\t'* ]] && vers+="${k#*$'\t'} "
+      [[ "$k" == "$agent"$'\t'* ]] && vers_arr+=("${k#*$'\t'}")
     done
-    [ -n "$vers" ] && echo "| \`$agent\` | $(echo "$vers" | tr ' ' '\n' | sort -u | tr '\n' ' ') |"
+    if [ "${#vers_arr[@]}" -gt 0 ]; then
+      vers="$(printf '%s\n' "${vers_arr[@]}" | sort -u | tr '\n' ' ')"
+      echo "| \`$agent\` | ${vers% } |"
+    fi
   done
 } | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"

--- a/scripts/pinned-version-report.sh
+++ b/scripts/pinned-version-report.sh
@@ -37,10 +37,10 @@ load_host_tags() {
   [ -n "${HOST_LOADED[$host]:-}" ] && return 0
   HOST_LOADED[$host]=1
   local name sha
-  while IFS=$'\t' read -r name sha; do
+  while IFS=$'\t' read -r name sha || [ -n "$name" ]; do
     [ -n "$name" ] && TAG_SHA["$host"$'\t'"$name"]="$sha"
   done < <(gh api --paginate "repos/$ORG/$host/tags" \
-             --jq '.[] | [.name, .commit.sha] | @tsv' 2>/dev/null || true)
+             --jq '.[] | [.name, .commit.sha] | @tsv' 2>/dev/null | tr -d '\r' || true)
 }
 
 # resolve_version <host> <agent> <channel-ref> -> "vX.Y.Z" | "?" (unresolved)
@@ -49,7 +49,8 @@ resolve_version() {
   load_host_tags "$host"
   local chan_sha="${TAG_SHA["$host"$'\t'"$ref"]:-}"
   # If the pin is already an immutable vX.Y.Z, report it as-is.
-  if [[ "$ref" =~ ^"$agent"/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  ref_regex="^${agent}/v[0-9]+\.[0-9]+\.[0-9]+$"
+  if [[ "$ref" =~ $ref_regex ]]; then
     printf '%s' "${ref#"$agent"/}"; return 0
   fi
   [ -z "$chan_sha" ] && { printf '?'; return 0; }
@@ -74,13 +75,17 @@ for repo in "${REPOS[@]}"; do
   for agent in "${REUSABLES[@]}"; do
     # Caller stubs are conventionally named after the reusable (minus -reusable).
     stub=".github/workflows/${agent}.yml"
-    content="$(gh api "repos/$ORG/$repo/contents/$stub" --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true)"
+    content="$(gh api "repos/$ORG/$repo/contents/$stub" --jq '.content // empty' 2>/dev/null | base64 -d 2>/dev/null || true)"
     [ -n "$content" ] || continue
     # Extract the reusable uses: line -> host + @ref.
     uses_line="$(grep -oE "uses:[[:space:]]*$ORG/(\.github|\.github-private)/\.github/workflows/${agent}-reusable\.yml@[^[:space:]#]+" <<< "$content" | head -1 || true)"
     [ -n "$uses_line" ] || continue
-    host="$(sed -E "s#.*$ORG/(\.github(-private)?)/.*#\1#" <<< "$uses_line")"
-    ref="$(sed -E 's#.*@##' <<< "$uses_line")"          # e.g. dev-lead/v1-ring1
+    ref="${uses_line##*@}"          # e.g. dev-lead/v1-ring1
+    host=""
+    host_regex="$ORG/(\.github(-private)?)/"
+    if [[ "$uses_line" =~ $host_regex ]]; then
+      host="${BASH_REMATCH[1]}"
+    fi
     channel="${ref#"$agent"/}"                            # e.g. v1-ring1
     version="$(resolve_version "$host" "$agent" "$ref")"
     SEEN_VERSION["$agent"$'\t'"$version"]=1

--- a/scripts/pinned-version-report.sh
+++ b/scripts/pinned-version-report.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# pinned-version-report.sh — Safe Release SC8 (#495/#502): report each ring
+# consumer's currently-pinned CHANNEL and the concrete VERSION it resolves to,
+# for every ring-released reusable, so "who is on what version" is a single
+# reportable surface (not just drift detection).
+#
+# For each fleet repo × ring reusable it finds the caller-stub `uses:` line,
+# extracts the `@<agent>/<channel>` pin, resolves that channel tag to the
+# immutable `<agent>/vX.Y.Z` release it points at (matching tag SHAs on the host
+# repo), and flags whether the pin matches the repo's expected ring tier.
+#
+# Output: a Markdown report on stdout, and appended to $GITHUB_STEP_SUMMARY when
+# set. Read-only: only GET calls; never mutates.
+#
+# Env: GH_TOKEN (repo read + org metadata). ORG (default petry-projects).
+set -euo pipefail
+
+ORG="${ORG:-petry-projects}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/ring-pins.sh
+source "$SCRIPT_DIR/lib/ring-pins.sh"
+
+# Ring-released reusables to report on (mirrors RING_REUSABLES from ring-pins.sh).
+REUSABLES=("${RING_REUSABLES[@]}")
+
+# Fleet repos to scan (non-archived). Enumerated live so new repos are covered.
+mapfile -t REPOS < <(gh repo list "$ORG" --no-archived --limit 100 --json name --jq '.[].name' | sort)
+
+# --- channel -> version resolution -----------------------------------------
+# Cache each host repo's tags (name -> commit sha) once; resolve a channel tag to
+# the vX.Y.Z release sharing its SHA.
+declare -A TAG_SHA          # "host\ttag" -> sha
+declare -A HOST_LOADED      # host -> 1
+
+load_host_tags() {
+  local host="$1"
+  [ -n "${HOST_LOADED[$host]:-}" ] && return 0
+  HOST_LOADED[$host]=1
+  local name sha
+  while IFS=$'\t' read -r name sha; do
+    [ -n "$name" ] && TAG_SHA["$host"$'\t'"$name"]="$sha"
+  done < <(gh api --paginate "repos/$ORG/$host/tags" \
+             --jq '.[] | [.name, .commit.sha] | @tsv' 2>/dev/null || true)
+}
+
+# resolve_version <host> <agent> <channel-ref> -> "vX.Y.Z" | "?" (unresolved)
+resolve_version() {
+  local host="$1" agent="$2" ref="$3"
+  load_host_tags "$host"
+  local chan_sha="${TAG_SHA["$host"$'\t'"$ref"]:-}"
+  # If the pin is already an immutable vX.Y.Z, report it as-is.
+  if [[ "$ref" =~ ^"$agent"/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    printf '%s' "${ref#"$agent"/}"; return 0
+  fi
+  [ -z "$chan_sha" ] && { printf '?'; return 0; }
+  local t
+  for t in "${!TAG_SHA[@]}"; do
+    [[ "$t" == "$host"$'\t'"$agent"/v*.*.* ]] || continue
+    if [ "${TAG_SHA[$t]}" = "$chan_sha" ]; then
+      printf '%s' "${t##*/}"; return 0
+    fi
+  done
+  printf '?(%.8s)' "$chan_sha"
+}
+
+# --- scan -------------------------------------------------------------------
+today="$(date -u +%Y-%m-%d)"
+rows=""
+drift_count=0
+declare -A SEEN_VERSION   # "agent\tversion" -> 1 (for the fan-out summary)
+
+for repo in "${REPOS[@]}"; do
+  tier="$(ring_tier_for_repo "$repo")"
+  for agent in "${REUSABLES[@]}"; do
+    # Caller stubs are conventionally named after the reusable (minus -reusable).
+    stub=".github/workflows/${agent}.yml"
+    content="$(gh api "repos/$ORG/$repo/contents/$stub" --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true)"
+    [ -n "$content" ] || continue
+    # Extract the reusable uses: line -> host + @ref.
+    uses_line="$(grep -oE "uses:[[:space:]]*$ORG/(\.github|\.github-private)/\.github/workflows/${agent}-reusable\.yml@[^[:space:]#]+" <<< "$content" | head -1 || true)"
+    [ -n "$uses_line" ] || continue
+    host="$(sed -E "s#.*$ORG/(\.github(-private)?)/.*#\1#" <<< "$uses_line")"
+    ref="$(sed -E 's#.*@##' <<< "$uses_line")"          # e.g. dev-lead/v1-ring1
+    channel="${ref#"$agent"/}"                            # e.g. v1-ring1
+    version="$(resolve_version "$host" "$agent" "$ref")"
+    SEEN_VERSION["$agent"$'\t'"$version"]=1
+    # Drift: does the pinned tier match the repo's expected ring tier?
+    local_drift=""
+    case "$channel" in
+      *"$tier"|"$tier") : ;;                              # e.g. v1-ring1 endswith ring1
+      stable|v*-stable) [ "$tier" = "stable" ] || local_drift="⚠️" ;;
+      *) local_drift="⚠️" ;;
+    esac
+    [ -n "$local_drift" ] && drift_count=$((drift_count + 1))
+    rows+="| \`$repo\` | \`$agent\` | \`$tier\` | \`$channel\` | \`$version\` | ${local_drift:-✅} |"$'\n'
+  done
+done
+
+# --- render -----------------------------------------------------------------
+{
+  echo "## Pinned-version report — $today"
+  echo ""
+  echo "_Safe Release SC8 (#495/#502): each ring consumer's pinned channel and the immutable release it resolves to._"
+  echo ""
+  echo "| Repo | Reusable | Ring tier | Pinned channel | Resolved version | Tier match |"
+  echo "|------|----------|-----------|----------------|------------------|:----------:|"
+  printf '%b' "$rows"
+  echo ""
+  echo "**Drift (pin not on the repo's ring tier): $drift_count**  ·  \`?\` = channel tag did not resolve to a vX.Y.Z release."
+  echo ""
+  echo "### Version fan-out (who is on each release)"
+  echo ""
+  echo "| Reusable | Versions in the fleet |"
+  echo "|----------|-----------------------|"
+  # Group SEEN_VERSION by agent.
+  for agent in "${REUSABLES[@]}"; do
+    vers=""
+    for k in "${!SEEN_VERSION[@]}"; do
+      [[ "$k" == "$agent"$'\t'* ]] && vers+="${k#*$'\t'} "
+    done
+    [ -n "$vers" ] && echo "| \`$agent\` | $(echo "$vers" | tr ' ' '\n' | sort -u | tr '\n' ' ') |"
+  done
+} | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"

--- a/test/scripts/pinned-version-report/resolve-and-drift.bats
+++ b/test/scripts/pinned-version-report/resolve-and-drift.bats
@@ -1,0 +1,108 @@
+#!/usr/bin/env bats
+# Tests for scripts/pinned-version-report.sh — SC8 pin-resolution and drift detection.
+#
+# Covers the key decision paths:
+#   - resolve_version: channel tag resolves to a vX.Y.Z release (SHA match)
+#   - resolve_version: channel tag present but no vX.Y.Z shares its SHA → ?(sha)
+#   - resolve_version: channel tag absent entirely → ?
+#   - Drift detection: tier match → ✅, tier mismatch → ⚠️
+#   - Fan-out table: no blank version entries (trailing-space regression, #502)
+#
+# gh is stubbed via test/scripts/pinned-version-report/stubs/gh; no live API.
+
+bats_require_minimum_version 1.5.0
+
+SCRIPT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)/scripts/pinned-version-report.sh"
+GH_STUB="$(cd "$BATS_TEST_DIRNAME" && pwd)/stubs/gh"
+
+setup() {
+  TMP="$(mktemp -d)"
+  export TMP
+  mkdir -p "$TMP/bin"
+  cp "$GH_STUB" "$TMP/bin/gh"
+  chmod +x "$TMP/bin/gh"
+  PATH="$TMP/bin:$PATH"
+  export PATH
+  export GH_STUB_LOG="$TMP/gh.log"
+  : >"$GH_STUB_LOG"
+  export ORG="petry-projects"
+  # Default: one stable-tier repo (anything not in the explicit ring lists)
+  export GH_STUB_REPOS="my-fleet-repo"
+  # Workflow content: a stub that pins dev-lead-reusable.yml@dev-lead/stable.
+  # The script base64-decodes the content, so the stub returns base64 text.
+  export GH_STUB_CONTENTS
+  GH_STUB_CONTENTS="$(printf 'jobs:\n  dev-lead:\n    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable\n    secrets: inherit\n' | base64)"
+  # Default: no tags (unresolved channel)
+  export GH_STUB_TAGS_TSV=""
+}
+
+teardown() {
+  [ -n "${TMP:-}" ] && [ -d "$TMP" ] && rm -rf "$TMP"
+}
+
+run_report() {
+  run bash "$SCRIPT"
+}
+
+# ── resolve_version ────────────────────────────────────────────────────────────
+
+@test "channel tag resolves to vX.Y.Z when SHA matches a release tag" {
+  # dev-lead/stable and dev-lead/v2.1.0 share the same SHA: channel resolves.
+  GH_STUB_TAGS_TSV="$(printf 'dev-lead/stable\tabcdef1234567890\ndev-lead/v2.1.0\tabcdef1234567890\n')"
+  run_report
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"v2.1.0"* ]]
+}
+
+@test "channel tag present but no vX.Y.Z shares its SHA gives SHA hint" {
+  # dev-lead/stable exists but its SHA has no matching release tag → ?(sha).
+  # First 8 chars of abcdef1234567890 = abcdef12
+  GH_STUB_TAGS_TSV="$(printf 'dev-lead/stable\tabcdef1234567890\n')"
+  run_report
+  [ "$status" -eq 0 ]
+  grep -qF "?(abcdef12)" <<< "$output"
+}
+
+@test "channel tag absent entirely gives plain ?" {
+  # No tags at all: SHA lookup fails, resolve_version returns ?.
+  GH_STUB_TAGS_TSV=""
+  run_report
+  [ "$status" -eq 0 ]
+  # The version column in the main table should contain the literal `?`
+  grep -qF '`?`' <<< "$output"
+}
+
+# ── drift detection ────────────────────────────────────────────────────────────
+
+@test "tier match: stable-tier repo pinning stable channel shows no drift" {
+  # my-fleet-repo → stable tier; stub pins dev-lead/stable → no mismatch.
+  GH_STUB_TAGS_TSV=""
+  run_report
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✅"* ]]
+  [[ "$output" != *"⚠️"* ]]
+}
+
+@test "tier mismatch: ring1-tier repo pinning stable channel shows drift flag" {
+  # TalkTerm → ring1 tier; stub pins dev-lead/stable → drift.
+  GH_STUB_REPOS="TalkTerm"
+  GH_STUB_TAGS_TSV=""
+  run_report
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"⚠️"* ]]
+}
+
+# ── fan-out table (trailing-space regression) ──────────────────────────────────
+
+@test "fan-out table has no blank version entry from trailing space (#502)" {
+  # Before fix: vers+='v2.1.0 ' then tr ' ' '\n' creates an empty token that
+  # sort-u promotes to a leading space in the cell: "|  v2.1.0  |".
+  # After fix (array-based join): "| v2.1.0 |" with no extra whitespace.
+  GH_STUB_TAGS_TSV="$(printf 'dev-lead/stable\tabcdef1234567890\ndev-lead/v2.1.0\tabcdef1234567890\n')"
+  run_report
+  [ "$status" -eq 0 ]
+  # Fan-out rows are NOT backtick-wrapped (unlike main table); look for
+  # the exact "| v2.1.0 |" pattern. With the bug, the cell starts with a
+  # space ("| " + " v2.1.0") and would not match this pattern.
+  grep -qF '| v2.1.0 |' <<< "$output"
+}

--- a/test/scripts/pinned-version-report/stubs/gh
+++ b/test/scripts/pinned-version-report/stubs/gh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Fake gh binary for pinned-version-report bats tests.
+#
+# Routes by argv content so each test can control the three distinct gh call
+# types the script makes without per-fixture stub variants:
+#   - 'repo list'   -> newline-separated repo names  (GH_STUB_REPOS)
+#   - 'contents/'   -> base64-encoded file content    (GH_STUB_CONTENTS, empty = not found)
+#   - '/tags'       -> pre-jq'd TSV lines: name\tsha  (GH_STUB_TAGS_TSV)
+#
+# The script applies --jq filters to API calls internally, so the stub returns
+# the already-processed text that gh would output after the filter.
+#
+# Recognized vars:
+#   GH_STUB_REPOS      newline-separated repo names (for 'repo list')
+#   GH_STUB_CONTENTS   base64 string returned for any 'contents/' API call
+#                      (empty string = file not found; script skips it)
+#   GH_STUB_TAGS_TSV   pre-jq'd TSV output for any '/tags' API call
+#                      (empty = no tags; channel stays unresolved)
+#   GH_STUB_EXIT       exit code (default 0)
+#   GH_STUB_LOG        append-only argv log (shell-quoted, one line per call)
+
+set -euo pipefail
+
+if [ -n "${GH_STUB_LOG:-}" ]; then
+  # shellcheck disable=SC2059
+  printf '%q ' "$@" >>"$GH_STUB_LOG"
+  printf '\n' >>"$GH_STUB_LOG"
+fi
+
+args="$*"
+
+case "$args" in
+  *"repo list"*)
+    printf '%s\n' "${GH_STUB_REPOS:-}"
+    ;;
+  *"contents/"*)
+    printf '%s\n' "${GH_STUB_CONTENTS:-}"
+    ;;
+  *"/tags"*)
+    printf '%s\n' "${GH_STUB_TAGS_TSV:-}"
+    ;;
+  *)
+    ;;
+esac
+
+exit "${GH_STUB_EXIT:-0}"


### PR DESCRIPTION
Closes the **SC8** residual of #502 (the rollback half already ships via `cut-release.sh --promote`).

## What
`scripts/pinned-version-report.sh` + a weekly workflow that publishes **who is on what version** across the fleet. For each repo × ring reusable it:
- finds the caller-stub `uses:` pin,
- resolves the `@<agent>/<channel>` tag to the immutable `<agent>/vX.Y.Z` release it points at (matching tag SHAs on the host repo),
- reports **ring tier · pinned channel · resolved version**, and
- flags **ring-tier drift** + unresolved pins.

Read-only (GET-only, no mutation). Runs Mondays 08:00 UTC + `workflow_dispatch`, writing to the run's step summary.

## Live output (real fleet, today)
Renders a full repo×reusable table with resolved versions (e.g. `dev-lead → v1.5.4`, `auto-rebase → v2.1.1`) plus a per-reusable version fan-out. It already surfaces **2 real drifts** — including `broodly/feature-ideation` pinned to a raw SHA that resolves to no release.

## Validation
`bash -n` + shellcheck (0 findings); workflow YAML valid; executed live against the fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Juznz5V6su81ffSND8fg7s