### PR TITLE
docs: refresh org READMEs (automated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Scheduled workflows in this repo post audit reports and status digests as issues
 
 | Workflow | Purpose |
 |----------|---------|
-| [`compliance-audit-and-improvement.yml`](.github/workflows/compliance-audit-and-improvement.yml) | Weekly org standards compliance audit + runtime health survey, with per-finding remediation issues |
-| [`daily-org-status.yml`](.github/workflows/daily-org-status.yml) | Daily "Org Status" digest posted as an issue for maintainers |
-| [`org-scorecard.yml`](.github/workflows/org-scorecard.yml) | Weekly OpenSSF Scorecard security-posture review across public repos; findings tracked as issues |
+| [`compliance-audit-and-improvement.yml`](https://github.com/petry-projects/.github/blob/main/.github/workflows/compliance-audit-and-improvement.yml) | Weekly org standards compliance audit + runtime health survey, with per-finding remediation issues |
+| [`daily-org-status.yml`](https://github.com/petry-projects/.github/blob/main/.github/workflows/daily-org-status.yml) | Daily "Org Status" digest posted as an issue for maintainers |
+| [`org-scorecard.yml`](https://github.com/petry-projects/.github/blob/main/.github/workflows/org-scorecard.yml) | Weekly OpenSSF Scorecard security-posture review across public repos; findings tracked as issues |
 
 ## Related
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -18,7 +18,7 @@ beekeeping tech, and agent orchestration.
 | [google-app-scripts](https://github.com/petry-projects/google-app-scripts) | A place to share Google AppScripts for personal productivity | JavaScript |
 | [incubator](https://github.com/petry-projects/incubator) | Product incubator: pre-product idea Discussions, decision briefs/PRD-lite, and disposable POCs. Ideas graduate to their own product repo once a POC proves out. | Shell |
 | [repo-template](https://github.com/petry-projects/repo-template) | Org template repository: one-click scaffold for new petry-projects repos. Files via 'Use this template'; non-file standards via bootstrap. | Shell |
-| [.github-private](https://github.com/petry-projects/.github-private) | Org-wide Copilot custom agents and agentic workflow infrastructure | Shell |
+| [.github-private](https://github.com/petry-projects/.github-private) | Org-wide Copilot custom agents, skills, and agentic workflow infrastructure | Shell |
 | [.github](https://github.com/petry-projects/.github) | Organization-wide GitHub configuration, CI templates, and engineering standards | Shell |
 
 ---
@@ -28,46 +28,46 @@ beekeeping tech, and agent orchestration.
 All repositories in this org follow shared engineering standards defined in
 [`.github`](https://github.com/petry-projects/.github):
 
-- **[CI Standards](../standards/ci-standards.md)** — Reusable workflow versioning via the `stable` channel;
+- **[CI Standards](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md)** — Reusable workflow versioning via the `stable` channel;
   staged promotion through concentric rings; action pinning policy; permissions policy; workflow patterns
   by tech stack (Node.js, Go, Python, Electron).
 
-- **[Advanced Security](../standards/advanced-security.md)** — Code Security Configurations for the org
+- **[Advanced Security](https://github.com/petry-projects/.github/blob/main/standards/advanced-security.md)** — Code Security Configurations for the org
   fleet; push-protection live-fire canary test; custom secret scanning patterns; compliance audit checks.
 
-- **[Push Protection](../standards/push-protection.md)** — GitHub push protection (primary enforcement);
+- **[Push Protection](https://github.com/petry-projects/.github/blob/main/standards/push-protection.md)** — GitHub push protection (primary enforcement);
   local pre-commit prevention; CI secret scanning (secondary defense); incident response runbook.
 
-- **[Agent Standards](../standards/agent-standards.md)** — AgentShield deep security scan; required agent
+- **[Agent Standards](https://github.com/petry-projects/.github/blob/main/standards/agent-standards.md)** — AgentShield deep security scan; required agent
   files and compliance exemptions; BMAD Method workflows; decision-making reusables.
 
-- **[Dependabot Policy](../standards/dependabot-policy.md)** — Stack-specific templates (npm, Go, Rust,
+- **[Dependabot Policy](https://github.com/petry-projects/.github/blob/main/standards/dependabot-policy.md)** — Stack-specific templates (npm, Go, Rust,
   Python, Terraform, Actions); auto-merge workflow; vulnerability audit CI check; CODEOWNERS approval
   timing.
 
-- **[GitHub Settings](../standards/github-settings.md)** — Repository rulesets (`pr-quality`,
+- **[GitHub Settings](https://github.com/petry-projects/.github/blob/main/standards/github-settings.md)** — Repository rulesets (`pr-quality`,
   `code-quality`); auto-merge configuration; bypass actors; labels — standard set; org-level secrets.
 
-- **[CODEOWNERS Standard](../standards/codeowners-standard.md)** — Branch protection; team composition;
+- **[CODEOWNERS Standard](https://github.com/petry-projects/.github/blob/main/standards/codeowners-standard.md)** — Branch protection; team composition;
   required setup for new bots.
 
-- **[Copilot Instructions Standard](../standards/copilot-instructions-standard.md)** — Canonical
+- **[Copilot Instructions Standard](https://github.com/petry-projects/.github/blob/main/standards/copilot-instructions-standard.md)** — Canonical
   instruction files (source of truth in `.github`); adding a new language; content quality rules.
 
-- **[Feature Ideation Sources](../standards/feature-ideation-sources.md)** — AI/ML vendor & lab primary
+- **[Feature Ideation Sources](https://github.com/petry-projects/.github/blob/main/standards/feature-ideation-sources.md)** — AI/ML vendor & lab primary
   sources; research & trends; developer tooling and platform changelogs; security & compliance feeds;
   newsletters, podcasts, and conferences.
 
-- **[Initiatives Project](../standards/initiatives-project.md)** — What belongs on the board; fields;
+- **[Initiatives Project](https://github.com/petry-projects/.github/blob/main/standards/initiatives-project.md)** — What belongs on the board; fields;
   theme → initiative mapping; views; how the auto-add works.
 
-- **[Persona Standards](../standards/persona-standards.md)** — Trigger matrix (the onboarding checklist);
+- **[Persona Standards](https://github.com/petry-projects/.github/blob/main/standards/persona-standards.md)** — Trigger matrix (the onboarding checklist);
   canary onboarding (the last step); trust, permissions, and safety.
 
-- **[PR Limits](../standards/pr-limits.md)** — Exempt actors; operator runbook; reconciliation with the
+- **[PR Limits](https://github.com/petry-projects/.github/blob/main/standards/pr-limits.md)** — Exempt actors; operator runbook; reconciliation with the
   Dependabot cap.
 
-- **[Ruleset Remediation Runbook](../standards/ruleset-remediation-runbook.md)** — Snapshot every ruleset
+- **[Ruleset Remediation Runbook](https://github.com/petry-projects/.github/blob/main/standards/ruleset-remediation-runbook.md)** — Snapshot every ruleset
   for rollback insurance; bypass actor management; legacy ruleset migration; verify and rollback
   procedures.
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -18,7 +18,7 @@ beekeeping tech, and agent orchestration.
 | [google-app-scripts](https://github.com/petry-projects/google-app-scripts) | A place to share Google AppScripts for personal productivity | JavaScript |
 | [incubator](https://github.com/petry-projects/incubator) | Product incubator: pre-product idea Discussions, decision briefs/PRD-lite, and disposable POCs. Ideas graduate to their own product repo once a POC proves out. | Shell |
 | [repo-template](https://github.com/petry-projects/repo-template) | Org template repository: one-click scaffold for new petry-projects repos. Files via 'Use this template'; non-file standards via bootstrap. | Shell |
-| [.github-private](https://github.com/petry-projects/.github-private) | Org-wide Copilot custom agents, Claude Code skills, and agentic workflow infrastructure | Shell |
+| [.github-private](https://github.com/petry-projects/.github-private) | Org-wide Copilot custom agents and agentic workflow infrastructure | Shell |
 | [.github](https://github.com/petry-projects/.github) | Organization-wide GitHub configuration, CI templates, and engineering standards | Shell |
 
 ---
@@ -28,43 +28,48 @@ beekeeping tech, and agent orchestration.
 All repositories in this org follow shared engineering standards defined in
 [`.github`](https://github.com/petry-projects/.github):
 
-- **CI Standards** — Reusable workflow versioning via the `stable` channel; staged promotion through
-  concentric rings; action pinning policy; permissions policy; workflow patterns by tech stack
-  (Node.js, Go, Python, Electron).
+- **[CI Standards](../standards/ci-standards.md)** — Reusable workflow versioning via the `stable` channel;
+  staged promotion through concentric rings; action pinning policy; permissions policy; workflow patterns
+  by tech stack (Node.js, Go, Python, Electron).
 
-- **Advanced Security** — Code Security Configurations for the org fleet; push-protection live-fire
-  canary test; custom secret scanning patterns; compliance audit checks.
+- **[Advanced Security](../standards/advanced-security.md)** — Code Security Configurations for the org
+  fleet; push-protection live-fire canary test; custom secret scanning patterns; compliance audit checks.
 
-- **Push Protection** — GitHub push protection (primary enforcement); local pre-commit prevention;
-  CI secret scanning (secondary defense); incident response runbook.
+- **[Push Protection](../standards/push-protection.md)** — GitHub push protection (primary enforcement);
+  local pre-commit prevention; CI secret scanning (secondary defense); incident response runbook.
 
-- **Agent Standards** — AgentShield deep security scan; required agent files and compliance
-  exemptions; BMAD Method workflows; decision-making reusables.
+- **[Agent Standards](../standards/agent-standards.md)** — AgentShield deep security scan; required agent
+  files and compliance exemptions; BMAD Method workflows; decision-making reusables.
 
-- **Dependabot Policy** — Stack-specific templates (npm, Go, Rust, Python, Terraform, Actions);
-  auto-merge workflow; vulnerability audit CI check; CODEOWNERS approval timing.
+- **[Dependabot Policy](../standards/dependabot-policy.md)** — Stack-specific templates (npm, Go, Rust,
+  Python, Terraform, Actions); auto-merge workflow; vulnerability audit CI check; CODEOWNERS approval
+  timing.
 
-- **GitHub Settings** — Repository rulesets (`pr-quality`, `code-quality`); auto-merge
-  configuration; bypass actors; labels — standard set; org-level secrets.
+- **[GitHub Settings](../standards/github-settings.md)** — Repository rulesets (`pr-quality`,
+  `code-quality`); auto-merge configuration; bypass actors; labels — standard set; org-level secrets.
 
-- **CODEOWNERS Standard** — Branch protection; team composition; required setup for new bots.
+- **[CODEOWNERS Standard](../standards/codeowners-standard.md)** — Branch protection; team composition;
+  required setup for new bots.
 
-- **Copilot Instructions Standard** — Canonical instruction files (source of truth in `.github`);
-  adding a new language; content quality rules.
+- **[Copilot Instructions Standard](../standards/copilot-instructions-standard.md)** — Canonical
+  instruction files (source of truth in `.github`); adding a new language; content quality rules.
 
-- **Feature Ideation Sources** — AI/ML vendor & lab primary sources; research & trends; developer
-  tooling and platform changelogs; security & compliance feeds; newsletters, podcasts, and conferences.
+- **[Feature Ideation Sources](../standards/feature-ideation-sources.md)** — AI/ML vendor & lab primary
+  sources; research & trends; developer tooling and platform changelogs; security & compliance feeds;
+  newsletters, podcasts, and conferences.
 
-- **Initiatives Project** — What belongs on the board; fields; theme → initiative mapping; views;
-  how the auto-add works.
+- **[Initiatives Project](../standards/initiatives-project.md)** — What belongs on the board; fields;
+  theme → initiative mapping; views; how the auto-add works.
 
-- **Persona Standards** — Trigger matrix (the onboarding checklist); canary onboarding (the last
-  step); trust, permissions, and safety.
+- **[Persona Standards](../standards/persona-standards.md)** — Trigger matrix (the onboarding checklist);
+  canary onboarding (the last step); trust, permissions, and safety.
 
-- **PR Limits** — Exempt actors; operator runbook; reconciliation with the Dependabot cap.
+- **[PR Limits](../standards/pr-limits.md)** — Exempt actors; operator runbook; reconciliation with the
+  Dependabot cap.
 
-- **Ruleset Remediation Runbook** — Snapshot every ruleset for rollback insurance; bypass actor
-  management; legacy ruleset migration; verify and rollback procedures.
+- **[Ruleset Remediation Runbook](../standards/ruleset-remediation-runbook.md)** — Snapshot every ruleset
+  for rollback insurance; bypass actor management; legacy ruleset migration; verify and rollback
+  procedures.
 
 ---
 
@@ -72,10 +77,12 @@ All repositories in this org follow shared engineering standards defined in
 
 Scheduled reports and dashboards post as issues or run summaries for org maintainers:
 
-- **Compliance audit & improvement** — Weekly org standards compliance audit + runtime health survey,
-  with per-finding remediation issues.
-- **Daily org status** — Daily "Org Status" digest posted as an issue for maintainers.
-- **OpenSSF Scorecard** — Weekly security-posture review across public repos; findings tracked as issues.
+- **[Compliance audit & improvement](https://github.com/petry-projects/.github/blob/main/.github/workflows/compliance-audit-and-improvement.yml)**
+  — Weekly org standards compliance audit + runtime health survey, with per-finding remediation issues.
+- **[Daily org status](https://github.com/petry-projects/.github/blob/main/.github/workflows/daily-org-status.yml)**
+  — Daily "Org Status" digest posted as an issue for maintainers.
+- **[OpenSSF Scorecard](https://github.com/petry-projects/.github/blob/main/.github/workflows/org-scorecard.yml)**
+  — Weekly security-posture review across public repos; findings tracked as issues.
 
 ---
 


### PR DESCRIPTION
## Automated README refresh

Regenerated the org meta-repo README(s) in `petry-projects/.github` from live org state
(repository list, standards docs, agent profiles, and installed frameworks).

Generated by the weekly `readme-refresh` workflow in `petry-projects/.github-private`.
Review the diff — curated prose is preserved; only missing/stale facts are corrected.

**Action needed:** these repos have empty GitHub descriptions — set them on the repo page so future refreshes can enrich the table: TalkTerm, markets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated reporting and dashboard references to use direct links to their GitHub workflow pages.
  * Added links from standards and practices entries to their detailed documentation.
  * Clarified the Projects table by removing the “Claude Code skills” reference.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->