### PR TITLE
docs: refresh org READMEs (automated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ The `standards/` directory contains the authoritative policy documents for this 
 | [`push-protection`](standards/push-protection.md) | Secret push protection configuration | Layer 1 — GitHub Push Protection, Layer 2 — local pre-commit prevention, Layer 3 — CI secret scanning, incident response, compliance audit checks |
 | [`ruleset-remediation-runbook`](standards/ruleset-remediation-runbook.md) | Runbook for resolving ruleset violations | Snapshot (rollback insurance), bypass actors, legacy ruleset migration, verify, 2026-06-10 fleet remediation |
 
+## Reporting & Dashboards
+
+Scheduled workflows in this repo post audit reports and status digests as issues or run summaries for maintainers.
+
+| Workflow | Purpose |
+|----------|---------|
+| [`compliance-audit-and-improvement.yml`](workflows/compliance-audit-and-improvement.yml) | Weekly org standards compliance audit + runtime health survey, with per-finding remediation issues |
+| [`daily-org-status.yml`](workflows/daily-org-status.yml) | Daily "Org Status" digest posted as an issue for maintainers |
+| [`org-scorecard.yml`](workflows/org-scorecard.yml) | Weekly OpenSSF Scorecard security-posture review across public repos; findings tracked as issues |
+
 ## Related
 
 The companion repository [`petry-projects/.github-private`](https://github.com/petry-projects/.github-private) holds private automation:

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Scheduled workflows in this repo post audit reports and status digests as issues
 
 | Workflow | Purpose |
 |----------|---------|
-| [`compliance-audit-and-improvement.yml`](workflows/compliance-audit-and-improvement.yml) | Weekly org standards compliance audit + runtime health survey, with per-finding remediation issues |
-| [`daily-org-status.yml`](workflows/daily-org-status.yml) | Daily "Org Status" digest posted as an issue for maintainers |
-| [`org-scorecard.yml`](workflows/org-scorecard.yml) | Weekly OpenSSF Scorecard security-posture review across public repos; findings tracked as issues |
+| [`compliance-audit-and-improvement.yml`](.github/workflows/compliance-audit-and-improvement.yml) | Weekly org standards compliance audit + runtime health survey, with per-finding remediation issues |
+| [`daily-org-status.yml`](.github/workflows/daily-org-status.yml) | Daily "Org Status" digest posted as an issue for maintainers |
+| [`org-scorecard.yml`](.github/workflows/org-scorecard.yml) | Weekly OpenSSF Scorecard security-posture review across public repos; findings tracked as issues |
 
 ## Related
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -17,7 +17,7 @@ beekeeping tech, and agent orchestration.
 | [bmad-bgreat-suite](https://github.com/petry-projects/bmad-bgreat-suite) | BMad Operations Suite — SRE and DevOps agents and workflows for the BMad Method ecosystem | Shell |
 | [google-app-scripts](https://github.com/petry-projects/google-app-scripts) | A place to share Google AppScripts for personal productivity | JavaScript |
 | [incubator](https://github.com/petry-projects/incubator) | Product incubator: pre-product idea Discussions, decision briefs/PRD-lite, and disposable POCs. Ideas graduate to their own product repo once a POC proves out. | Shell |
-| [repo-template](https://github.com/petry-projects/repo-template) | Org template repository: one-click scaffold for new petry-projects repos. Files via 'Use this template'; non-file standards via bootstrap. See epic petry-projects/.github-private#964. | Shell |
+| [repo-template](https://github.com/petry-projects/repo-template) | Org template repository: one-click scaffold for new petry-projects repos. Files via 'Use this template'; non-file standards via bootstrap. | Shell |
 | [.github-private](https://github.com/petry-projects/.github-private) | Org-wide Copilot custom agents, Claude Code skills, and agentic workflow infrastructure | Shell |
 | [.github](https://github.com/petry-projects/.github) | Organization-wide GitHub configuration, CI templates, and engineering standards | Shell |
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -15,9 +15,9 @@ beekeeping tech, and agent orchestration.
 | [broodminder-export](https://github.com/petry-projects/broodminder-export) | Extract all of your data from the BroodMinder API into portable files — resumable, rate-limit-aware. | Python |
 | [ContentTwin](https://github.com/petry-projects/ContentTwin) | AI-powered Social Media Agent for small organizations — enterprise-quality social presence at non-profit pricing | Shell |
 | [bmad-bgreat-suite](https://github.com/petry-projects/bmad-bgreat-suite) | BMad Operations Suite — SRE and DevOps agents and workflows for the BMad Method ecosystem | Shell |
-| [google-app-scripts](https://github.com/petry-projects/google-app-scripts) | A collection of Google Apps Scripts for personal productivity automation | JavaScript |
+| [google-app-scripts](https://github.com/petry-projects/google-app-scripts) | A place to share Google AppScripts for personal productivity | JavaScript |
 | [incubator](https://github.com/petry-projects/incubator) | Product incubator: pre-product idea Discussions, decision briefs/PRD-lite, and disposable POCs. Ideas graduate to their own product repo once a POC proves out. | Shell |
-| [repo-template](https://github.com/petry-projects/repo-template) | Org template repository: one-click scaffold for new petry-projects repos. Files via 'Use this template'; non-file standards via bootstrap. | Shell |
+| [repo-template](https://github.com/petry-projects/repo-template) | Org template repository: one-click scaffold for new petry-projects repos. Files via 'Use this template'; non-file standards via bootstrap. See epic petry-projects/.github-private#964. | Shell |
 | [.github-private](https://github.com/petry-projects/.github-private) | Org-wide Copilot custom agents, Claude Code skills, and agentic workflow infrastructure | Shell |
 | [.github](https://github.com/petry-projects/.github) | Organization-wide GitHub configuration, CI templates, and engineering standards | Shell |
 
@@ -52,10 +52,30 @@ All repositories in this org follow shared engineering standards defined in
 - **Copilot Instructions Standard** — Canonical instruction files (source of truth in `.github`);
   adding a new language; content quality rules.
 
+- **Feature Ideation Sources** — AI/ML vendor & lab primary sources; research & trends; developer
+  tooling and platform changelogs; security & compliance feeds; newsletters, podcasts, and conferences.
+
+- **Initiatives Project** — What belongs on the board; fields; theme → initiative mapping; views;
+  how the auto-add works.
+
 - **Persona Standards** — Trigger matrix (the onboarding checklist); canary onboarding (the last
   step); trust, permissions, and safety.
 
 - **PR Limits** — Exempt actors; operator runbook; reconciliation with the Dependabot cap.
+
+- **Ruleset Remediation Runbook** — Snapshot every ruleset for rollback insurance; bypass actor
+  management; legacy ruleset migration; verify and rollback procedures.
+
+---
+
+## Reporting & Dashboards
+
+Scheduled reports and dashboards post as issues or run summaries for org maintainers:
+
+- **Compliance audit & improvement** — Weekly org standards compliance audit + runtime health survey,
+  with per-finding remediation issues.
+- **Daily org status** — Daily "Org Status" digest posted as an issue for maintainers.
+- **OpenSSF Scorecard** — Weekly security-posture review across public repos; findings tracked as issues.
 
 ---
 


### PR DESCRIPTION
## Automated README refresh

Regenerated the org meta-repo README(s) in `petry-projects/.github` from live org state
(repository list, standards docs, agent profiles, and installed frameworks).

Generated by the weekly `readme-refresh` workflow in `petry-projects/.github-private`.
Review the diff — curated prose is preserved; only missing/stale facts are corrected.

**Action needed:** these repos have empty GitHub descriptions — set them on the repo page so future refreshes can enrich the table: TalkTerm, markets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Reporting & Dashboards” section describing scheduled compliance, organization-status, and OpenSSF Scorecard reports.
  * Documented the workflows’ purposes, including audit remediation and issue tracking.
  * Expanded standards and practices references with feature ideation, initiatives, and remediation guidance.
  * Updated the project description for the Google Apps Scripts repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->