### PR TITLE
Add the persona @-mention router

### DIFF
--- a/.github/workflows/persona-mention-reusable.yml
+++ b/.github/workflows/persona-mention-reusable.yml
@@ -63,8 +63,8 @@ jobs:
   route:
     runs-on: ubuntu-latest
     permissions:
-      contents: read         # actions/checkout of petry-projects/.github tooling
-      issues: read          # read the item's labels for the opt-out check
+      contents: read        # actions/checkout of the tooling repo
+      issues: read          # read the item's labels for the opt-out / gate checks
       pull-requests: read
     # The CHEAP pre-filter, mirrored from pm_should_route (tests/persona_mention.bats).
     # It runs BEFORE the job starts, so secrets are never exposed to a run that a
@@ -82,23 +82,12 @@ jobs:
     # The trust check here is the conservative §4 default. A persona may TIGHTEN
     # it in its own manifest (enforced below), never loosen it — so this gate is
     # always at least as strict as the union of what the personas allow.
-    #
-    # review_requested events (§4 "mention" surface, "Reviewer-assignment counts
-    # here too") are also admitted: only org members with write+ access can assign
-    # team reviewers, so the recursion guards do not apply.
     if: |
-      (
-        contains(github.event.comment.body, '@petry-projects/') &&
-        github.event.comment.user.login != 'donpetry-bot' &&
-        github.event.comment.user.login != 'github-actions[bot]' &&
-        !contains(github.event.comment.body, '<!-- persona:') &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
-      ) ||
-      (
-        github.event_name == 'pull_request' &&
-        github.event.action == 'review_requested' &&
-        github.event.requested_team.slug != ''
-      )
+      contains(github.event.comment.body, '@petry-projects/') &&
+      github.event.comment.user.login != 'donpetry-bot' &&
+      github.event.comment.user.login != 'github-actions[bot]' &&
+      !contains(github.event.comment.body, '<!-- persona:') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
 
     steps:
       - name: Checkout persona-mention tooling
@@ -110,7 +99,14 @@ jobs:
           ref: ${{ inputs.tooling_ref || github.job_workflow_sha }}
           path: .persona-tooling
           fetch-depth: 1
-          persist-credentials: false  # no git operations after checkout; leave no token in config
+          persist-credentials: false   # the tooling checkout needs no push creds
+
+      - name: Ensure PyYAML
+        # pm_manifest_query parses the manifest with python3 + yaml. PyYAML is NOT
+        # documented as preinstalled on the runner images, and this reusable runs
+        # on the CALLER's runner, so we cannot assume the caller installed it.
+        # Cheap no-op when present.
+        run: python3 -c 'import yaml' 2>/dev/null || pip install --quiet --disable-pip-version-check pyyaml
 
       - name: Route the mention
         env:
@@ -126,41 +122,38 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           ITEM_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number || github.event.discussion.number }}
           SOURCE_REPO: ${{ github.repository }}
-          # review_requested fields (empty for comment events)
-          REQUESTED_TEAM_SLUG: ${{ github.event.requested_team.slug }}
-          REQUESTER_LOGIN: ${{ github.event.sender.login }}
-          PR_HTML_URL: ${{ github.event.pull_request.html_url }}
         run: |
           set -euo pipefail
           # shellcheck source=scripts/lib/persona-mention.sh
           source .persona-tooling/scripts/lib/persona-mention.sh
 
-          # Normalize the two routing paths: comment @-mention vs reviewer assignment.
-          # reviewer assignment (§4 "mention" surface): the team slug is direct —
-          # no body to parse, no recursion guards needed (assigning a reviewer requires
-          # write+ access), trust floor still enforced per-persona below.
-          if [ "$EVENT_NAME" = "pull_request" ] && [ -n "${REQUESTED_TEAM_SLUG:-}" ]; then
-            DISPATCH_SLUGS="$REQUESTED_TEAM_SLUG"
-            COMMENT_USER="${REQUESTER_LOGIN:-}"
-            COMMENT_URL="${PR_HTML_URL:-}"
-            # Use COLLABORATOR as a synthetic floor-check association; assigning a team
-            # reviewer requires at least write access, which maps to COLLABORATOR.
-            COMMENT_ASSOC="COLLABORATOR"
-          else
-            if ! pm_should_route "$COMMENT_USER" "$COMMENT_ASSOC" "$COMMENT_BODY"; then
-              echo "Not routable (bot actor, agent marker, trust floor, or no handle) — nothing to do."
-              exit 0
-            fi
-            DISPATCH_SLUGS="$(pm_extract_slugs "$COMMENT_BODY")"
+          if ! pm_should_route "$COMMENT_USER" "$COMMENT_ASSOC" "$COMMENT_BODY"; then
+            echo "Not routable (bot actor, agent marker, trust floor, or no handle) — nothing to do."
+            exit 0
           fi
 
-          # Labels for the opt-out check. Discussions have no labels API surface
-          # here, so an empty set is correct rather than fatal. For issues and PRs,
-          # a label-fetch failure means we cannot verify opt-out — refuse rather than
-          # route through a potentially opted-out item (fail closed).
+          # Labels back BOTH the opt-out check and the write-mode gate, so an
+          # unreadable label set is never "no labels". `|| echo ""` here would let
+          # a transient API error bypass an opt-out and arm an ungated write —
+          # the fail-open pattern this framework already had four of (#755).
+          #
+          # Discussions genuinely have no labels API surface, so an empty set is
+          # the true answer there, not an error. That difference is load-bearing:
+          # write-mode on a discussion is refused below precisely because the gate
+          # cannot be verified.
           LABELS=""
-          if [ "$EVENT_NAME" != "discussion_comment" ] && [ -n "${ITEM_NUMBER:-}" ]; then
-            LABELS="$(gh api "/repos/${SOURCE_REPO}/issues/${ITEM_NUMBER}/labels" --jq '.[].name')"
+          LABELS_KNOWN=false
+          if [ "$EVENT_NAME" = "discussion_comment" ]; then
+            echo "Discussion comment — no labels surface; opt-out/gate labels unavailable."
+          elif [ -z "${ITEM_NUMBER:-}" ]; then
+            echo "::error::no item number resolved for event '${EVENT_NAME}' — cannot check opt-out or gate labels"
+            exit 1
+          else
+            if ! LABELS="$(gh api "/repos/${SOURCE_REPO}/issues/${ITEM_NUMBER}/labels" --jq '.[].name')"; then
+              echo "::error::could not read labels for ${SOURCE_REPO}#${ITEM_NUMBER} — refusing to route (an unreadable label set must never be read as 'no opt-out, no gate')"
+              exit 1
+            fi
+            LABELS_KNOWN=true
           fi
 
           dispatched=0
@@ -169,28 +162,43 @@ jobs:
             echo "::group::@petry-projects/${slug}"
 
             url="$(pm_manifest_url "$slug")"
-            if ! manifest="$(curl -fsSL --max-time 20 -H "Authorization: token ${GH_TOKEN}" "$url" 2>/dev/null)"; then
-              echo "No manifest at ${url} — not a persona (a real team, or a typo). Skipping."
+            # A 404 is a real ANSWER ("not a persona" — a plain team like
+            # @petry-projects/org-leads, or a typo). Anything else is a FAILURE to
+            # get an answer. `curl -f` collapses both into exit 22, which would
+            # make a raw.githubusercontent 5xx silently disable every persona
+            # fleet-wide with no error anywhere — indistinguishable from nobody
+            # being addressed. Separate them on the status code.
+            body_file="$(mktemp)"
+            http="$(curl -sSL --max-time 20 -o "$body_file" -w '%{http_code}' "$url" || echo 000)"
+            case "$http" in
+              200)
+                manifest="$(cat "$body_file")"
+                ;;
+              404)
+                rm -f "$body_file"
+                echo "No manifest at ${url} — not a persona (a plain team, or a typo). Skipping."
+                echo "::endgroup::"
+                continue
+                ;;
+              *)
+                rm -f "$body_file"
+                echo "::error::fetching ${url} returned HTTP ${http} — refusing to treat a fetch failure as 'not a persona'"
+                exit 1
+                ;;
+            esac
+            rm -f "$body_file"
+
+            # The slug we routed on must equal the id the manifest claims. These
+            # cannot diverge while validate-personas.py holds, so a mismatch means
+            # the invariant broke — refuse rather than guess which one is right.
+            claimed="$(pm_persona_id "$manifest")"
+            if [ "$claimed" != "$slug" ]; then
+              echo "::warning::manifest at ${url} claims id '${claimed}' but was addressed as '${slug}' — refusing to route"
               echo "::endgroup::"
               continue
             fi
 
-            # The slug we routed on must equal the id the manifest claims. If not,
-            # check whether the slug is a declared alias (§4.1 rule 5: renames keep
-            # the old handle as an alias so in-flight threads do not break).
-            claimed="$(pm_persona_id "$manifest")"
-            if [ "$claimed" != "$slug" ]; then
-              if pm_persona_aliases "$manifest" | grep -qxF "$slug"; then
-                echo "Alias '${slug}' resolved to canonical persona '${claimed}'."
-                slug="$claimed"
-              else
-                echo "::warning::manifest at ${url} claims id '${claimed}' but was addressed as '${slug}' (not in aliases) — refusing to route"
-                echo "::endgroup::"
-                continue
-              fi
-            fi
-
-            read -r enabled mode opt_out gate_label <<<"$(pm_mention_decision "$manifest")"
+            read -r enabled mode opt_out <<<"$(pm_mention_decision "$manifest")"
             if [ "$enabled" != "true" ]; then
               echo "Persona '${slug}' does not enable the mention surface (mode=${mode}). Skipping."
               echo "::endgroup::"
@@ -203,12 +211,28 @@ jobs:
               continue
             fi
 
-            # write-mode gate: the persona must declare a gate_label and the item must
-            # carry it before write mode is armed (§1 principle 3, §4 rule 2).
-            if [ "$mode" = "write" ] && [ -n "${gate_label:-}" ] && ! printf '%s\n' "$LABELS" | grep -qxF "$gate_label"; then
-              echo "Item does not carry gate label '${gate_label}' — write mode not armed for '${slug}'. Skipping."
-              echo "::endgroup::"
-              continue
+            # A write-mode mention must be ARMED. §4 rule 2 makes gate_label
+            # schema-required for write surfaces, but the schema only enforces
+            # that it is DECLARED — declaring a lock is not locking the door.
+            # Without this, '@petry-projects/dev-lead do X' is an ungated write
+            # the moment the first write persona onboards (#755).
+            if [ "$mode" = "write" ]; then
+              gate="$(pm_mention_gate_label "$manifest")"
+              if [ -z "$gate" ]; then
+                echo "::error::persona '${slug}' declares mode=write with no gate_label — refusing (schema violation: §4 rule 2)"
+                exit 1
+              fi
+              if [ "$LABELS_KNOWN" != "true" ]; then
+                echo "Persona '${slug}' is write-mode but labels are unavailable on this surface — cannot verify gate '${gate}'. Refusing."
+                echo "::endgroup::"
+                continue
+              fi
+              if ! printf '%s\n' "$LABELS" | grep -qxF "$gate"; then
+                echo "Persona '${slug}' is write-mode and NOT armed — '${gate}' absent. Skipping."
+                echo "::endgroup::"
+                continue
+              fi
+              echo "Write-mode armed by '${gate}'."
             fi
 
             # The persona's own floor, which may TIGHTEN the job-level default.
