### PR TITLE
Persona opt-out label sync must not fail open

### DIFF
--- a/scripts/apply-repo-settings.sh
+++ b/scripts/apply-repo-settings.sh
@@ -74,24 +74,40 @@ usage() {
 }
 
 # Populated on the first apply_labels() call; reused for every subsequent repo in
-# --all mode. persona_opt_out_label_configs runs in a process-substitution subshell
-# so the cache must live at the apply_labels level, not inside the function.
+# --all mode. persona_opt_out_label_configs runs in a subshell so the cache must
+# live at the apply_labels level, not inside the function.
 _PERSONA_OPT_OUT_CONFIGS_CACHE=()
 _PERSONA_OPT_OUT_CONFIGS_CACHED=false
+
+# Set when the persona opt-out family could not be derived faithfully — either the
+# manifest listing failed, or a manifest could not be read and its label had to be
+# guessed from the convention. The run then MUST NOT report success.
+#
+# Why this exists (petry-projects/.github#755): the opt-out family is the escape
+# hatch §4 rule 4 mandates. Printing "All repos processed successfully" while it is
+# silently absent means nobody learns until someone tells a persona to leave an
+# issue alone and it ignores them. Reading an error as a negative answer is the
+# systemic bug this framework already had four instances of; this is not the fifth.
+_PERSONA_OPT_OUT_SYNC_FAILED=false
 
 # persona_opt_out_label_configs — emit one "name|color|description" line per persona,
 # deriving the <id>:hands-off opt-out label from the persona manifests rather than a
 # hand-maintained list. Adding a persona therefore needs NO edit here: the family
 # follows from personas/<id>/persona.yml, the index-of-record (persona-standards.md
 # §1.1). Draft personas are included — being able to say "hands-off" is exactly what
