### PR TITLE
docs: refresh org READMEs (automated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,21 +14,21 @@ Organization-wide GitHub configuration and workflows for the `petry-projects` or
 
 The `standards/` directory contains the authoritative policy documents for this org.
 
-| Standard | Topic |
-|----------|-------|
-| [`advanced-security`](standards/advanced-security.md) | GitHub Advanced Security configuration |
-| [`agent-standards`](standards/agent-standards.md) | Copilot and agentic workflow standards |
-| [`ci-standards`](standards/ci-standards.md) | CI pipeline conventions and enforcement |
-| [`codeowners-standard`](standards/codeowners-standard.md) | CODEOWNERS file policy |
-| [`copilot-instructions-standard`](standards/copilot-instructions-standard.md) | Copilot instructions file conventions |
-| [`dependabot-policy`](standards/dependabot-policy.md) | Dependabot configuration and auto-merge rules |
-| [`feature-ideation-sources`](standards/feature-ideation-sources.md) | Sources and process for feature ideation |
-| [`github-settings`](standards/github-settings.md) | Repository settings policy |
-| [`initiatives-project`](standards/initiatives-project.md) | GitHub Projects board conventions |
-| [`persona-standards`](standards/persona-standards.md) | Agent and persona definition standards |
-| [`pr-limits`](standards/pr-limits.md) | Pull request size and scope limits |
-| [`push-protection`](standards/push-protection.md) | Secret push protection configuration |
-| [`ruleset-remediation-runbook`](standards/ruleset-remediation-runbook.md) | Runbook for resolving ruleset violations |
+| Standard | Topic | Key topics |
+|----------|-------|------------|
+| [`advanced-security`](standards/advanced-security.md) | GitHub Advanced Security configuration | Code Security Configurations, push-protection live-fire test (canary), licensing & billing, verification, compliance audit checks |
+| [`agent-standards`](standards/agent-standards.md) | Copilot and agentic workflow standards | Required files, agent configuration security, AgentShield CI workflow, Decision-Making Reusables, BMAD Method Workflows |
+| [`ci-standards`](standards/ci-standards.md) | CI pipeline conventions and enforcement | Staged promotion through concentric rings, reusable workflow versioning (`stable` channel), action pinning policy, permissions policy, required workflows |
+| [`codeowners-standard`](standards/codeowners-standard.md) | CODEOWNERS file policy | Rule, team composition, required setup for new bots, branch protection |
+| [`copilot-instructions-standard`](standards/copilot-instructions-standard.md) | Copilot instructions file conventions | Canonical instruction files, adding a new language, content quality rules, compliance |
+| [`dependabot-policy`](standards/dependabot-policy.md) | Dependabot configuration and auto-merge rules | Policy, configuration files, auto-merge workflow, CODEOWNERS approval timing, vulnerability audit CI check |
+| [`feature-ideation-sources`](standards/feature-ideation-sources.md) | Sources and process for feature ideation | AI/ML vendor & lab sources, developer tooling changelogs, security & compliance, newsletters, podcasts |
+| [`github-settings`](standards/github-settings.md) | Repository settings policy | Repository rulesets, organization-level secrets, GitHub Apps & integrations, labels — standard set, compliance audit process |
+| [`initiatives-project`](standards/initiatives-project.md) | GitHub Projects board conventions | What belongs on the board, fields, Theme → Initiative, how the auto-add works, views |
+| [`persona-standards`](standards/persona-standards.md) | Agent and persona definition standards | The trigger matrix, canary onboarding, trust & permissions, definition layers, Definition of Done |
+| [`pr-limits`](standards/pr-limits.md) | Pull request size and scope limits | What is limited, exempt actors, reconciliation with Dependabot cap, operator runbook |
+| [`push-protection`](standards/push-protection.md) | Secret push protection configuration | Layer 1 — GitHub Push Protection, Layer 2 — local pre-commit prevention, Layer 3 — CI secret scanning, incident response, compliance audit checks |
+| [`ruleset-remediation-runbook`](standards/ruleset-remediation-runbook.md) | Runbook for resolving ruleset violations | Snapshot (rollback insurance), bypass actors, legacy ruleset migration, verify, 2026-06-10 fleet remediation |
 
 ## Related
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,7 @@
 # Petry Projects
 
-A collection of open-source tools and experiments spanning terminal UX, market data, AI content tooling, beekeeping tech, and agent orchestration.
+A collection of open-source tools and experiments spanning terminal UX, market data, AI content tooling,
+beekeeping tech, and agent orchestration.
 
 ---
 
@@ -10,7 +11,7 @@ A collection of open-source tools and experiments spanning terminal UX, market d
 | --- | --- | --- |
 | [TalkTerm](https://github.com/petry-projects/TalkTerm) | Terminal-based communication tool | HTML |
 | [markets](https://github.com/petry-projects/markets) | Market data and analysis tooling (dual-licensed AGPL / Commercial) | HTML |
-| [broodly](https://github.com/petry-projects/broodly) | Field-first beekeeping decision-support app — mobile-first (iOS, Android, web) via Expo + React Native with a Go GraphQL API on GCP | HTML |
+| [broodly](https://github.com/petry-projects/broodly) | A test implementation of the BMAD method | HTML |
 | [broodminder-export](https://github.com/petry-projects/broodminder-export) | Extract all of your data from the BroodMinder API into portable files — resumable, rate-limit-aware. | Python |
 | [ContentTwin](https://github.com/petry-projects/ContentTwin) | AI-powered Social Media Agent for small organizations — enterprise-quality social presence at non-profit pricing | Shell |
 | [bmad-bgreat-suite](https://github.com/petry-projects/bmad-bgreat-suite) | BMad Operations Suite — SRE and DevOps agents and workflows for the BMad Method ecosystem | Shell |
@@ -24,20 +25,45 @@ A collection of open-source tools and experiments spanning terminal UX, market d
 
 ## Standards & Practices
 
-All repositories in this org follow shared engineering standards defined in [`.github`](https://github.com/petry-projects/.github):
+All repositories in this org follow shared engineering standards defined in
+[`.github`](https://github.com/petry-projects/.github):
 
-- **TDD** — tests are written before implementation; coverage gates enforced in CI
-- **CodeQL** — static analysis on every PR
-- **SonarCloud** — code quality and security scanning
-- **Dependabot** — automated dependency updates with automerge for patch-level changes
-- **Claude Code** — AI-assisted development via [agent standards](https://github.com/petry-projects/.github/blob/main/AGENTS.md)
+- **CI Standards** — Reusable workflow versioning via the `stable` channel; staged promotion through
+  concentric rings; action pinning policy; permissions policy; workflow patterns by tech stack
+  (Node.js, Go, Python, Electron).
+
+- **Advanced Security** — Code Security Configurations for the org fleet; push-protection live-fire
+  canary test; custom secret scanning patterns; compliance audit checks.
+
+- **Push Protection** — GitHub push protection (primary enforcement); local pre-commit prevention;
+  CI secret scanning (secondary defense); incident response runbook.
+
+- **Agent Standards** — AgentShield deep security scan; required agent files and compliance
+  exemptions; BMAD Method workflows; decision-making reusables.
+
+- **Dependabot Policy** — Stack-specific templates (npm, Go, Rust, Python, Terraform, Actions);
+  auto-merge workflow; vulnerability audit CI check; CODEOWNERS approval timing.
+
+- **GitHub Settings** — Repository rulesets (`pr-quality`, `code-quality`); auto-merge
+  configuration; bypass actors; labels — standard set; org-level secrets.
+
+- **CODEOWNERS Standard** — Branch protection; team composition; required setup for new bots.
+
+- **Copilot Instructions Standard** — Canonical instruction files (source of truth in `.github`);
+  adding a new language; content quality rules.
+
+- **Persona Standards** — Trigger matrix (the onboarding checklist); canary onboarding (the last
+  step); trust, permissions, and safety.
+
+- **PR Limits** — Exempt actors; operator runbook; reconciliation with the Dependabot cap.
 
 ---
 
 ## Contributing
 
 1. Fork the relevant repository and create a branch off `main`.
-2. Follow the [AGENTS.md](https://github.com/petry-projects/.github/blob/main/AGENTS.md) guidelines for commit style, TDD, and CI requirements.
+2. Follow the [AGENTS.md](https://github.com/petry-projects/.github/blob/main/AGENTS.md) guidelines
+   for commit style, TDD, and CI requirements.
 3. Open a pull request — CI must pass before review.
 
 Questions or feedback? Open an issue in the relevant repo.


### PR DESCRIPTION
## Automated README refresh

Regenerated the org meta-repo README(s) in `petry-projects/.github` from live org state
(repository list, standards docs, agent profiles, and installed frameworks).

Generated by the weekly `readme-refresh` workflow in `petry-projects/.github-private`.
Review the diff — curated prose is preserved; only missing/stale facts are corrected.

**Action needed:** these repos have empty GitHub descriptions — set them on the repo page so future refreshes can enrich the table: TalkTerm, markets