### PR TITLE
docs(security): add org-level SECURITY.md (Scorecard Security-Policy, 6 findings)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ This policy applies to all repositories in the **petry-projects** organization
 Report privately via **GitHub's [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)**:
 open the affected repository → **Security** tab → **Report a vulnerability**.
 
-If private reporting is unavailable on a given repo, email **donpetry@gmail.com**
+If private reporting is unavailable on a given repo, email **<donpetry@gmail.com>**
 with the details and "SECURITY" in the subject.
 
 Please include, where possible:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+This policy applies to all repositories in the **petry-projects** organization
+(GitHub serves it as the default for any repo without its own `SECURITY.md`).
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security vulnerabilities.**
+
+Report privately via **GitHub's [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)**:
+open the affected repository → **Security** tab → **Report a vulnerability**.
+
+If private reporting is unavailable on a given repo, email **donpetry@gmail.com**
+with the details and "SECURITY" in the subject.
+
+Please include, where possible:
+
+- the affected repository and version / commit,
+- a description of the issue and its impact,
+- steps to reproduce or a proof of concept,
+- any suggested remediation.
+
+## What to expect
+
+- **Acknowledgement** within 5 business days.
+- An assessment and, for confirmed issues, a remediation plan with a target
+  timeline proportional to severity.
+- Credit in the advisory once a fix is released, if you'd like it.
+
+## Supported versions
+
+These are actively-maintained projects; security fixes are applied to the
+**default branch** and the current release line. Older tags are not patched —
+please upgrade to the latest release.
+
+## Scope
+
+In scope: code, workflows, and configuration in this organization's repositories.
+Out of scope: third-party dependencies (report those upstream), and findings that
+require compromised maintainer credentials or physical access.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,10 +15,10 @@ with the details and "SECURITY" in the subject.
 
 Please include, where possible:
 
-- the affected repository and version / commit,
-- a description of the issue and its impact,
-- steps to reproduce or a proof of concept,
-- any suggested remediation.
+- The affected repository and version / commit.
+- A description of the issue and its impact.
+- Steps to reproduce or a proof of concept.
+- Any suggested remediation.
 
 ## What to expect
 


### PR DESCRIPTION
**Tier 1 quick win.** No org-level security policy existed, so OpenSSF Scorecard's `Security-Policy` check failed across the fleet (**6 open findings**: .github, .github-private, bmad-bgreat-suite, broodminder-export, incubator, repo-template).

A `SECURITY.md` in the **public `.github` repo** is served by GitHub as the **org default** for every repo without its own — so this single file satisfies the check org-wide. Covers private vulnerability reporting (GitHub advisories + email fallback), response SLAs, supported versions, and scope.

_(A copy for `.github-private` will follow so private repos are covered too.)_

Closes the Security-Policy bucket of the scorecard analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Juznz5V6su81ffSND8fg7s