-# a draft needs. If the manifest listing cannot be read (e.g. transient API error) we
-# warn and emit nothing, so a network hiccup never blocks the static label set.
+# a draft needs.
+#
+# Returns non-zero if the family could not be derived faithfully. It still emits
+# whatever it resolved (so a hiccup never blocks the STATIC label set — that
+# resilience is deliberate), but the caller records the failure and the run exits
+# non-zero rather than claiming success. Emitting nothing and returning 0 would
+# make "labels applied ✅" indistinguishable from "the opt-out hatch is missing".
 persona_opt_out_label_configs() {
-  local ids id opt_out opt_out_raw
+  local ids id opt_out opt_out_raw rc=0
   ids=$(gh api "repos/$PERSONA_MANIFEST_REPO/contents/personas?ref=$PERSONA_MANIFEST_REF" 2>/dev/null \
         | jq -r '.[]? | select(.type == "dir") | .name' 2>/dev/null) || {
-    warn "  Could not list persona manifests from $PERSONA_MANIFEST_REPO — skipping opt-out labels"
-    return 0
+    warn "  Could not list persona manifests from $PERSONA_MANIFEST_REPO — opt-out labels NOT applied"
+    return 1
   }
 
   while IFS= read -r id; do
@@ -103,13 +119,20 @@ persona_opt_out_label_configs() {
       opt_out=$(echo "$opt_out_raw" | sed -n 's/^[[:space:]]*opt_out_label:[[:space:]]*//p' | head -1 \
                 | tr -d '\r' | tr -d "\"'" | awk '{print $1}')
     else
-      echo "Warning: Failed to fetch persona.yml for $id" >&2
+      # The convention fallback below is a GUESS. §4 rule 4 makes <id>:hands-off
+      # only a convention — the schema lets a persona declare any opt_out_label —
+      # so if the manifest is unreadable we may create a label nobody uses while
+      # the real one stays absent, leaving opt-out silently broken. Emit it (it is
+      # the best guess) but do not call the run a success.
+      warn "  Could not read personas/$id/persona.yml — guessing '$id:hands-off' from the convention"
       opt_out=""
+      rc=1
     fi
     [ -z "$opt_out" ] && opt_out="$id:hands-off"
     printf '%s|%s|Opt an item out of the %s persona automation entirely\n' \
       "$opt_out" "$PERSONA_OPT_OUT_COLOR" "$id"
   done <<< "$ids"
+  return "$rc"
 }
 
 apply_labels() {
@@ -129,8 +152,22 @@ apply_labels() {
 
   # Append the derived persona opt-out family (<id>:hands-off, one per persona).
   # Cache on first call so --all mode doesn't re-fetch all manifests per repo.
+  #
+  # Captured with $( ) rather than `mapfile < <(...)`: process substitution runs
+  # the function in a subshell whose EXIT CODE is unreachable (mapfile reports its
+  # own status), so a failure there could never be seen — which is exactly how the
+  # fail-open survived review. $( ) is also a subshell, but its status propagates.
   if [ "$_PERSONA_OPT_OUT_CONFIGS_CACHED" != true ]; then
-    mapfile -t _PERSONA_OPT_OUT_CONFIGS_CACHE < <(persona_opt_out_label_configs)
+    local persona_out=""
+    if ! persona_out=$(persona_opt_out_label_configs); then
+      _PERSONA_OPT_OUT_SYNC_FAILED=true
+    fi
+    _PERSONA_OPT_OUT_CONFIGS_CACHE=()
+    # Guard the empty case: `mapfile <<< ""` yields one empty element, which would
+    # become a bogus "||" label config.
+    if [ -n "$persona_out" ]; then
+      mapfile -t _PERSONA_OPT_OUT_CONFIGS_CACHE <<< "$persona_out"
+    fi
     _PERSONA_OPT_OUT_CONFIGS_CACHED=true
   fi
   if [ "${#_PERSONA_OPT_OUT_CONFIGS_CACHE[@]}" -gt 0 ]; then
@@ -405,6 +442,14 @@ if [ "$1" = "--all" ]; then
     exit 1
   fi
 
+  # The persona opt-out family is the escape hatch §4 rule 4 mandates. If it could
+  # not be derived faithfully, the static labels still landed — but this run did
+  # NOT do what it claims, and saying so is the whole point (#755).
+  if [ "$_PERSONA_OPT_OUT_SYNC_FAILED" = true ]; then
+    err "persona opt-out labels could not be derived faithfully — static labels applied, but the <id>:hands-off family is incomplete or guessed"
+    exit 1
+  fi
+
   ok "All repos processed successfully"
 else
   repo_json=$(gh api "repos/$ORG/$1" 2>/dev/null || echo "{}")
@@ -418,6 +463,13 @@ else
   pp_apply_security_and_analysis "$1"
   apply_codeql_default_setup "$1"
   apply_check_suite_prefs "$1"
+
+  # Same guard as --all: a single-repo run must not exit 0 while the mandated
+  # opt-out hatch is missing from that repo.
+  if [ "$_PERSONA_OPT_OUT_SYNC_FAILED" = true ]; then
+    err "persona opt-out labels could not be derived faithfully — static labels applied, but the <id>:hands-off family is incomplete or guessed"
+    exit 1
+  fi
 fi
 }
 

--- a/scripts/apply-repo-settings.sh
+++ b/scripts/apply-repo-settings.sh
@@ -116,8 +116,19 @@ persona_opt_out_label_configs() {
     # convention (persona-standards.md §4 rule 4) when the field cannot be read.
     if opt_out_raw=$(gh api "repos/$PERSONA_MANIFEST_REPO/contents/personas/$id/persona.yml?ref=$PERSONA_MANIFEST_REF" \
                        -H "Accept: application/vnd.github.raw" 2>/dev/null); then
-      opt_out=$(echo "$opt_out_raw" | sed -n 's/^[[:space:]]*opt_out_label:[[:space:]]*//p' | head -1 \
-                | tr -d '\r' | tr -d "\"'" | awk '{print $1}')
+      # `opt_out_label` is a free-form string in the schema, and GitHub label names
+      # may contain spaces — so this must NOT truncate at the first word (an
+      # `awk '{print $1}'` here would provision "needs" for a label named
+      # "needs human review", leaving the real opt-out absent and the hatch broken).
+      # Take the whole scalar, then strip: trailing YAML comment (which requires
+      # leading whitespace), trailing space, and surrounding quotes.
+      opt_out=$(printf '%s' "$opt_out_raw" \
+                | sed -n 's/^[[:space:]]*opt_out_label:[[:space:]]*//p' | head -1 \
+                | tr -d '\r' \
+                | sed -e 's/[[:space:]]\{1,\}#.*$//' \
+                      -e 's/[[:space:]]*$//' \
+                      -e 's/^"\(.*\)"$/\1/' \
+                      -e "s/^'\(.*\)'$/\1/")
     else
       # The convention fallback below is a GUESS. §4 rule 4 makes <id>:hands-off
       # only a convention — the schema lets a persona declare any opt_out_label —
@@ -159,7 +170,15 @@ apply_labels() {
   # fail-open survived review. $( ) is also a subshell, but its status propagates.
   if [ "$_PERSONA_OPT_OUT_CONFIGS_CACHED" != true ]; then
     local persona_out=""
-    if ! persona_out=$(persona_opt_out_label_configs); then
+    if persona_out=$(persona_opt_out_label_configs); then
+      # Cache only a GOOD derivation. Caching a failure would mean a transient
+      # error on the first repo of an --all sweep denies opt-out labels to every
+      # LATER repo too, even once the API recovers — turning one blip into a
+      # fleet-wide gap. Retrying costs a few API calls on the failure path only.
+      _PERSONA_OPT_OUT_CONFIGS_CACHED=true
+    else
+      # Sticky by design: the repo we just processed went without its opt-out
+      # labels, so the RUN did not do what it claims even if later repos recover.
       _PERSONA_OPT_OUT_SYNC_FAILED=true
     fi
     _PERSONA_OPT_OUT_CONFIGS_CACHE=()
@@ -168,7 +187,6 @@ apply_labels() {
     if [ -n "$persona_out" ]; then
       mapfile -t _PERSONA_OPT_OUT_CONFIGS_CACHE <<< "$persona_out"
     fi
-    _PERSONA_OPT_OUT_CONFIGS_CACHED=true
   fi
   if [ "${#_PERSONA_OPT_OUT_CONFIGS_CACHE[@]}" -gt 0 ]; then
     label_configs+=("${_PERSONA_OPT_OUT_CONFIGS_CACHE[@]}")

--- a/test/scripts/apply-repo-settings/apply-repo-settings.bats
+++ b/test/scripts/apply-repo-settings/apply-repo-settings.bats
@@ -166,22 +166,70 @@ _run_fn() { run "$@"; }
   ! grep -q 'hands-off' "$CALLS"
 }
 
+# _apply_labels <repo> — run apply_labels in THIS shell and record its status in
+# $APPLY_RC. Must NOT echo the status: $( ) is a subshell, and the whole point is
+# to observe the flag mutations apply_labels makes in the CURRENT shell.
+# `|| true` would mask an unexpected non-zero and let a flag assertion pass on a
+# broken function, so the status is captured explicitly with errexit off.
+_apply_labels() {
+  set +e; apply_labels "$1" >/dev/null 2>&1; APPLY_RC=$?; set -e
+}
+
 @test "apply_labels records the failure so the run cannot claim success" {
   # The honesty half: the static labels landed, but _PERSONA_OPT_OUT_SYNC_FAILED is
   # set, and main() turns that into a non-zero exit.
   export PERSONA_DIRS_JSON='not-json'
-  _run_fn apply_labels acme
-  [ "$status" -eq 0 ]
-  # _run_fn runs in a subshell, so re-derive in THIS shell to observe the flag.
   _PERSONA_OPT_OUT_CONFIGS_CACHED=false
   _PERSONA_OPT_OUT_SYNC_FAILED=false
-  apply_labels acme >/dev/null 2>&1 || true
+  _apply_labels acme
+  [ "$APPLY_RC" -eq 0 ]
   [ "$_PERSONA_OPT_OUT_SYNC_FAILED" = true ]
 }
 
 @test "a healthy derivation leaves the failure flag unset" {
   _PERSONA_OPT_OUT_CONFIGS_CACHED=false
   _PERSONA_OPT_OUT_SYNC_FAILED=false
-  apply_labels acme >/dev/null 2>&1 || true
+  _apply_labels acme
+  [ "$APPLY_RC" -eq 0 ]
   [ "$_PERSONA_OPT_OUT_SYNC_FAILED" = false ]
+}
+
+@test "a failed derivation is NOT cached — later repos retry and recover" {
+  # --all sweeps share the cache. Caching a failure would let one transient blip on
+  # the first repo deny opt-out labels to every later repo even after the API
+  # recovers, turning a hiccup into a fleet-wide gap.
+  _PERSONA_OPT_OUT_CONFIGS_CACHED=false
+  _PERSONA_OPT_OUT_SYNC_FAILED=false
+  export PERSONA_DIRS_JSON='not-json'          # repo 1: derivation fails
+  _apply_labels repo-one
+  [ "$APPLY_RC" -eq 0 ]
+  [ "$_PERSONA_OPT_OUT_CONFIGS_CACHED" = false ]   # must NOT have cached the failure
+  export PERSONA_DIRS_JSON='[{"type":"dir","name":"qa-lead"}]'  # repo 2: API recovers
+  _apply_labels repo-two
+  [ "$APPLY_RC" -eq 0 ]
+  grep -q 'qa-lead:hands-off' "$CALLS"           # repo 2 DID get the label
+  [ "$_PERSONA_OPT_OUT_SYNC_FAILED" = true ]     # but the run still cannot claim success
+}
+
+@test "a successful derivation IS cached — no refetch per repo" {
+  _PERSONA_OPT_OUT_CONFIGS_CACHED=false
+  _apply_labels repo-one
+  [ "$APPLY_RC" -eq 0 ]
+  [ "$_PERSONA_OPT_OUT_CONFIGS_CACHED" = true ]
+}
+
+@test "an opt_out_label containing spaces is not truncated at the first word" {
+  # opt_out_label is free-form in the schema and GitHub labels may contain spaces.
+  # Truncating would provision "needs" and leave the real hatch absent.
+  printf 'triggers:\n  opt_out_label: "needs human review"\n' > "$MANIFEST_DIR/qa-lead.yml"
+  _run_fn persona_opt_out_label_configs
+  [ "$status" -eq 0 ]
+  [[ "$output" == "needs human review|"* ]]
+}
+
+@test "a trailing YAML comment is stripped from opt_out_label" {
+  printf 'triggers:\n  opt_out_label: qa-lead:hands-off  # the escape hatch\n' > "$MANIFEST_DIR/qa-lead.yml"
+  _run_fn persona_opt_out_label_configs
+  [ "$status" -eq 0 ]
+  [[ "$output" == "qa-lead:hands-off|"* ]]
 }

--- a/test/scripts/apply-repo-settings/apply-repo-settings.bats
+++ b/test/scripts/apply-repo-settings/apply-repo-settings.bats
@@ -43,8 +43,10 @@ args="\$*"
 case "\$args" in
   *"contents/personas/"*"persona.yml"*)
     id=\$(printf '%s' "\$args" | sed -n 's#.*contents/personas/\([^/?]*\)/persona.yml.*#\1#p')
-    [ -f "$MANIFEST_DIR/\$id.yml" ] && cat "$MANIFEST_DIR/\$id.yml"
-    exit 0 ;;
+    # A real `gh api` on an unreachable/absent manifest exits NON-zero (404).
+    # The stub must too, or the fetch-failure path is untestable.
+    if [ -f "$MANIFEST_DIR/\$id.yml" ]; then cat "$MANIFEST_DIR/\$id.yml"; exit 0; fi
+    exit 1 ;;
   *"contents/personas"*)
     printf '%s' "\${PERSONA_DIRS_JSON:-[]}"; exit 0 ;;
   *"label create"*)
@@ -106,14 +108,28 @@ _run_fn() { run "$@"; }
   [[ "$output" == *"business-analyst:hands-off|"* ]]
 }
 
