### PR TITLE
docs: tag org-level reporting workflows for README discovery

### DIFF
--- a/.github/workflows/compliance-audit-and-improvement.yml
+++ b/.github/workflows/compliance-audit-and-improvement.yml
@@ -8,6 +8,7 @@
 #   Phase 6: Summary report.
 # Standard: https://github.com/${{ github.repository_owner }}/.github/tree/main/standards
 name: Org Standards Compliance Audit
+# readme-report: Weekly org standards compliance audit + runtime health survey, with per-finding remediation issues.
 
 on:
   schedule:

--- a/.github/workflows/daily-org-status.yml
+++ b/.github/workflows/daily-org-status.yml
@@ -1,4 +1,5 @@
 name: Daily Org Status
+# readme-report: Daily "Org Status" digest posted as an issue for maintainers.
 
 on:
   schedule:

--- a/.github/workflows/org-scorecard.yml
+++ b/.github/workflows/org-scorecard.yml
@@ -2,6 +2,7 @@
 # Creates/updates/closes GitHub Issues for findings across the org.
 # Standard: https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#openssf-scorecard-org-scorecardyml
 name: Org Scorecard Review
+# readme-report: Weekly OpenSSF Scorecard security-posture review across public repos; findings tracked as issues.
 
 on:
   schedule:


### PR DESCRIPTION
Adds `# readme-report:` markers to the 3 org-level reporting workflows (daily-org-status, org-scorecard, compliance-audit-and-improvement) so the README Refresh agent lists them in the org READMEs' new **Reporting & Dashboards** section.

Companion to the `.github-private` PR that adds the discovery mechanism + prompt rule. These markers are read via API from `main`, so this should merge for the org-level reports to appear in the refreshed READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the purpose and outputs of weekly compliance audits.
  * Documented that daily organization status digests are posted as issues.
  * Added context for weekly security posture reviews and issue tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->