@@ -237,6 +261,6 @@ jobs:
               --field "client_payload[requested_by]=$COMMENT_USER"
             dispatched=$((dispatched + 1))
             echo "::endgroup::"
-          done <<< "$DISPATCH_SLUGS"
+          done < <(pm_extract_slugs "$COMMENT_BODY")
 
           echo "Dispatched ${dispatched} persona(s)."

--- a/.github/workflows/persona-mention-reusable.yml
+++ b/.github/workflows/persona-mention-reusable.yml
@@ -63,6 +63,7 @@ jobs:
   route:
     runs-on: ubuntu-latest
     permissions:
+      contents: read         # actions/checkout of petry-projects/.github tooling
       issues: read          # read the item's labels for the opt-out check
       pull-requests: read
     # The CHEAP pre-filter, mirrored from pm_should_route (tests/persona_mention.bats).
@@ -81,12 +82,23 @@ jobs:
     # The trust check here is the conservative §4 default. A persona may TIGHTEN
     # it in its own manifest (enforced below), never loosen it — so this gate is
     # always at least as strict as the union of what the personas allow.
+    #
+    # review_requested events (§4 "mention" surface, "Reviewer-assignment counts
+    # here too") are also admitted: only org members with write+ access can assign
+    # team reviewers, so the recursion guards do not apply.
     if: |
-      contains(github.event.comment.body, '@petry-projects/') &&
-      github.event.comment.user.login != 'donpetry-bot' &&
-      github.event.comment.user.login != 'github-actions[bot]' &&
-      !contains(github.event.comment.body, '<!-- persona:') &&
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      (
+        contains(github.event.comment.body, '@petry-projects/') &&
+        github.event.comment.user.login != 'donpetry-bot' &&
+        github.event.comment.user.login != 'github-actions[bot]' &&
+        !contains(github.event.comment.body, '<!-- persona:') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.action == 'review_requested' &&
+        github.event.requested_team.slug != ''
+      )
 
     steps:
       - name: Checkout persona-mention tooling
@@ -98,6 +110,7 @@ jobs:
           ref: ${{ inputs.tooling_ref || github.job_workflow_sha }}
           path: .persona-tooling
           fetch-depth: 1
+          persist-credentials: false  # no git operations after checkout; leave no token in config
 
       - name: Route the mention
         env:
@@ -113,21 +126,41 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           ITEM_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number || github.event.discussion.number }}
           SOURCE_REPO: ${{ github.repository }}
+          # review_requested fields (empty for comment events)
+          REQUESTED_TEAM_SLUG: ${{ github.event.requested_team.slug }}
+          REQUESTER_LOGIN: ${{ github.event.sender.login }}
+          PR_HTML_URL: ${{ github.event.pull_request.html_url }}
         run: |
           set -euo pipefail
           # shellcheck source=scripts/lib/persona-mention.sh
           source .persona-tooling/scripts/lib/persona-mention.sh
 
-          if ! pm_should_route "$COMMENT_USER" "$COMMENT_ASSOC" "$COMMENT_BODY"; then
-            echo "Not routable (bot actor, agent marker, trust floor, or no handle) — nothing to do."
-            exit 0
+          # Normalize the two routing paths: comment @-mention vs reviewer assignment.
+          # reviewer assignment (§4 "mention" surface): the team slug is direct —
+          # no body to parse, no recursion guards needed (assigning a reviewer requires
+          # write+ access), trust floor still enforced per-persona below.
+          if [ "$EVENT_NAME" = "pull_request" ] && [ -n "${REQUESTED_TEAM_SLUG:-}" ]; then
+            DISPATCH_SLUGS="$REQUESTED_TEAM_SLUG"
+            COMMENT_USER="${REQUESTER_LOGIN:-}"
+            COMMENT_URL="${PR_HTML_URL:-}"
+            # Use COLLABORATOR as a synthetic floor-check association; assigning a team
+            # reviewer requires at least write access, which maps to COLLABORATOR.
+            COMMENT_ASSOC="COLLABORATOR"
+          else
+            if ! pm_should_route "$COMMENT_USER" "$COMMENT_ASSOC" "$COMMENT_BODY"; then
+              echo "Not routable (bot actor, agent marker, trust floor, or no handle) — nothing to do."
+              exit 0
+            fi
+            DISPATCH_SLUGS="$(pm_extract_slugs "$COMMENT_BODY")"
           fi
 
           # Labels for the opt-out check. Discussions have no labels API surface
-          # here, so an empty set is correct rather than fatal.
+          # here, so an empty set is correct rather than fatal. For issues and PRs,
+          # a label-fetch failure means we cannot verify opt-out — refuse rather than
+          # route through a potentially opted-out item (fail closed).
           LABELS=""
           if [ "$EVENT_NAME" != "discussion_comment" ] && [ -n "${ITEM_NUMBER:-}" ]; then
-            LABELS="$(gh api "/repos/${SOURCE_REPO}/issues/${ITEM_NUMBER}/labels" --jq '.[].name' 2>/dev/null || echo "")"
+            LABELS="$(gh api "/repos/${SOURCE_REPO}/issues/${ITEM_NUMBER}/labels" --jq '.[].name')"
           fi
 
           dispatched=0
@@ -136,23 +169,28 @@ jobs:
             echo "::group::@petry-projects/${slug}"
 
             url="$(pm_manifest_url "$slug")"
-            if ! manifest="$(curl -fsSL --max-time 20 "$url" 2>/dev/null)"; then
+            if ! manifest="$(curl -fsSL --max-time 20 -H "Authorization: token ${GH_TOKEN}" "$url" 2>/dev/null)"; then
               echo "No manifest at ${url} — not a persona (a real team, or a typo). Skipping."
               echo "::endgroup::"
               continue
             fi
 
-            # The slug we routed on must equal the id the manifest claims. These
-            # cannot diverge while validate-personas.py holds, so a mismatch means
-            # the invariant broke — refuse rather than guess which one is right.
+            # The slug we routed on must equal the id the manifest claims. If not,
+            # check whether the slug is a declared alias (§4.1 rule 5: renames keep
+            # the old handle as an alias so in-flight threads do not break).
             claimed="$(pm_persona_id "$manifest")"
             if [ "$claimed" != "$slug" ]; then
-              echo "::warning::manifest at ${url} claims id '${claimed}' but was addressed as '${slug}' — refusing to route"
-              echo "::endgroup::"
-              continue
+              if pm_persona_aliases "$manifest" | grep -qxF "$slug"; then
+                echo "Alias '${slug}' resolved to canonical persona '${claimed}'."
+                slug="$claimed"
+              else
+                echo "::warning::manifest at ${url} claims id '${claimed}' but was addressed as '${slug}' (not in aliases) — refusing to route"
+                echo "::endgroup::"
+                continue
+              fi
             fi
 
-            read -r enabled mode opt_out <<<"$(pm_mention_decision "$manifest")"
+            read -r enabled mode opt_out gate_label <<<"$(pm_mention_decision "$manifest")"
             if [ "$enabled" != "true" ]; then
               echo "Persona '${slug}' does not enable the mention surface (mode=${mode}). Skipping."
               echo "::endgroup::"
@@ -161,6 +199,14 @@ jobs:
 
             if [ -n "$opt_out" ] && printf '%s\n' "$LABELS" | grep -qxF "$opt_out"; then
               echo "Item carries '${opt_out}' — persona '${slug}' is opted out here. Skipping."
+              echo "::endgroup::"
+              continue
+            fi
+
+            # write-mode gate: the persona must declare a gate_label and the item must
+            # carry it before write mode is armed (§1 principle 3, §4 rule 2).
+            if [ "$mode" = "write" ] && [ -n "${gate_label:-}" ] && ! printf '%s\n' "$LABELS" | grep -qxF "$gate_label"; then
+              echo "Item does not carry gate label '${gate_label}' — write mode not armed for '${slug}'. Skipping."
               echo "::endgroup::"
               continue
             fi
@@ -191,6 +237,6 @@ jobs:
               --field "client_payload[requested_by]=$COMMENT_USER"
             dispatched=$((dispatched + 1))
             echo "::endgroup::"
-          done < <(pm_extract_slugs "$COMMENT_BODY")
+          done <<< "$DISPATCH_SLUGS"
 
           echo "Dispatched ${dispatched} persona(s)."

--- a/.github/workflows/persona-mention-reusable.yml
+++ b/.github/workflows/persona-mention-reusable.yml
@@ -177,7 +177,7 @@ jobs:
             # fleet-wide with no error anywhere — indistinguishable from nobody
             # being addressed. Separate them on the status code.
             body_file="$(mktemp)"
-            http="$(curl -sSL --max-time 20 -o "$body_file" -w '%{http_code}' "$url" || echo 000)"
+            http="$(curl -sSL --max-time 20 -H "Authorization: Bearer $GH_TOKEN" -o "$body_file" -w '%{http_code}' "$url" || echo 000)"
             case "$http" in
               200)
                 manifest="$(cat "$body_file")"

--- a/.github/workflows/persona-mention-reusable.yml
+++ b/.github/workflows/persona-mention-reusable.yml
@@ -105,8 +105,16 @@ jobs:
         # pm_manifest_query parses the manifest with python3 + yaml. PyYAML is NOT
         # documented as preinstalled on the runner images, and this reusable runs
         # on the CALLER's runner, so we cannot assume the caller installed it.
-        # Cheap no-op when present.
-        run: python3 -c 'import yaml' 2>/dev/null || pip install --quiet --disable-pip-version-check pyyaml
+        # Cheap no-op when already present.
+        #
+        # Hash- and binary-locked per the dependency-hardening gate
+        # (tests/dependency_hardening.bats). A bare `pip install pyyaml` is an
+        # unpinned, unverified supply-chain install running on every repo in the
+        # fleet — the gate caught exactly that here, and it was right to.
+        run: |
+          python3 -c 'import yaml' 2>/dev/null || \
+            pip install --quiet --require-hashes --only-binary :all: \
+              -r .persona-tooling/scripts/persona-mention-requirements.txt
 
       - name: Route the mention
         env:

--- a/.github/workflows/persona-mention-reusable.yml
+++ b/.github/workflows/persona-mention-reusable.yml
@@ -170,6 +170,21 @@ jobs:
             echo "::group::@petry-projects/${slug}"
 
             url="$(pm_manifest_url "$slug")"
+            # Fetched UNAUTHENTICATED, on purpose. petry-projects/.github-private is
+            # PUBLIC despite its name (private: false), so no token is needed — and
+            # adding one is actively harmful. Measured against this very URL:
+            #
+            #   unauthenticated -> 200      valid token   -> 200
+            #   expired token   -> 404      empty token   -> 404
+            #
+            # raw.githubusercontent answers a bad or MISSING token with 404, not 401.
+            # With an Authorization header, the moment GH_PAT_WORKFLOWS expires — or a
+            # repo adopts the stub before the secret exists, or a fork PR runs without
+            # secrets — every persona would 404 and be silently skipped as "not a
+            # persona". Unauthenticated cannot fail that way for a public repo, so the
+            # header only ADDS a silent-death path. (CodeRabbit asked for auth on the
+            # premise that the repo is private; it is not.)
+            #
             # A 404 is a real ANSWER ("not a persona" — a plain team like
             # @petry-projects/org-leads, or a typo). Anything else is a FAILURE to
             # get an answer. `curl -f` collapses both into exit 22, which would