-# ── graceful degradation ──────────────────────────────────────────────────────
-@test "unavailable manifest listing degrades to no opt-out labels (returns 0)" {
+# ── failure is reported, not swallowed (#755) ─────────────────────────────────
+# The static label set still lands on a hiccup — that resilience is deliberate —
+# but the run must NEVER report success while the mandated <id>:hands-off escape
+# hatch is absent. "Applied ✅" with no opt-out label is worse than a red run:
+# nobody learns until they tell a persona to back off and it ignores them.
+@test "unavailable manifest listing returns NON-ZERO (does not fail open)" {
   export PERSONA_DIRS_JSON='not-json'  # jq parse failure on the listing
   _run_fn persona_opt_out_label_configs
-  [ "$status" -eq 0 ]
-  # No label emitted to stdout; only a WARN (which run merges from stderr) is present.
+  [ "$status" -ne 0 ]
+  # Still emits no label to stdout; only a WARN (which run merges from stderr).
   [[ "$output" != *":hands-off"* ]]
   [[ "$output" != *"|ededed|"* ]]
+}
+
+@test "an unreadable manifest returns NON-ZERO even though it guesses the label" {
+  # <id>:hands-off is only a CONVENTION (§4 rule 4); the schema lets a persona
+  # declare any opt_out_label. If the manifest cannot be read we may create a label
+  # nobody uses while the real one stays absent — so emit the guess, but say so.
+  rm -f "$MANIFEST_DIR/qa-lead.yml"
+  _run_fn persona_opt_out_label_configs
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"qa-lead:hands-off"* ]]   # the best guess is still emitted
 }
 
 # ── integration with apply_labels ─────────────────────────────────────────────
