### PR TITLE
ci: scope workflow GITHUB_TOKEN permissions (Scorecard Token-Permissions)

### DIFF
--- a/.github/workflows/auto-rebase-reusable.yml
+++ b/.github/workflows/auto-rebase-reusable.yml
@@ -80,6 +80,8 @@ on:
         description: "PAT with workflows scope — required for sentinel comment to trigger dev-lead rebase"
         required: false
 
+permissions: {}  # no default permissions; each job grants only what it needs
+
 jobs:
   auto-rebase:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependabot-automerge-reusable.yml
+++ b/.github/workflows/dependabot-automerge-reusable.yml
@@ -30,6 +30,8 @@ on:
         description: "GitHub App private key"
         required: true
 
+permissions: {}  # no default permissions; each job grants only what it needs
+
 jobs:
   dependabot:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependabot-rebase-reusable.yml
+++ b/.github/workflows/dependabot-rebase-reusable.yml
@@ -53,6 +53,8 @@ on:
         description: "GitHub App private key"
         required: true
 
+permissions: {}  # no default permissions; each job grants only what it needs
+
 jobs:
   update-and-merge:
     runs-on: ubuntu-latest

--- a/.github/workflows/feature-ideation-reusable.yml
+++ b/.github/workflows/feature-ideation-reusable.yml
@@ -115,6 +115,8 @@ on:
         description: 'Claude Code OAuth token (org-level secret)'
         required: true
 
+permissions: {}  # no default permissions; each job grants only what it needs
+
 jobs:
   # ---------------------------------------------------------------------------
   # Job 1: Gather signals — issues, discussions, releases, community feedback

--- a/.github/workflows/idea-enhancer-reusable.yml
+++ b/.github/workflows/idea-enhancer-reusable.yml
@@ -34,6 +34,8 @@ on:
         description: "Classic PAT with repo + workflow scope used to dispatch the central idea-enhancer (GITHUB_TOKEN cannot start a workflow_dispatch run)."
         required: true
 
+permissions: {}  # no default permissions; each job grants only what it needs
+
 jobs:
   dispatch:
     runs-on: ubuntu-latest

--- a/.github/workflows/idea-triage-reusable.yml
+++ b/.github/workflows/idea-triage-reusable.yml
@@ -31,6 +31,8 @@ on:
         description: "Classic PAT with repo + workflow scope used to dispatch the central idea-triage (GITHUB_TOKEN cannot start a workflow_dispatch run)."
         required: true
 
+permissions: {}  # no default permissions; each job grants only what it needs
+
 jobs:
   dispatch:
     runs-on: ubuntu-latest

--- a/.github/workflows/initiative-planner-reusable.yml
+++ b/.github/workflows/initiative-planner-reusable.yml
@@ -37,6 +37,8 @@ on:
         description: "Classic PAT with repo + workflow scope used to dispatch the central initiative-planner (GITHUB_TOKEN cannot start a workflow_dispatch run)."
         required: true
 
+permissions: {}  # no default permissions; each job grants only what it needs
+
 jobs:
   dispatch:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-auto-review-reusable.yml
+++ b/.github/workflows/pr-auto-review-reusable.yml
@@ -28,6 +28,8 @@ on:
         description: "Classic PAT with repo scope used for API calls and dispatching the review agent"
         required: true
 
+permissions: {}  # no default permissions; each job grants only what it needs
+
 jobs:
   check-and-dispatch:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-review-mention-reusable.yml
+++ b/.github/workflows/pr-review-mention-reusable.yml
@@ -23,6 +23,8 @@ on:
         description: "Classic PAT owned by donpetry-bot, used to post acknowledgement comments as the bot"
         required: true
 
+permissions: {}  # no default permissions; each job grants only what it needs
+
 jobs:
   handle-mention:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why
OpenSSF Scorecard **Token-Permissions** scored this repo **7/10** — some workflows had no top-level `permissions:` block, so their `GITHUB_TOKEN` defaults to broad write at the workflow level.

## What — scoped (9 workflows)
Added a top-level `permissions: {}` to each reusable that lacked one. **Every job in these reusables already declares its own least-privilege `permissions:` block**, so a job-level block always overrides the top-level default — the change is a **runtime no-op** that only removes the implicit broad default and matches the existing fleet convention (`ci.yml`, `dev-lead.yml`, `daily-org-status.yml`).

- `auto-rebase-reusable.yml`
- `dependabot-automerge-reusable.yml`
- `dependabot-rebase-reusable.yml`
- `feature-ideation-reusable.yml`
- `idea-enhancer-reusable.yml`
- `idea-triage-reusable.yml`
- `initiative-planner-reusable.yml`
- `pr-auto-review-reusable.yml`
- `pr-review-mention-reusable.yml`

## Left for manual review
All other workflows already have an explicitly scoped top-level block (`permissions: {}` or `contents: read`); none use `write-all`. Per a conservative scope, no already-scoped block was reduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Juznz5V6su81ffSND8fg7s