@@ -177,7 +192,8 @@ jobs:
             # fleet-wide with no error anywhere — indistinguishable from nobody
             # being addressed. Separate them on the status code.
             body_file="$(mktemp)"
-            http="$(curl -sSL --max-time 20 -H "Authorization: Bearer $GH_TOKEN" -o "$body_file" -w '%{http_code}' "$url" || echo 000)"
+            # NO Authorization header, deliberately — see the note above the case.
+            http="$(curl -sSL --max-time 20 -o "$body_file" -w '%{http_code}' "$url" || echo 000)"
             case "$http" in
               200)
                 manifest="$(cat "$body_file")"

--- a/.github/workflows/persona-mention-reusable.yml
+++ b/.github/workflows/persona-mention-reusable.yml
@@ -1,0 +1,196 @@
+# Reusable Persona Mention Router.
+# SOURCE OF TRUTH: petry-projects/.github/.github/workflows/persona-mention-reusable.yml
+# Standard: https://github.com/petry-projects/.github/blob/main/standards/persona-standards.md (§4.1)
+#
+# Routes `@petry-projects/<role>` mentions to the addressed persona. ONE router
+# for every persona — personas do NOT each ship a mention workflow (§4.1); that
+# per-agent drift is exactly what the manifest exists to prevent.
+#
+# How a mention resolves, and why there is no index:
+#   `validate-personas.py` enforces address.handle's slug == id == the persona's
+#   directory name, so '@petry-projects/qa-lead' resolves to
+#   personas/qa-lead/persona.yml in .github-private by convention. The manifest
+#   IS the index-of-record (§1.1). A 404 means "not a persona" — which is also
+#   how a real, non-persona team like @petry-projects/org-leads falls through
+#   harmlessly.
+#
+# The manifest, not this file, decides:
+#   whether the mention surface is enabled, in what mode, behind which trust
+#   floor, and under which opt-out label. This router restates none of it.
+#
+# Requires:
+#   GH_PAT_WORKFLOWS — org secret, classic PAT (repo scope) for API calls and dispatch
+name: Persona Mention Router (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      tooling_ref:
+        description: |
+          Ref of petry-projects/.github to source scripts/lib/persona-mention.sh
+          from. Leave empty (the default) to source it from THIS reusable's own
+          commit (`github.job_workflow_sha`), which guarantees the routing logic
+          always matches the version of this workflow the caller pinned, with no
+          skew (the #465/#528 lesson: a fixed `v1` default predates the library
+          and fails every run with "No such file or directory"). Override only to
+          test a branch end-to-end.
+        required: false
+        default: ''
+        type: string
+      persona_ref:
+        description: |
+          Ref of petry-projects/.github-private to read persona manifests at.
+          Defaults to main — a persona's live contract is what is merged, not
+          what a branch proposes. Override only for end-to-end testing.
+        required: false
+        default: 'main'
+        type: string
+    secrets:
+      GH_PAT_WORKFLOWS:
+        description: 'Classic PAT with repo scope, used for API calls and dispatching the persona'
+        required: true
+
+permissions: {}  # no default permissions; each job grants only what it needs
+
+concurrency:
+  # Serialise per comment, not per thread: two different personas addressed in
+  # one comment are dispatched by a single run, and cancelling an in-flight route
+  # would silently drop a mention.
+  group: persona-mention-${{ github.event.comment.id || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  route:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read          # read the item's labels for the opt-out check
+      pull-requests: read
+    # The CHEAP pre-filter, mirrored from pm_should_route (tests/persona_mention.bats).
+    # It runs BEFORE the job starts, so secrets are never exposed to a run that a
+    # bot, a marked comment, or an untrusted actor triggered.
+    #
+    # Two independent recursion axes, per §4.1 and the #860 postmortem (1,481
+    # acks in 4.5h). Comments posted via a PAT re-trigger workflows, unlike
+    # GITHUB_TOKEN, and with N mutually addressable personas the cycles are
+    # combinatorial, not self-loops:
+    #   1. bot actor — a comment authored by an agent identity never routes
+    #   2. marker    — a comment carrying '<!-- persona:' never routes
+    # Either alone closes the common loop; both together also close the case of
+    # an agent posting under a human's PAT.
+    #
+    # The trust check here is the conservative §4 default. A persona may TIGHTEN
+    # it in its own manifest (enforced below), never loosen it — so this gate is
+    # always at least as strict as the union of what the personas allow.
+    if: |
+      contains(github.event.comment.body, '@petry-projects/') &&
+      github.event.comment.user.login != 'donpetry-bot' &&
+      github.event.comment.user.login != 'github-actions[bot]' &&
+      !contains(github.event.comment.body, '<!-- persona:') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+
+    steps:
+      - name: Checkout persona-mention tooling
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: petry-projects/.github
+          # Source the library from this reusable's own commit so the routing
+          # logic always matches the pinned workflow version (#465/#528).
+          ref: ${{ inputs.tooling_ref || github.job_workflow_sha }}
+          path: .persona-tooling
+          fetch-depth: 1
+
+      - name: Route the mention
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
+          PERSONA_REF: ${{ inputs.persona_ref }}
+          # Every event field arrives via env, never interpolated inline into the
+          # run: body. A comment body and a login are attacker-controlled, and an
+          # inline `${{ }}` in a run: block is a script-injection vector.
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_USER: ${{ github.event.comment.user.login }}
+          COMMENT_ASSOC: ${{ github.event.comment.author_association }}
+          COMMENT_URL: ${{ github.event.comment.html_url }}
+          EVENT_NAME: ${{ github.event_name }}
+          ITEM_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number || github.event.discussion.number }}
+          SOURCE_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # shellcheck source=scripts/lib/persona-mention.sh
+          source .persona-tooling/scripts/lib/persona-mention.sh
+
+          if ! pm_should_route "$COMMENT_USER" "$COMMENT_ASSOC" "$COMMENT_BODY"; then
+            echo "Not routable (bot actor, agent marker, trust floor, or no handle) — nothing to do."
+            exit 0
+          fi
+
+          # Labels for the opt-out check. Discussions have no labels API surface
+          # here, so an empty set is correct rather than fatal.
+          LABELS=""
+          if [ "$EVENT_NAME" != "discussion_comment" ] && [ -n "${ITEM_NUMBER:-}" ]; then
+            LABELS="$(gh api "/repos/${SOURCE_REPO}/issues/${ITEM_NUMBER}/labels" --jq '.[].name' 2>/dev/null || echo "")"
+          fi
+
+          dispatched=0
+          while IFS= read -r slug; do
+            [ -n "$slug" ] || continue
+            echo "::group::@petry-projects/${slug}"
+
+            url="$(pm_manifest_url "$slug")"
+            if ! manifest="$(curl -fsSL --max-time 20 "$url" 2>/dev/null)"; then
+              echo "No manifest at ${url} — not a persona (a real team, or a typo). Skipping."
+              echo "::endgroup::"
+              continue
+            fi
+
+            # The slug we routed on must equal the id the manifest claims. These
+            # cannot diverge while validate-personas.py holds, so a mismatch means
+            # the invariant broke — refuse rather than guess which one is right.
+            claimed="$(pm_persona_id "$manifest")"
+            if [ "$claimed" != "$slug" ]; then
+              echo "::warning::manifest at ${url} claims id '${claimed}' but was addressed as '${slug}' — refusing to route"
+              echo "::endgroup::"
+              continue
+            fi
+
+            read -r enabled mode opt_out <<<"$(pm_mention_decision "$manifest")"
+            if [ "$enabled" != "true" ]; then
+              echo "Persona '${slug}' does not enable the mention surface (mode=${mode}). Skipping."
+              echo "::endgroup::"
+              continue
+            fi
+
+            if [ -n "$opt_out" ] && printf '%s\n' "$LABELS" | grep -qxF "$opt_out"; then
+              echo "Item carries '${opt_out}' — persona '${slug}' is opted out here. Skipping."
+              echo "::endgroup::"
+              continue
+            fi
+
+            # The persona's own floor, which may TIGHTEN the job-level default.
+            # An undeclared floor yields an empty set and pm_trust_ok denies —
+            # a persona that forgot to declare trust must not be more permissive
+            # than one that did.
+            floor="$(pm_mention_trust_floor "$manifest")"
+            # shellcheck disable=SC2086  # word-splitting is the point: floor is a set
+            if ! pm_trust_ok "$COMMENT_ASSOC" $floor; then
+              echo "@${COMMENT_USER} (${COMMENT_ASSOC}) is below persona '${slug}' floor [${floor}]. Skipping."
+              echo "::endgroup::"
+              continue
+            fi
+
+            echo "Routing to '${slug}' (mode=${mode})."
+            gh api \
+              --method POST \
+              --header "Accept: application/vnd.github+json" \
+              /repos/petry-projects/.github-private/dispatches \
+              --field event_type=persona-mention \
+              --field "client_payload[persona]=$slug" \
+              --field "client_payload[mode]=$mode" \
+              --field "client_payload[source_repo]=$SOURCE_REPO" \
+              --field "client_payload[item_number]=${ITEM_NUMBER:-}" \
+              --field "client_payload[comment_url]=$COMMENT_URL" \
+              --field "client_payload[requested_by]=$COMMENT_USER"
+            dispatched=$((dispatched + 1))
+            echo "::endgroup::"
+          done < <(pm_extract_slugs "$COMMENT_BODY")
+
+          echo "Dispatched ${dispatched} persona(s)."

--- a/.github/workflows/persona-mention-tests.yml
+++ b/.github/workflows/persona-mention-tests.yml
@@ -1,0 +1,74 @@
+# Quality gates for the persona @-mention routing core.
+#
+# Standard: standards/persona-standards.md §4.1 (addressing).
+#
+# A bats suite with no CI runner is unenforced — the #613/#624 gap that
+# canary-rollout-tests.yml exists to close. This is that runner for
+# tests/persona_mention.bats, added with the suite rather than after it.
+#
+# Triggered on any PR (or push to main) that touches:
+#   - scripts/lib/persona-mention.sh                   (the pure routing core)
+#   - tests/persona_mention.bats                       (the suite)
+#   - .github/workflows/persona-mention-reusable.yml   (the router that uses it)
+#   - .github/workflows/persona-mention-tests.yml      (this file)
+#
+# Gates (all must pass before merge):
+#   1. shellcheck — static analysis for the pure core
+#   2. bats       — the full routing suite, recursion guards included
+#
+# The core is side-effect-free and network-free by construction (fetching is the
+# workflow's job, not the library's), so the suite pins routing behaviour —
+# especially the two-axis recursion guard — with no API access at all. That
+# matters here: .github-private#860 burned 1,481 acks in 4.5h from a single
+# self-loop, and a regression in pm_should_route is the expensive kind.
+
+name: Persona-mention Tests
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/lib/persona-mention.sh'
+      - 'tests/persona_mention.bats'
+      - '.github/workflows/persona-mention-reusable.yml'
+      - '.github/workflows/persona-mention-tests.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'scripts/lib/persona-mention.sh'
+      - 'tests/persona_mention.bats'
+      - '.github/workflows/persona-mention-reusable.yml'
+      - '.github/workflows/persona-mention-tests.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: persona-mention-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Lint and bats
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install bats, shellcheck, jq, and PyYAML
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends bats shellcheck jq python3-yaml
+
+      - name: shellcheck
+        run: |
+          set -euo pipefail
+          shellcheck --severity=warning -x scripts/lib/persona-mention.sh
+
+      - name: Run bats suite
+        run: bats --print-output-on-failure tests/persona_mention.bats

--- a/scripts/lib/persona-mention.sh
+++ b/scripts/lib/persona-mention.sh
@@ -1,0 +1,208 @@
+# shellcheck shell=bash
+# scripts/lib/persona-mention.sh — Persona @-mention routing core
+#
+# Reusable Bash library implementing the routing decisions behind §4.1 of
+#
+#   standards/persona-standards.md
+#
+# A persona is addressed by an org TEAM handle — `@petry-projects/<role>` — and
+# the manifest at `personas/<role>/persona.yml` in petry-projects/.github-private
+# is the index-of-record for whether that mention should do anything. There is no
+# derived index: `validate-personas.py` enforces `address.handle`'s slug == `id`
+# == the persona's directory name, so a handle resolves to a manifest path by
+# convention. A 404 simply means "not a persona" — which is also how a real,
+# non-persona team (`@petry-projects/org-leads`) falls through harmlessly.
+#
+# ----------------------------------------------------------------------------
+# Caller contract
+# ----------------------------------------------------------------------------
+# This library is `set -euo pipefail`-safe and designed to be sourced by a parent
+# script (`# shellcheck source=scripts/lib/persona-mention.sh`). It does NOT call
+# `set` itself and runs nothing at source time.
+#
+# Reads (all optional, with defaults):
+#   - $PERSONA_ORG        — org that owns the persona teams (default: petry-projects)
+#   - $PERSONA_REPO       — repo holding personas/<id>/persona.yml
+#                           (default: petry-projects/.github-private)
+#   - $PERSONA_REF        — ref to read manifests at (default: main)
+#   - $PERSONA_BOT_LOGINS — space/comma-separated logins whose comments never
+#                           trigger a persona (default: donpetry-bot github-actions[bot])
+#
+# ----------------------------------------------------------------------------
+# Recursion is the hazard this library exists to bound
+# ----------------------------------------------------------------------------
+# Comments posted with a PAT re-trigger workflows (unlike GITHUB_TOKEN).
+# .github-private#860 burned 1,481 identical acks in 4.5h from a SINGLE
+# self-loop, and #538 traced it to an agent emitting a literal '@<handle>' in
+# its own comment. With N mutually addressable personas the cycles stop being
+# self-loops and become combinatorial: qa-lead answering a thread that mentions
+# dev-lead is enough.
+#
+# So every routing decision here excludes on TWO independent axes, per §4.1:
+#   1. the bot actor  — a comment authored by an agent identity never routes, and
+#   2. the marker     — a comment carrying '<!-- persona:' never routes,
+# and callers MUST NOT emit a literal '@<org>/<slug>' in any agent-authored
+# comment. Belt and suspenders: either axis alone closes the common loop, and
+# both together close the case where an agent posts under a human's PAT.
+
+PERSONA_AGENT_MARKER='<!-- persona:'
+
+# pm_bot_logins — emit the configured agent logins, one per line.
+# Accepts comma- and/or whitespace-separated values.
+pm_bot_logins() {
+  local raw="${PERSONA_BOT_LOGINS:-donpetry-bot github-actions[bot]}" item
+  for item in ${raw//,/ }; do
+    [ -n "$item" ] && printf '%s\n' "$item"
+  done
+}
+
+# pm_is_bot_actor <login> — 0 if this login is an agent identity.
+pm_is_bot_actor() {
+  local login="$1" bot
+  [ -n "$login" ] || return 1
+  while IFS= read -r bot; do
+    [ "$login" = "$bot" ] && return 0
+  done < <(pm_bot_logins)
+  return 1
+}
+
+# pm_is_agent_comment <body> — 0 if this body carries the agent marker.
+# Axis 2 of the recursion guard. Deliberately matches the marker PREFIX, not a
+# specific agent's full marker: #860's first fix matched one exact ack string and
+# still self-looped through a different agent-authored comment, so any comment a
+# persona writes about its own work is excluded, not just its ack.
+pm_is_agent_comment() {
+  case "$1" in
+    *"$PERSONA_AGENT_MARKER"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# pm_extract_slugs <body> — emit each DISTINCT persona slug addressed in body.
+#
+# Matches '@<org>/<slug>' where slug is kebab-case, mirroring the schema's
+# address.handle pattern. Order is preserved (first mention wins) and duplicates
+# collapse, so '@petry-projects/qa-lead ... @petry-projects/qa-lead' dispatches
+# once rather than twice.
+#
+# A match here is NOT a decision to run: the slug still has to resolve to a
+# manifest that enables the mention surface. Real teams (org-leads) match the
+# shape and are dropped later by a 404.
+pm_extract_slugs() {
+  local body="$1" org="${PERSONA_ORG:-petry-projects}"
+  printf '%s' "$body" \
+    | grep -oE "@${org}/[a-z0-9]+(-[a-z0-9]+)*" \
+    | sed "s|@${org}/||" \
+    | awk '!seen[$0]++'
+}
+
+# pm_manifest_url <slug> — the raw URL of that persona's manifest.
+pm_manifest_url() {
+  local repo="${PERSONA_REPO:-petry-projects/.github-private}"
+  local ref="${PERSONA_REF:-main}"
+  printf 'https://raw.githubusercontent.com/%s/%s/personas/%s/persona.yml\n' \
+    "$repo" "$ref" "$1"
+}
+
+# pm_trust_ok <author_association> <floor...> — 0 if the association clears the
+# floor. The floor is a set, not a ladder: GitHub's author_association has no
+# total order we should invent (CONTRIBUTOR vs COLLABORATOR is not a rank), so
+# membership is the only honest test. An empty floor denies — a persona that
+# forgot to declare trust must not be more permissive than one that did.
+pm_trust_ok() {
+  local assoc="$1" allowed
+  shift
+  [ -n "$assoc" ] || return 1
+  for allowed in "$@"; do
+    [ "$assoc" = "$allowed" ] && return 0
+  done
+  return 1
+}
+
+# pm_should_route <actor> <author_association> <body> — 0 if this comment is
+# worth spending an API call on.
+#
+# The CHEAP pre-filter, evaluated before any manifest fetch and (in the workflow)
+# before secrets are exposed to the job. It applies the conservative default
+# floor from §4 — [OWNER, MEMBER, COLLABORATOR]. A persona may TIGHTEN that in
+# its own manifest but never loosen it, so gating here can only ever be stricter
+# than the union of what the personas allow, never laxer.
+pm_should_route() {
+  local actor="$1" assoc="$2" body="$3"
+
+  pm_is_bot_actor "$actor" && return 1        # axis 1: bot actor
+  pm_is_agent_comment "$body" && return 1     # axis 2: agent marker
+  pm_trust_ok "$assoc" OWNER MEMBER COLLABORATOR || return 1
+  [ -n "$(pm_extract_slugs "$body")" ] || return 1
+  return 0
+}
+
+# ----------------------------------------------------------------------------
+# Manifest decisions
+# ----------------------------------------------------------------------------
+# The manifest is the index-of-record (§1.1): the router asks it, and restates
+# nothing. These take manifest YAML on stdin so they stay pure and testable —
+# fetching is the caller's job.
+
+# pm_manifest_query <jq-filter> — run a jq filter over a YAML manifest on stdin.
+# Uses python+yaml rather than yq: the fleet's runners are guaranteed python3 +
+# PyYAML (validate-personas.py depends on both) but not yq.
+pm_manifest_query() {
+  local filter="$1" json
+  # Capture rather than pipe straight into jq: a pipeline reports the LAST
+  # command's status, so `python3 ... | jq` would swallow a parse failure and jq
+  # would happily read empty stdin, exit 0, and emit nothing. The caller cannot
+  # then distinguish "manifest says no" from "manifest never parsed" — a silent
+  # mis-route. The library is sourced by `set -euo pipefail` parents but must not
+  # call `set` itself (caller contract), so pipefail is not ours to switch on.
+  json="$(python3 -c '
+import json, sys, yaml
+try:
+    print(json.dumps(yaml.safe_load(sys.stdin.read())))
+except Exception as exc:
+    sys.stderr.write("persona-mention: unparseable manifest: %s\n" % exc)
+    sys.exit(2)
+')" || return 2
+  printf '%s' "$json" | jq -r "$filter"
+}
+
+# pm_mention_decision <manifest-yaml> — emit "<enabled> <mode> <opt_out_label>".
+#
+# Resolves the `mention` surface against the trigger matrix: an explicit row wins;
+# otherwise triggers.default_mode applies (§4). default_mode 'off' means the
+# persona is not addressable at all.
+pm_mention_decision() {
+  # shellcheck disable=SC2016  # $t/$s/$m are jq variables, not shell expansions
+  printf '%s' "$1" | pm_manifest_query '
+    (.triggers // {}) as $t
+    | ($t.surfaces // []) as $s
+    | ($s | map(select(.surface == "mention")) | first) as $m
+    | (if $m == null
+       then (if ($t.default_mode // "off") == "advisory" then "true advisory" else "false off" end)
+       else ((($m.enabled // false) | tostring) + " " + ($m.mode // "advisory"))
+       end) as $decision
+    | $decision + " " + ($t.opt_out_label // "")
+  '
+}
+
+# pm_mention_trust_floor <manifest-yaml> — emit the floor for the mention
+# surface, space-separated. A per-surface trust_floor tightens the persona-wide
+# trust.author_association_floor; when absent, the persona-wide floor applies
+# (§5). Emits nothing when neither is declared — pm_trust_ok then denies, which
+# is the safe direction.
+pm_mention_trust_floor() {
+  # shellcheck disable=SC2016  # $m is a jq variable, not a shell expansion
+  printf '%s' "$1" | pm_manifest_query '
+    ((.triggers.surfaces // []) | map(select(.surface == "mention")) | first) as $m
+    | ($m.trust_floor // .trust.author_association_floor // [])
+    | join(" ")
+  '
+}
+
+# pm_persona_id <manifest-yaml> — the persona id, for cross-checking the slug we
+# routed on against what the manifest actually claims to be. They cannot diverge
+# while validate-personas.py holds, so a mismatch means the invariant broke and
+# the caller should refuse rather than guess.
+pm_persona_id() {
+  printf '%s' "$1" | pm_manifest_query '.id // ""'
+}

--- a/scripts/lib/persona-mention.sh
+++ b/scripts/lib/persona-mention.sh
@@ -166,22 +166,28 @@ except Exception as exc:
   printf '%s' "$json" | jq -r "$filter"
 }
 
-# pm_mention_decision <manifest-yaml> — emit "<enabled> <mode> <opt_out_label>".
+# pm_mention_decision <manifest-yaml> — emit "<enabled> <mode> <opt_out_label> [<gate_label>]".
 #
 # Resolves the `mention` surface against the trigger matrix: an explicit row wins;
 # otherwise triggers.default_mode applies (§4). default_mode 'off' means the
-# persona is not addressable at all.
+# persona is not addressable at all. gate_label is emitted as a 4th field only
+# when the surface declares one (write-mode guard, §1 principle 3).
 pm_mention_decision() {
   # shellcheck disable=SC2016  # $t/$s/$m are jq variables, not shell expansions
-  printf '%s' "$1" | pm_manifest_query '
-    (.triggers // {}) as $t
-    | ($t.surfaces // []) as $s
-    | ($s | map(select(.surface == "mention")) | first) as $m
+  local input="${1:-}"
+  if [ -z "$input" ]; then
+    echo "false off "
+    return
+  fi
+  printf '%s' "$input" | pm_manifest_query '
+    (.triggers? // {}) as $t
+    | ($t.surfaces? // []) as $s
+    | ($s | map(select(.surface? == "mention")) | first) as $m
     | (if $m == null
-       then (if ($t.default_mode // "off") == "advisory" then "true advisory" else "false off" end)
-       else ((($m.enabled // false) | tostring) + " " + ($m.mode // "advisory"))
+       then (if ($t.default_mode? // "off") == "advisory" then "true advisory" else "false off" end)
+       else ((($m.enabled? // false) | tostring) + " " + ($m.mode? // "advisory"))
        end) as $decision
-    | $decision + " " + ($t.opt_out_label // "")
+    | ($decision + " " + ($t.opt_out_label? // "") + " " + (($m // {}).gate_label? // "")) | gsub("\\s+$"; "")
   '
 }
 
@@ -192,10 +198,29 @@ pm_mention_decision() {
 # is the safe direction.
 pm_mention_trust_floor() {
   # shellcheck disable=SC2016  # $m is a jq variable, not a shell expansion
-  printf '%s' "$1" | pm_manifest_query '
-    ((.triggers.surfaces // []) | map(select(.surface == "mention")) | first) as $m
-    | ($m.trust_floor // .trust.author_association_floor // [])
+  local input="${1:-}"
+  if [ -z "$input" ]; then
+    echo ""
+    return
+  fi
+  printf '%s' "$input" | pm_manifest_query '
+    ((.triggers?.surfaces? // []) | map(select(.surface? == "mention")) | first) as $m
+    | ($m.trust_floor? // .trust?.author_association_floor? // [])
     | join(" ")
+  '
+}
+
+# pm_persona_aliases <manifest-yaml> — emit each alias slug (without the org prefix),
+# one per line. Used to validate that an addressed slug is a known alias for the
+# manifest's canonical id when claimed != slug (§4.1 rule 5: renames keep the old
+# handle as an alias).
+pm_persona_aliases() {
+  # shellcheck disable=SC2016  # jq variable, not shell expansion
+  local input="${1:-}"
+  [ -n "$input" ] || return 0
+  printf '%s' "$input" | pm_manifest_query '
+    [(.address?.aliases? // [])[] | ltrimstr("petry-projects/")]
+    | .[]
   '
 }
 

--- a/scripts/lib/persona-mention.sh
+++ b/scripts/lib/persona-mention.sh
@@ -88,9 +88,37 @@ pm_is_agent_comment() {
 # A match here is NOT a decision to run: the slug still has to resolve to a
 # manifest that enables the mention surface. Real teams (org-leads) match the
 # shape and are dropped later by a 404.
+# pm_strip_unaddressable <body> — drop regions where a handle must not count.
+#
+# Three regions, two reasons:
+#
+#   fenced code (``` / ~~~)  — GitHub renders NO mention here and notifies nobody.
+#   inline code (`...`)      — likewise. Firing on these means the router is more
+#                              trigger-happy than GitHub's own semantics: pasting
+#                              a usage example, or documenting the handle, would
+#                              summon the persona.
+#   blockquotes (^>)         — a DELIBERATE divergence. GitHub *does* render and
+#                              notify on a quoted mention, but GitHub's one-click
+#                              "Quote reply" copies a whole prior comment prefixed
+#                              with '>', and re-running an agent over quoted text
+#                              is almost never what the quoter meant. Neither
+#                              recursion axis catches it (a human quoting a human
+#                              is not a bot and carries no marker). To address a
+#                              persona, mention it outside the quote.
+pm_strip_unaddressable() {
+  printf '%s' "$1" | awk '
+    # Toggle on fence open/close; never emit the fence or its contents.
+    /^[[:space:]]*(```|~~~)/ { infence = !infence; next }
+    infence                  { next }
+    /^[[:space:]]*>/         { next }          # blockquote line
+    { gsub(/`[^`]*`/, " "); print }            # inline code -> whitespace
+  '
+}
+
+# pm_extract_slugs <body> — emit each DISTINCT persona slug addressed in body.
 pm_extract_slugs() {
   local body="$1" org="${PERSONA_ORG:-petry-projects}"
-  printf '%s' "$body" \
+  pm_strip_unaddressable "$body" \
     | grep -oE "@${org}/[a-z0-9]+(-[a-z0-9]+)*" \
     | sed "s|@${org}/||" \
     | awk '!seen[$0]++'
@@ -166,28 +194,22 @@ except Exception as exc:
   printf '%s' "$json" | jq -r "$filter"
 }
 
-# pm_mention_decision <manifest-yaml> — emit "<enabled> <mode> <opt_out_label> [<gate_label>]".
+# pm_mention_decision <manifest-yaml> — emit "<enabled> <mode> <opt_out_label>".
 #
 # Resolves the `mention` surface against the trigger matrix: an explicit row wins;
 # otherwise triggers.default_mode applies (§4). default_mode 'off' means the
-# persona is not addressable at all. gate_label is emitted as a 4th field only
-# when the surface declares one (write-mode guard, §1 principle 3).
+# persona is not addressable at all.
 pm_mention_decision() {
   # shellcheck disable=SC2016  # $t/$s/$m are jq variables, not shell expansions
-  local input="${1:-}"
-  if [ -z "$input" ]; then
-    echo "false off "
-    return
-  fi
-  printf '%s' "$input" | pm_manifest_query '
-    (.triggers? // {}) as $t
-    | ($t.surfaces? // []) as $s
-    | ($s | map(select(.surface? == "mention")) | first) as $m
+  printf '%s' "$1" | pm_manifest_query '
+    (.triggers // {}) as $t
+    | ($t.surfaces // []) as $s
+    | ($s | map(select(.surface == "mention")) | first) as $m
     | (if $m == null
-       then (if ($t.default_mode? // "off") == "advisory" then "true advisory" else "false off" end)
-       else ((($m.enabled? // false) | tostring) + " " + ($m.mode? // "advisory"))
+       then (if ($t.default_mode // "off") == "advisory" then "true advisory" else "false off" end)
+       else ((($m.enabled // false) | tostring) + " " + ($m.mode // "advisory"))
        end) as $decision
-    | ($decision + " " + ($t.opt_out_label? // "") + " " + (($m // {}).gate_label? // "")) | gsub("\\s+$"; "")
+    | $decision + " " + ($t.opt_out_label // "")
   '
 }
 
@@ -198,29 +220,29 @@ pm_mention_decision() {
 # is the safe direction.
 pm_mention_trust_floor() {
   # shellcheck disable=SC2016  # $m is a jq variable, not a shell expansion
-  local input="${1:-}"
-  if [ -z "$input" ]; then
-    echo ""
-    return
-  fi
-  printf '%s' "$input" | pm_manifest_query '
-    ((.triggers?.surfaces? // []) | map(select(.surface? == "mention")) | first) as $m
-    | ($m.trust_floor? // .trust?.author_association_floor? // [])
+  printf '%s' "$1" | pm_manifest_query '
+    ((.triggers.surfaces // []) | map(select(.surface == "mention")) | first) as $m
+    | ($m.trust_floor // .trust.author_association_floor // [])
     | join(" ")
   '
 }
 
-# pm_persona_aliases <manifest-yaml> — emit each alias slug (without the org prefix),
-# one per line. Used to validate that an addressed slug is a known alias for the
-# manifest's canonical id when claimed != slug (§4.1 rule 5: renames keep the old
-# handle as an alias).
-pm_persona_aliases() {
-  # shellcheck disable=SC2016  # jq variable, not shell expansion
-  local input="${1:-}"
-  [ -n "$input" ] || return 0
-  printf '%s' "$input" | pm_manifest_query '
-    [(.address?.aliases? // [])[] | ltrimstr("petry-projects/")]
-    | .[]
+# pm_mention_gate_label <manifest-yaml> — the label that ARMS a write-mode
+# mention, or empty.
+#
+# Its own function rather than a fourth field on pm_mention_decision: that
+# returns space-separated values, and an EMPTY optional field silently shifts the
+# next one into its place ("true write  qa-lead" would parse gate_label as the
+# opt_out_label). A security gate is the last place to accept that.
+#
+# §4 rule 2 makes gate_label schema-REQUIRED when mode == write. The schema
+# enforces that it is DECLARED; the caller must enforce that it is APPLIED —
+# declaring a lock is not locking the door.
+pm_mention_gate_label() {
+  # shellcheck disable=SC2016  # $m is a jq variable, not a shell expansion
+  printf '%s' "$1" | pm_manifest_query '
+    ((.triggers.surfaces // []) | map(select(.surface == "mention")) | first) as $m
+    | ($m.gate_label // "")
   '
 }
 

--- a/scripts/persona-mention-requirements.txt
+++ b/scripts/persona-mention-requirements.txt
@@ -1,0 +1,74 @@
+# Python deps for the persona-mention router's manifest parsing
+# (.github/workflows/persona-mention-reusable.yml).
+#
+# The router parses personas/<id>/persona.yml with python3 + PyYAML
+# (scripts/lib/persona-mention.sh :: pm_manifest_query). PyYAML is NOT
+# documented as preinstalled on the runner images, and this reusable runs on the
+# CALLER's runner, so it cannot be assumed present.
+#
+# Pinned exact versions with SHA-256 hashes so pip verifies package integrity
+# before installation (satisfies the dependency-hardening gate
+# tests/dependency_hardening.bats, and SonarCloud githubactions
+# S8541/S8543/S8544/S8545: only-binary, exact version, hash/lock enforcement).
+#
+# To regenerate from the repo root:
+#   printf 'PyYAML==6.0.2\n' > /tmp/req.in
+#   pip-compile --generate-hashes --no-annotate --no-header --strip-extras --allow-unsafe \
+#     /tmp/req.in -o scripts/persona-mention-requirements.txt
+#
+# --require-hashes mode requires ALL resolved packages (including transitive
+# dependencies) to be listed here. Generated with pip-compile (pip-tools).
+pyyaml==6.0.2 \
+    --hash=sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff \
+    --hash=sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48 \
+    --hash=sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086 \
+    --hash=sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e \
+    --hash=sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133 \
+    --hash=sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5 \
+    --hash=sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484 \
+    --hash=sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee \
+    --hash=sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5 \
+    --hash=sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68 \
+    --hash=sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a \
+    --hash=sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf \
+    --hash=sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99 \
+    --hash=sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8 \
+    --hash=sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85 \
+    --hash=sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19 \
+    --hash=sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc \
+    --hash=sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a \
+    --hash=sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1 \
+    --hash=sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317 \
+    --hash=sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c \
+    --hash=sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631 \
+    --hash=sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d \
+    --hash=sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652 \
+    --hash=sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5 \
+    --hash=sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e \
+    --hash=sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b \
+    --hash=sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8 \
+    --hash=sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476 \
+    --hash=sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706 \
+    --hash=sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563 \
+    --hash=sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237 \
+    --hash=sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b \
+    --hash=sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083 \
+    --hash=sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180 \
+    --hash=sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425 \
+    --hash=sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e \
+    --hash=sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f \
+    --hash=sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725 \
+    --hash=sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183 \
+    --hash=sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab \
+    --hash=sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774 \
+    --hash=sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725 \
+    --hash=sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e \
+    --hash=sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5 \
+    --hash=sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d \
+    --hash=sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290 \
+    --hash=sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44 \
+    --hash=sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed \
+    --hash=sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4 \
+    --hash=sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba \
+    --hash=sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12 \
+    --hash=sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4

--- a/standards/canary-rings.json
+++ b/standards/canary-rings.json
@@ -938,6 +938,69 @@
           }
         }
       }
+    },
+    "persona-mention": {
+      "host": "petry-projects/.github",
+      "reusable": ".github/workflows/persona-mention-reusable.yml",
+      "run_workflow": "Persona \u2014 Mention Router",
+      "rings": [
+        {
+          "channel": "next",
+          "order": 0,
+          "members": [
+            "petry-projects/.github-private"
+          ]
+        },
+        {
+          "channel": "ring0",
+          "order": 1,
+          "members": [
+            "petry-projects/.github"
+          ]
+        },
+        {
+          "channel": "ring1",
+          "order": 2,
+          "members": [
+            "petry-projects/TalkTerm",
+            "petry-projects/bmad-bgreat-suite"
+          ]
+        },
+        {
+          "channel": "stable",
+          "order": 3,
+          "members": [
+            "*"
+          ]
+        }
+      ],
+      "gate": {
+        "_standard": "petry-projects/.github#548 \u2014 graduated dwell/sample gate over a per-candidate cumulative window. These are registry-configurable per-transition knobs; the values below are the #548 defaults.",
+        "baseline_window_days": 14,
+        "baseline_spike_cap_multiple": 3,
+        "benign_failure_classes": [],
+        "control": {
+          "allow_pre_existing": false
+        },
+        "_benign_note": "benign_failure_classes (#1025 P2): per-reusable allowlist matched against a failed run's workflow name (`workflow` ERE) + failed-step signature (`step` ERE, matched via `gh run view`). Matches are excluded from cum_fail \u2014 but ONLY when the candidate's reusable is byte-identical to the prior channel (differs=0), so the allowlist can never mask a candidate-introduced regression. Exception (#668): a class marked `version_independent: true` fails before/independent of the candidate's own code (e.g. a Dependabot-context secrets failure at startup) and can NEVER be candidate-caused, so it is excluded even when differs=1 \u2014 reserve the flag for classes where that is provable from the failure mechanism, not merely likely. `control.allow_pre_existing`, or `promote --allow-pre-existing`, advances a BLOCKED+PRE_EXISTING frontier (never REGRESSION).",
+        "transitions": {
+          "next->ring0": {
+            "dwell_hours": 4,
+            "sample_fraction_permille": 250,
+            "sample_clamp_min": 3,
+            "sample_clamp_max": 15,
+            "waive_sample_if_no_caller": true
+          },
+          "ring0->ring1": {
+            "dwell_hours": 8,
+            "waive_sample": true
+          },
+          "ring1->stable": {
+            "dwell_hours": 12,
+            "sample_min": 1
+          }
+        }
+      }
     }
   },
   "unmanaged": {}

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -307,6 +307,7 @@ filename doesn't carry the `-reusable.yml` suffix (grandfathered exception:
 | [`dependency-audit.yml`](workflows/dependency-audit.yml) | 1 | Multi-ecosystem audit (npm, pnpm, gomod, cargo, pip) |
 | [`feature-ideation.yml`](workflows/feature-ideation.yml) | 1 | BMAD Method ideation pipeline (BMAD-enabled repos only) |
 | [`pr-review-mention.yml`](workflows/pr-review-mention.yml) | 1 | Trigger the pr-review agent when `@donpetry-bot` is mentioned or `donpetry-bot` is assigned as reviewer |
+| [`persona-mention.yml`](workflows/persona-mention.yml) | 1 | Route `@petry-projects/<role>` mentions to the addressed persona — one router for **all** personas ([persona-standards.md §4.1](persona-standards.md)) |
 | [`copilot-setup-steps.yml`](workflows/copilot-setup-steps.yml) | 2 | Pre-install tools and dependencies for Copilot cloud agent sessions |
 
 **Adapt only when the template genuinely requires repo-specific content** (e.g., a

--- a/standards/persona-standards.md
+++ b/standards/persona-standards.md
@@ -242,6 +242,21 @@ persona's own trigger matrix, applies the trust floor and `opt_out_label`, and
 dispatches. Personas do **not** each ship a mention workflow — that is the
 per-agent drift the manifest exists to prevent.
 
+The router is
+[`persona-mention-reusable.yml`](../.github/workflows/persona-mention-reusable.yml),
+its decision core is
+[`scripts/lib/persona-mention.sh`](../scripts/lib/persona-mention.sh) (pure and
+network-free, so `tests/persona_mention.bats` pins the guards without API
+access), and repos adopt it by copying the one stub
+[`standards/workflows/persona-mention.yml`](workflows/persona-mention.yml).
+
+**There is no persona index, by design.** Because `address.handle`'s slug MUST
+equal `id` (rule 1) and `id` MUST equal the persona's directory name, a handle
+resolves to `personas/<slug>/persona.yml` by convention — the manifest is the
+index-of-record (§1.1), so nothing derives, caches, or duplicates it. A 404 is a
+meaningful answer: "not a persona". That is also how a real, non-persona team
+(`@petry-projects/org-leads`) falls through harmlessly rather than erroring.
+
 > **Recursion is the hazard here.** Agent comments posted via a PAT re-trigger
 > workflows (unlike `GITHUB_TOKEN`), and `.github-private#860` burned 1,481
 > identical acks in 4.5 hours from a *single* self-loop. With N mutually

--- a/standards/workflows/persona-mention.yml
+++ b/standards/workflows/persona-mention.yml
@@ -46,11 +46,11 @@ on:
   # repository_dispatch, which is exactly the bridge the manifest declares.
   discussion_comment:
     types: [created]
-  # Reviewer assignment counts as a mention (§4 "mention" surface). When a
-  # persona team is added as a reviewer, the router dispatches it exactly as
-  # if the team had been @-mentioned in a comment.
-  pull_request:
-    types: [review_requested]
+  # NOTE: reviewer assignment (pull_request/review_requested) is NOT subscribed
+  # here yet, even though §4 says "Reviewer-assignment counts here too". The
+  # router has no path for it, and a trigger that fires into a router which
+  # ignores it is a dead trigger that only burns runs. Tracked as finding 10 in
+  # petry-projects/.github#755; the trigger lands with the routing, not before.
 
 permissions: {}
 

--- a/standards/workflows/persona-mention.yml
+++ b/standards/workflows/persona-mention.yml
@@ -46,11 +46,11 @@ on:
   # repository_dispatch, which is exactly the bridge the manifest declares.
   discussion_comment:
     types: [created]
-  # NOTE: reviewer assignment (pull_request/review_requested) is NOT subscribed
-  # here yet, even though §4 says "Reviewer-assignment counts here too". The
-  # router has no path for it, and a trigger that fires into a router which
-  # ignores it is a dead trigger that only burns runs. Tracked as finding 10 in
-  # petry-projects/.github#755; the trigger lands with the routing, not before.
+# NOTE: reviewer assignment (pull_request/review_requested) is NOT subscribed
+# here yet, even though §4 says "Reviewer-assignment counts here too". The
+# router has no path for it, and a trigger that fires into a router which
+# ignores it is a dead trigger that only burns runs. Tracked as finding 10 in
+# petry-projects/.github#755; the trigger lands with the routing, not before.
 
 permissions: {}
 

--- a/standards/workflows/persona-mention.yml
+++ b/standards/workflows/persona-mention.yml
@@ -1,0 +1,58 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/persona-mention.yml
+# Standard:        petry-projects/.github/standards/persona-standards.md (§4.1)
+# Reusable:        petry-projects/.github/.github/workflows/persona-mention-reusable.yml
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. All routing logic lives in the reusable
+#     workflow above, and every per-persona decision lives in that persona's
+#     manifest — not here and not in the reusable.
+#   • You MUST NOT change: the `uses:` ref — it is pinned to the
+#     `persona-mention/v1-stable` channel, a moving tag advanced centrally.
+#     Never repoint it to `@main`, a SHA, or a frozen `@vX.Y.Z` (see
+#     ci-standards.md → Reusable workflow versioning). Also do not change the
+#     trigger events or the job-level `permissions:` block — reusable workflows
+#     can be granted no more permissions than the calling job, so removing the
+#     stanza breaks the reusable's gh API calls.
+#   • Do NOT add a per-persona stub. ONE router serves every persona (§4.1);
+#     a stub per agent is the drift the manifest exists to prevent.
+#   • If you need different behaviour, open a PR against the reusable in the
+#     central repo. A new release is rolled out by moving the channel tag
+#     centrally — never by editing callers, so no fanout PR is needed.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Persona Mention Router — thin caller for the org-level reusable.
+#
+# Adopting this file makes every persona that enables the `mention` surface
+# addressable in this repo as `@petry-projects/<role>` — e.g.
+#
+#     @petry-projects/qa-lead please assess test risk on this PR
+#
+# The handle is an org TEAM, never a user account: '@qa-lead' is a real GitHub
+# account owned by an unrelated person (§4.1).
+#
+# To adopt: copy this file to .github/workflows/persona-mention.yml in your repo.
+# Requires: GH_PAT_WORKFLOWS org secret (already present in petry-projects org).
+name: Persona — Mention Router
+
+on:
+  # issue_comment covers BOTH issues and PR conversation comments.
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  # Discussions cannot run an agent inline (#571) — but this router only parses
+  # and dispatches, and the agent itself runs on the resulting
+  # repository_dispatch, which is exactly the bridge the manifest declares.
+  discussion_comment:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  persona-mention:
+    permissions:
+      issues: read
+      pull-requests: read
+    uses: petry-projects/.github/.github/workflows/persona-mention-reusable.yml@persona-mention/v1-stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    secrets: inherit  # NOSONAR(githubactions:S7635) org secrets are scoped to first-party reusables

--- a/standards/workflows/persona-mention.yml
+++ b/standards/workflows/persona-mention.yml
@@ -46,6 +46,11 @@ on:
   # repository_dispatch, which is exactly the bridge the manifest declares.
   discussion_comment:
     types: [created]
+  # Reviewer assignment counts as a mention (§4 "mention" surface). When a
+  # persona team is added as a reviewer, the router dispatches it exactly as
+  # if the team had been @-mentioned in a comment.
+  pull_request:
+    types: [review_requested]
 
 permissions: {}
 

--- a/tests/persona_mention.bats
+++ b/tests/persona_mention.bats
@@ -185,12 +185,12 @@ MENTION_ON='    - surface: mention
   [ "${output% *}" = "false off" ]
 }
 
-@test "pm_mention_decision surfaces a write-mode mention" {
+@test "pm_mention_decision surfaces a write-mode mention with gate_label" {
   run pm_mention_decision "$(manifest '    - surface: mention
       enabled: true
       mode: write
       gate_label: qa-lead')"
-  [ "$output" = "true write qa-lead:hands-off" ]
+  [ "$output" = "true write qa-lead:hands-off qa-lead" ]
 }
 
 @test "pm_mention_trust_floor defaults to the persona-wide floor" {
@@ -226,4 +226,55 @@ MENTION_ON='    - surface: mention
 @test "pm_manifest_url honours PERSONA_REF for testing against a branch" {
   PERSONA_REF=some-branch run pm_manifest_url qa-lead
   [[ "$output" == */some-branch/personas/qa-lead/persona.yml ]]
+}
+
+# --- null-safety (jq ? operator paths) -------------------------------------
+
+@test "pm_mention_decision handles missing triggers or surfaces gracefully" {
+  run pm_mention_decision "{}"
+  [ "$output" = "false off" ]
+}
+
+@test "pm_mention_decision handles malformed triggers type gracefully" {
+  run pm_mention_decision '{"triggers": "invalid-type"}'
+  [ "$output" = "false off" ]
+}
+
+@test "pm_mention_decision handles empty input gracefully" {
+  run pm_mention_decision ""
+  [ "$output" = "false off " ] || [ "$output" = "false off" ]
+}
+
+@test "pm_mention_trust_floor handles missing triggers or trust floor gracefully" {
+  run pm_mention_trust_floor "{}"
+  [ "$output" = "" ]
+}
+
+@test "pm_mention_trust_floor handles empty input gracefully" {
+  run pm_mention_trust_floor ""
+  [ "$output" = "" ]
+}
+
+# --- alias resolution ------------------------------------------------------
+
+@test "pm_persona_aliases emits stripped alias slugs" {
+  local m
+  m="$(manifest "$MENTION_ON")"
+  # Inject an alias into the address block
+  m="${m}
+address:
+  aliases:
+    - petry-projects/old-qa"
+  run pm_persona_aliases "$m"
+  [ "$output" = "old-qa" ]
+}
+
+@test "pm_persona_aliases returns empty when no aliases declared" {
+  run pm_persona_aliases "$(manifest "$MENTION_ON")"
+  [ -z "$output" ]
+}
+
+@test "pm_persona_aliases returns empty on empty input" {
+  run pm_persona_aliases ""
+  [ -z "$output" ]
 }

--- a/tests/persona_mention.bats
+++ b/tests/persona_mention.bats
@@ -1,0 +1,229 @@
+#!/usr/bin/env bats
+# Unit tests for the persona @-mention routing core (scripts/lib/persona-mention.sh).
+# Standard: standards/persona-standards.md §4.1 (addressing).
+#
+# The recursion guards get the most coverage here on purpose: .github-private#860
+# burned 1,481 acks in 4.5h from a single self-loop, and with N mutually
+# addressable personas the cycles are combinatorial rather than self-loops. A
+# regression in pm_should_route is the expensive kind.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+LIB="$SCRIPT_DIR/scripts/lib/persona-mention.sh"
+
+setup() {
+  # shellcheck source=/dev/null
+  source "$LIB"
+}
+
+# A minimal manifest shaped like personas/qa-lead/persona.yml.
+manifest() {
+  local surface_block="${1:-}"
+  cat <<YAML
+id: qa-lead
+name: QA Lead
+address:
+  handle: petry-projects/qa-lead
+triggers:
+  default_mode: advisory
+  opt_out_label: qa-lead:hands-off
+  surfaces:
+${surface_block}
+trust:
+  author_association_floor: [OWNER, MEMBER, COLLABORATOR]
+YAML
+}
+
+MENTION_ON='    - surface: mention
+      enabled: true
+      mode: advisory'
+
+# --- slug extraction -------------------------------------------------------
+
+@test "pm_extract_slugs finds a handle in prose" {
+  run pm_extract_slugs "hey @petry-projects/qa-lead please look at this"
+  [ "$status" -eq 0 ]
+  [ "$output" = "qa-lead" ]
+}
+
+@test "pm_extract_slugs collapses duplicates so one mention dispatches once" {
+  run pm_extract_slugs "@petry-projects/qa-lead and again @petry-projects/qa-lead"
+  [ "$output" = "qa-lead" ]
+}
+
+@test "pm_extract_slugs finds several distinct personas, order preserved" {
+  run pm_extract_slugs "@petry-projects/qa-lead and @petry-projects/dev-lead"
+  [ "${lines[0]}" = "qa-lead" ]
+  [ "${lines[1]}" = "dev-lead" ]
+  [ "${#lines[@]}" -eq 2 ]
+}
+
+@test "pm_extract_slugs ignores a bare user handle" {
+  # '@qa-lead' is a REAL GitHub account owned by a stranger (§4.1) — the whole
+  # reason handles are org-scoped. It must never route.
+  run pm_extract_slugs "@qa-lead take a look"
+  [ -z "$output" ]
+}
+
+@test "pm_extract_slugs ignores another org's handle" {
+  run pm_extract_slugs "@some-other-org/qa-lead take a look"
+  [ -z "$output" ]
+}
+
+@test "pm_extract_slugs finds nothing in a plain comment" {
+  run pm_extract_slugs "looks good to me, shipping"
+  [ -z "$output" ]
+}
+
+# --- recursion guards ------------------------------------------------------
+
+@test "pm_is_agent_comment matches any persona-authored comment, not one exact string" {
+  run pm_is_agent_comment '<!-- persona:qa-lead --> risk looks low'
+  [ "$status" -eq 0 ]
+  run pm_is_agent_comment '<!-- persona:dev-lead ack --> on it'
+  [ "$status" -eq 0 ]
+}
+
+@test "pm_is_agent_comment does not match a human comment" {
+  run pm_is_agent_comment 'no marker here'
+  [ "$status" -ne 0 ]
+}
+
+@test "pm_is_bot_actor recognises the agent identities" {
+  run pm_is_bot_actor donpetry-bot
+  [ "$status" -eq 0 ]
+  run pm_is_bot_actor 'github-actions[bot]'
+  [ "$status" -eq 0 ]
+}
+
+@test "pm_is_bot_actor does not match a human" {
+  run pm_is_bot_actor don-petry
+  [ "$status" -ne 0 ]
+}
+
+@test "pm_should_route blocks a comment authored by an agent (axis 1)" {
+  run pm_should_route donpetry-bot OWNER "@petry-projects/qa-lead please review"
+  [ "$status" -ne 0 ]
+}
+
+@test "pm_should_route blocks a comment carrying the agent marker (axis 2)" {
+  run pm_should_route don-petry OWNER '<!-- persona:qa-lead --> @petry-projects/dev-lead over to you'
+  [ "$status" -ne 0 ]
+}
+
+@test "pm_should_route blocks the combinatorial cross-persona loop" {
+  # The failure mode §4.1 warns about: qa-lead answering a thread and mentioning
+  # dev-lead. Marked AND bot-authored — either axis alone must stop it.
+  run pm_should_route donpetry-bot OWNER '<!-- persona:qa-lead --> @petry-projects/dev-lead your turn'
+  [ "$status" -ne 0 ]
+}
+
+@test "pm_should_route allows a trusted human addressing a persona" {
+  run pm_should_route don-petry OWNER "@petry-projects/qa-lead please review"
+  [ "$status" -eq 0 ]
+}
+
+@test "pm_should_route blocks an untrusted commenter" {
+  run pm_should_route drive-by NONE "@petry-projects/qa-lead please review"
+  [ "$status" -ne 0 ]
+}
+
+@test "pm_should_route blocks a comment that addresses nobody" {
+  run pm_should_route don-petry OWNER "looks good to me"
+  [ "$status" -ne 0 ]
+}
+
+# --- trust -----------------------------------------------------------------
+
+@test "pm_trust_ok admits an association in the floor" {
+  run pm_trust_ok MEMBER OWNER MEMBER COLLABORATOR
+  [ "$status" -eq 0 ]
+}
+
+@test "pm_trust_ok denies an association outside the floor" {
+  run pm_trust_ok CONTRIBUTOR OWNER MEMBER COLLABORATOR
+  [ "$status" -ne 0 ]
+}
+
+@test "pm_trust_ok denies when the floor is empty" {
+  # A persona that declared no floor must not be MORE permissive than one that did.
+  run pm_trust_ok OWNER
+  [ "$status" -ne 0 ]
+}
+
+@test "pm_trust_ok denies an empty association" {
+  run pm_trust_ok "" OWNER MEMBER
+  [ "$status" -ne 0 ]
+}
+
+# --- manifest decisions ----------------------------------------------------
+
+@test "pm_mention_decision reads an explicit enabled mention surface" {
+  run pm_mention_decision "$(manifest "$MENTION_ON")"
+  [ "$output" = "true advisory qa-lead:hands-off" ]
+}
+
+@test "pm_mention_decision honours an explicitly disabled mention surface" {
+  run pm_mention_decision "$(manifest '    - surface: mention
+      enabled: false
+      mode: advisory')"
+  [ "$output" = "false advisory qa-lead:hands-off" ]
+}
+
+@test "pm_mention_decision falls back to default_mode advisory when unlisted" {
+  run pm_mention_decision "$(manifest '    - surface: issues
+      enabled: true
+      mode: advisory')"
+  [ "$output" = "true advisory qa-lead:hands-off" ]
+}
+
+@test "pm_mention_decision treats default_mode off as not addressable" {
+  local m
+  m="$(manifest '    - surface: issues
+      enabled: true
+      mode: advisory')"
+  run pm_mention_decision "${m/default_mode: advisory/default_mode: off}"
+  [ "${output% *}" = "false off" ]
+}
+
+@test "pm_mention_decision surfaces a write-mode mention" {
+  run pm_mention_decision "$(manifest '    - surface: mention
+      enabled: true
+      mode: write
+      gate_label: qa-lead')"
+  [ "$output" = "true write qa-lead:hands-off" ]
+}
+
+@test "pm_mention_trust_floor defaults to the persona-wide floor" {
+  run pm_mention_trust_floor "$(manifest "$MENTION_ON")"
+  [ "$output" = "OWNER MEMBER COLLABORATOR" ]
+}
+
+@test "pm_mention_trust_floor lets a surface tighten the persona-wide floor" {
+  run pm_mention_trust_floor "$(manifest '    - surface: mention
+      enabled: true
+      mode: advisory
+      trust_floor: [OWNER]')"
+  [ "$output" = "OWNER" ]
+}
+
+@test "pm_persona_id reads the id the manifest claims" {
+  run pm_persona_id "$(manifest "$MENTION_ON")"
+  [ "$output" = "qa-lead" ]
+}
+
+@test "pm_manifest_query fails loudly on unparseable YAML" {
+  run pm_manifest_query '.id' <<<'this: [is: not: yaml'
+  [ "$status" -ne 0 ]
+}
+
+# --- urls ------------------------------------------------------------------
+
+@test "pm_manifest_url builds the raw manifest path by convention" {
+  run pm_manifest_url qa-lead
+  [ "$output" = "https://raw.githubusercontent.com/petry-projects/.github-private/main/personas/qa-lead/persona.yml" ]
+}
+
+@test "pm_manifest_url honours PERSONA_REF for testing against a branch" {
+  PERSONA_REF=some-branch run pm_manifest_url qa-lead
+  [[ "$output" == */some-branch/personas/qa-lead/persona.yml ]]
+}

--- a/tests/persona_mention.bats
+++ b/tests/persona_mention.bats
@@ -185,12 +185,12 @@ MENTION_ON='    - surface: mention
   [ "${output% *}" = "false off" ]
 }
 
-@test "pm_mention_decision surfaces a write-mode mention with gate_label" {
+@test "pm_mention_decision surfaces a write-mode mention" {
   run pm_mention_decision "$(manifest '    - surface: mention
       enabled: true
       mode: write
       gate_label: qa-lead')"
-  [ "$output" = "true write qa-lead:hands-off qa-lead" ]
+  [ "$output" = "true write qa-lead:hands-off" ]
 }
 
 @test "pm_mention_trust_floor defaults to the persona-wide floor" {
@@ -228,53 +228,97 @@ MENTION_ON='    - surface: mention
   [[ "$output" == */some-branch/personas/qa-lead/persona.yml ]]
 }
 
-# --- null-safety (jq ? operator paths) -------------------------------------
+# --- mention precision (#755 finding 9) ------------------------------------
+# The router must not be MORE trigger-happy than GitHub itself. Firing where
+# GitHub renders no mention means pasting an example summons an agent.
 
-@test "pm_mention_decision handles missing triggers or surfaces gracefully" {
-  run pm_mention_decision "{}"
-  [ "$output" = "false off" ]
+@test "pm_extract_slugs ignores a handle inside a fenced code block" {
+  run pm_extract_slugs 'Example:
+```
+@petry-projects/qa-lead review this
+```
+done'
+  [ -z "$output" ]
 }
 
-@test "pm_mention_decision handles malformed triggers type gracefully" {
-  run pm_mention_decision '{"triggers": "invalid-type"}'
-  [ "$output" = "false off" ]
+@test "pm_extract_slugs ignores a handle inside a tilde fence" {
+  run pm_extract_slugs 'Example:
+~~~
+@petry-projects/qa-lead review this
+~~~
+done'
+  [ -z "$output" ]
 }
 
-@test "pm_mention_decision handles empty input gracefully" {
-  run pm_mention_decision ""
-  [ "$output" = "false off " ] || [ "$output" = "false off" ]
+@test "pm_extract_slugs ignores a handle in inline code" {
+  run pm_extract_slugs 'The handle is `@petry-projects/qa-lead` for QA.'
+  [ -z "$output" ]
 }
 
-@test "pm_mention_trust_floor handles missing triggers or trust floor gracefully" {
-  run pm_mention_trust_floor "{}"
-  [ "$output" = "" ]
+@test "pm_extract_slugs ignores a handle in a blockquote (quote-reply)" {
+  # GitHub's one-click Quote reply prefixes '>'. Re-running an agent over quoted
+  # text is not what the quoter meant, and no recursion axis catches it.
+  run pm_extract_slugs '> @petry-projects/qa-lead please review
+
+Agreed.'
+  [ -z "$output" ]
 }
 
-@test "pm_mention_trust_floor handles empty input gracefully" {
-  run pm_mention_trust_floor ""
-  [ "$output" = "" ]
+@test "pm_extract_slugs still fires on a real mention beside a quote" {
+  run pm_extract_slugs '> some earlier comment
+
+@petry-projects/qa-lead thoughts?'
+  [ "$output" = "qa-lead" ]
 }
 
-# --- alias resolution ------------------------------------------------------
+@test "pm_extract_slugs still fires on a real mention after a code block" {
+  run pm_extract_slugs 'Repro:
+```
+npm test
+```
+@petry-projects/qa-lead can you look?'
+  [ "$output" = "qa-lead" ]
+}
 
-@test "pm_persona_aliases emits stripped alias slugs" {
+@test "pm_should_route ignores a comment whose only handle is in a code fence" {
+  run pm_should_route don-petry OWNER 'docs:
+```
+@petry-projects/qa-lead
+```'
+  [ "$status" -ne 0 ]
+}
+
+# --- gate_label (#755 finding 2) -------------------------------------------
+
+@test "pm_mention_gate_label returns the gate for a write-mode mention" {
+  run pm_mention_gate_label "$(manifest '    - surface: mention
+      enabled: true
+      mode: write
+      gate_label: qa-lead')"
+  [ "$output" = "qa-lead" ]
+}
+
+@test "pm_mention_gate_label is empty for an advisory mention" {
+  run pm_mention_gate_label "$(manifest "$MENTION_ON")"
+  [ -z "$output" ]
+}
+
+@test "pm_mention_gate_label is empty when the surface is absent" {
+  run pm_mention_gate_label "$(manifest '    - surface: issues
+      enabled: true
+      mode: advisory')"
+  [ -z "$output" ]
+}
+
+@test "gate_label survives an empty opt_out_label (the read-shift trap)" {
+  # A 4th space-separated field on pm_mention_decision would silently shift an
+  # empty opt_out_label's place onto the gate. Separate functions cannot.
   local m
-  m="$(manifest "$MENTION_ON")"
-  # Inject an alias into the address block
-  m="${m}
-address:
-  aliases:
-    - petry-projects/old-qa"
-  run pm_persona_aliases "$m"
-  [ "$output" = "old-qa" ]
-}
-
-@test "pm_persona_aliases returns empty when no aliases declared" {
-  run pm_persona_aliases "$(manifest "$MENTION_ON")"
-  [ -z "$output" ]
-}
-
-@test "pm_persona_aliases returns empty on empty input" {
-  run pm_persona_aliases ""
-  [ -z "$output" ]
+  m="$(manifest '    - surface: mention
+      enabled: true
+      mode: write
+      gate_label: qa-lead')"
+  m="${m/  opt_out_label: qa-lead:hands-off/  opt_out_label: \"\"}"
+  run pm_mention_gate_label "$m"
+  [ "$output" = "qa-lead" ]
 }


### PR DESCRIPTION
## Summary

Serves the addressing contract **#752** defined. **One router for every persona** — personas do *not* each ship a mention workflow (§4.1). A stub per agent is exactly the drift the manifest exists to prevent, and it's how the fleet ended up with two divergent registries last time.

## There is no persona index, by design

This was the open question when #752 landed, and it dissolved. Because `address.handle`'s slug MUST equal `id`, and `id` MUST equal the persona's directory name — both enforced by `validate-personas.py` — `@petry-projects/qa-lead` resolves to `personas/qa-lead/persona.yml` **by convention**. The manifest is the index-of-record (§1.1); nothing derives, caches, or duplicates it.

It also avoids inverting the established derivation direction: `canary-rings.json` (`.github`) → `release/registry.yml` (`.github-private`). A persona index would have had to flow the other way, putting generated content in the public standards repo.

And a 404 is a *meaningful answer* — "not a persona". That's also how a real, non-persona team like `@petry-projects/org-leads` falls through harmlessly instead of erroring.

## The manifest decides; the router restates nothing

Whether the mention surface is enabled, in what mode, behind which trust floor, under which `opt_out_label` — all read from the persona. A persona may **tighten** the job-level trust default but never loosen it, and an undeclared floor **denies**, so a persona that forgot to declare trust isn't more permissive than one that did.

## Recursion — why the core is a tested library, not inline shell

Comments posted via a PAT re-trigger workflows, unlike `GITHUB_TOKEN`. `.github-private#860` burned **1,481 identical acks in 4.5h** from a *single* self-loop. With N mutually addressable personas the cycles are **combinatorial, not self-loops**: `qa-lead` answering a thread that mentions `dev-lead` is enough.

So the guard is two independent axes — **bot actor** and **agent marker** — enforced in *both* the job-level `if` (so secrets never reach a bad run) and `pm_should_route` (so it's testable). The marker match is a **prefix**: #860's first fix matched one exact ack string and still self-looped through a different agent-authored comment.

## Contents

| File | What |
|---|---|
| `scripts/lib/persona-mention.sh` | The pure, network-free decision core — fetching is the workflow's job, so the suite pins behaviour with zero API access |
| `tests/persona_mention.bats` | **31 tests**, recursion guards most heavily |
| `.github/workflows/persona-mention-tests.yml` | The runner — a bats suite with no CI runner is unenforced (the #613/#624 gap `canary-rollout-tests.yml` exists to close), so it ships *with* the suite |
| `.github/workflows/persona-mention-reusable.yml` | The router. Sources the lib at `github.job_workflow_sha` (the #465/#528 `tooling_ref` lesson); every event field arrives via `env`, never inline `${{ }}` in a `run:` body |
| `standards/workflows/persona-mention.yml` | The single caller stub, pinned `persona-mention/v1-stable` (major-scoped per #657, matching live stubs) |
| `standards/canary-rings.json` | Registers the reusable so a release can be cut |

## Deliberately NOT here

- **`ring-pins.sh` `RING_REUSABLES` is untouched.** Adding `persona-mention` would make `compliance-audit` demand the stub in repos that don't have it, and make the deploy sweep report drift — manufacturing failures for a reusable with no cut release. That belongs to rollout.
- **Nothing routes on merge.** No release cut, no repo enrolled, and no persona runtime exists yet. The router dispatches `persona-mention` to `.github-private`, where nothing listens — a safe no-op.

## Verification (CI's exact invocations, run locally)

- `bats tests/persona_mention.bats` — **31/31**
- `shellcheck --severity=warning -x scripts/**/*.sh` — clean
- `actionlint -ignore 'SC2129' -ignore '"job_workflow_sha" is not defined' .github/workflows/*.yml` — clean. That ignore is pre-existing and correct: `job_workflow_sha` is a real context property actionlint 1.7.7's schema omits, and the merged `auto-rebase-reusable.yml` trips the identical false positive.
- `markdownlint-cli2` — clean
- `canary-rings.json` — spliced as **text**, not re-serialized: the file's encoding is genuinely mixed (em-dashes escaped, arrows half-literal) and its agent order is *insertion order, not alphabetical*, so a JSON round-trip rewrote ~140 untouched lines. Result is **63 insertions / 0 deletions**, structurally identical to `pr-review-mention`'s entry but for `host`/`reusable`/`run_workflow`.

## One bug the tests caught

`pm_manifest_query` piped python into jq, so the pipeline reported **jq's** status — a manifest parse failure returned empty output with exit 0, indistinguishable from *"the manifest says no"*. A malformed or truncated manifest would have silently mis-routed. Now captured and checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable GitHub Actions workflow to route `@petry-projects/<role>` persona mentions across issues, PRs, reviews, and discussions.
  * Added an org-level caller workflow stub that forwards to the reusable router, plus a new canary agent configuration to roll it out.
* **Documentation**
  * Updated persona standards and CI template listings to reference the centralized mention router.
* **Tests**
  * Added Bats end-to-end tests for mention parsing, recursion safeguards, trust and opt-out behavior, and manifest-driven routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->