@@ -141,10 +157,31 @@ _run_fn() { run "$@"; }
   [ ! -f "$CALLS" ]
 }
 
-@test "apply_labels still succeeds when persona derivation is unavailable" {
+@test "apply_labels still applies the static 7 when persona derivation is unavailable" {
+  # The resilience half: a persona hiccup must not block unrelated label work.
   export PERSONA_DIRS_JSON='not-json'
   _run_fn apply_labels acme
   [ "$status" -eq 0 ]
   [ "$(grep -c 'label create' "$CALLS")" -eq 7 ]
   ! grep -q 'hands-off' "$CALLS"
+}
+
+@test "apply_labels records the failure so the run cannot claim success" {
+  # The honesty half: the static labels landed, but _PERSONA_OPT_OUT_SYNC_FAILED is
+  # set, and main() turns that into a non-zero exit.
+  export PERSONA_DIRS_JSON='not-json'
+  _run_fn apply_labels acme
+  [ "$status" -eq 0 ]
+  # _run_fn runs in a subshell, so re-derive in THIS shell to observe the flag.
+  _PERSONA_OPT_OUT_CONFIGS_CACHED=false
+  _PERSONA_OPT_OUT_SYNC_FAILED=false
+  apply_labels acme >/dev/null 2>&1 || true
+  [ "$_PERSONA_OPT_OUT_SYNC_FAILED" = true ]
+}
+
+@test "a healthy derivation leaves the failure flag unset" {
+  _PERSONA_OPT_OUT_CONFIGS_CACHED=false
+  _PERSONA_OPT_OUT_SYNC_FAILED=false
+  apply_labels acme >/dev/null 2>&1 || true
+  [ "$_PERSONA_OPT_OUT_SYNC_FAILED" = false ]
 }


### PR DESCRIPTION
Fixes the regression that shipped in #757. Flagged in review there, not addressed, merged anyway — it is **live on main now**.

```bash
ids=$(gh api .../contents/personas ...) || {
  warn "  Could not list persona manifests ... — skipping opt-out labels"
  return 0
}
```

A transient API error emits no labels and **returns success**. The repo gets *"All repos processed successfully"* while the `<id>:hands-off` family is silently absent — and the escape hatch [§4 rule 4](standards/persona-standards.md) **mandates** doesn't exist there. Nobody finds out until someone tells a persona to leave an issue alone and it ignores them.

That's a **fifth instance** of the systemic pattern #755 names as its headline finding: *reading an error as a negative answer*.

## Keeps both halves — that's the actual requirement

- **Resilience** — the static 7 labels still land. A persona hiccup must not block unrelated label work. The original rationale was right and is preserved.
- **Honesty** — the run can no longer **claim** success. `persona_opt_out_label_configs` returns non-zero, `apply_labels` records it, and **both** `main()` exit paths (`--all` *and* single-repo) fail the run.

## Why it survived review

The caller used `mapfile < <(persona_opt_out_label_configs)`. **Process substitution runs the function in a subshell whose exit code is unreachable** — `mapfile` reports its own status — so a failure there literally could not be observed. Switched to `$( )`: also a subshell, but its status propagates.

That's worth noting beyond this PR: the fail-open wasn't just an oversight, it was *structurally unobservable*.

## Also: the guessed-label path

`<id>:hands-off` is only a **convention** (§4 rule 4) — the schema lets a persona declare any `opt_out_label`. If the manifest is unreadable we may create a label nobody uses while the real one stays absent, leaving opt-out silently broken. The guess is still emitted (it's the best available), but the run now says so.

## Two tests encoded the defect as intended behaviour

| was | now |
|---|---|
| `"unavailable manifest listing degrades to no opt-out labels (returns 0)"` | `"... returns NON-ZERO (does not fail open)"` |
| `"apply_labels still succeeds when persona derivation is unavailable"` | split: the **resilience** half (static 7 still land) + the **honesty** half (failure flag set) |

The `gh` stub always exited 0 even for a missing fixture, so the fetch-failure path was **untestable** — a real `gh api` on an absent manifest exits non-zero (404). Made the stub faithful; that's what let the new guessed-label test fail first, then pass.

## Verification

- `bats test/scripts/apply-repo-settings/apply-repo-settings.bats` — **14/14** (11 + 3 new)
- `shellcheck --severity=warning -x` — clean
- **Live check against the real public manifests**: derives `qa-lead:hands-off|ededed|...`, exits 0 on the happy path

## Process note

This regression shipped because my finding was a **PR comment**, which is advisory — only `CHANGES_REQUESTED` or a red check stops the pipeline. Findings on agent PRs should land as blocking reviews from here on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)