### PR TITLE
Drop address.aliases from the contract (half 2 of 2) — HOLD until .github-private#1289 merges

### DIFF
--- a/standards/persona-standards.md
+++ b/standards/persona-standards.md
@@ -195,7 +195,6 @@ A persona that enables the `mention` surface MUST declare an `address` block
 ```yaml
 address:
   handle: petry-projects/qa-lead   # an org TEAM — mentioned as @petry-projects/qa-lead
-  aliases: []                      # additional handles that route here (renames)
 ```
 
 **The handle MUST be an org team, never a user account.** This is not a style
@@ -226,10 +225,39 @@ two things a bare convention cannot:
 3. **The team MUST set `notification_setting: notifications_disabled`.** The
    handle exists to route a webhook, not to page humans. Membership should be
    empty or bot-only.
-4. **Handles and aliases MUST be unique across all personas.** Cross-file, so
-   JSON Schema cannot see it — enforced by `validate-personas.py`.
-5. **A rename keeps the old handle as an `alias`.** Roles outlive their spelling;
-   in-flight threads must not break.
+4. **Handles are unique across all personas — by construction, not by check.**
+   The org is pinned by the pattern, the slug equals `id`, `id` equals the
+   persona's directory name, and directory names are unique. Two personas
+   therefore *cannot* claim the same handle, so there is deliberately no
+   cross-file uniqueness check: it could never fire.
+
+### Renames — and why there is no `aliases`
+
+An earlier draft of this standard let a persona declare `address.aliases[]` so a
+**renamed** role kept routing (`qa-lead` listing `petry-projects/murat`). That
+field is gone. Two reasons, one structural and one measured:
+
+- **Index-free routing could never have honoured it.** The router resolves
+  `@petry-projects/murat` to `personas/murat/persona.yml` — a 404 after the
+  rename. The alias is declared *inside the renamed persona's own manifest*,
+  which the router never opens, because it does not know to look there.
+- **There is nothing live left to route.** GitHub stops rendering a renamed
+  team's old handle as a mention at all — it becomes plain text. Measured:
+
+  ```text
+  before rename:  <a class="team-mention" …>@petry-projects/probe</a>
+  after rename:   <p>@petry-projects/probe please review</p>
+  ```
+
+  So the old handle is not a silently-broken mention that looks live — the
+  reader sees grey text and knows instantly it did not resolve. The fix is
+  obvious and local: mention the new handle.
+
+**To rename a role:** rename the persona directory, `id`, `name`, `canary.agent`,
+`opt_out_label`, `evals.path`, and the org team (its slug must keep matching
+`id`). In-flight mentions of the old handle stop resolving, visibly — which is
+the correct signal, not a regression. See
+[`.github#755`](https://github.com/petry-projects/.github/issues/755) finding 1.
 
 The **live** properties (rules 2 and 3 — does the team exist, is it closed, are
 notifications off?) need the network, and `validate-personas.py` is hermetic

--- a/standards/persona-standards.md
+++ b/standards/persona-standards.md
@@ -231,7 +231,7 @@ two things a bare convention cannot:
    therefore *cannot* claim the same handle, so there is deliberately no
    cross-file uniqueness check: it could never fire.
 
-### Renames — and why there is no `aliases`
+### 4.1.1 Renames — and why there is no `aliases`
 
 An earlier draft of this standard let a persona declare `address.aliases[]` so a
 **renamed** role kept routing (`qa-lead` listing `petry-projects/murat`). That

--- a/standards/personas/TEMPLATE/persona.yml
+++ b/standards/personas/TEMPLATE/persona.yml
@@ -81,7 +81,6 @@ definition:
 # live properties — the schema cannot.
 address:
   handle: petry-projects/change-me   # slug MUST equal `id` above
-  aliases: []                        # old handles kept routing after a rename
 
 # --- Capabilities the persona can invoke (advisory index) -----------------
 skills: []

--- a/standards/personas/persona.schema.json
+++ b/standards/personas/persona.schema.json
@@ -128,7 +128,7 @@
     "address": {
       "type": "object",
       "additionalProperties": false,
-      "description": "How a human addresses this persona from a comment (`@<handle>`). REQUIRED when the 'mention' surface is enabled. See persona-standards.md §4.1. There is deliberately NO `aliases` field — see §4.1 'Renames'.",
+      "description": "How a human addresses this persona from a comment (`@<handle>`). REQUIRED when the 'mention' surface is enabled. See persona-standards.md §4.1. There is deliberately NO `aliases` field — see §4.1.1 'Renames'.",
       "required": ["handle"],
       "properties": {
         "handle": {

--- a/standards/personas/persona.schema.json
+++ b/standards/personas/persona.schema.json
@@ -128,21 +128,13 @@
     "address": {
       "type": "object",
       "additionalProperties": false,
-      "description": "How a human addresses this persona from a comment (`@<handle>`). REQUIRED when the 'mention' surface is enabled. See persona-standards.md §4.1.",
+      "description": "How a human addresses this persona from a comment (`@<handle>`). REQUIRED when the 'mention' surface is enabled. See persona-standards.md §4.1. There is deliberately NO `aliases` field — see §4.1 'Renames'.",
       "required": ["handle"],
       "properties": {
         "handle": {
           "type": "string",
           "pattern": "^petry-projects/[a-z0-9]+(-[a-z0-9]+)*$",
-          "description": "The addressing handle in 'org/team-slug' form, mentioned as '@org/team-slug'. MUST be an org TEAM, never a user account: GitHub's user namespace is global and first-come, so a bare '@qa-lead' resolves to an unrelated real account and notifies a stranger on every mention (verified: qa-lead, dev-lead, scrum-master are all live accounts). An org team slug cannot collide. The slug MUST equal `id`, so routing is a prefix-strip. Team must be privacy 'closed' (secret teams are unmentionable) with notification_setting 'notifications_disabled'; those are live properties CI verifies, not shape this schema can check."
-        },
-        "aliases": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "pattern": "^petry-projects/[a-z0-9]+(-[a-z0-9]+)*$"
-          },
-          "description": "Additional handles that route here — the migration path when a role is renamed. Same org/team-slug rules as `handle`. Every alias must be unique across ALL personas' handles and aliases (cross-file, enforced by validate-personas.py)."
+          "description": "The addressing handle in 'org/team-slug' form, mentioned as '@org/team-slug'. MUST be an org TEAM, never a user account: GitHub's user namespace is global and first-come, so a bare '@qa-lead' resolves to an unrelated real account and notifies a stranger on every mention (verified: qa-lead, dev-lead, scrum-master are all live accounts). An org team slug cannot collide. The slug MUST equal `id`, so routing is a prefix-strip — which also makes handle uniqueness a theorem rather than a check (org is pinned, slug == id, id == the persona directory name, directory names are unique). Team must be privacy 'closed' (secret teams are unmentionable) with notification_setting 'notifications_disabled'; those are live properties CI verifies, not shape this schema can check."
         }
       }
     },


### PR DESCRIPTION
Second half of the ordered cross-repo pair. `petry-projects/.github-private#1289` removed every **use** of the field; this removes the field itself.

> ## ⚠️ MERGE ORDER
> **`.github-private`#1289 MUST land before this.** The schema is `additionalProperties: false`, so dropping `aliases` while `qa-lead`'s manifest still carries `aliases: []` fails `validate-personas` on main **fleet-wide**.
>
> Verified the rejection is real: a manifest carrying `aliases` now yields `"Additional properties are not allowed ('aliases' was unexpected)"`. That's the desired end state — and exactly why the order matters.

## Why aliases are gone (#755 finding 1)

They existed so a **renamed** role kept routing — `qa-lead` listing `petry-projects/murat` so old comments still reached it. Two reasons it goes, one structural and one measured:

**1. Index-free routing could never honour it.** The router resolves `@petry-projects/murat` → `personas/murat/persona.yml` → 404 after the rename. The alias is declared *inside the renamed persona's own manifest*, which the router never opens because it doesn't know to look there. The `pm_persona_aliases` attempt in #754 was unreachable for exactly this reason.

**2. There is nothing live left to route.** GitHub stops rendering a renamed team's old handle as a mention **at all**. I probed it — created a team, rendered its mention, renamed it, re-rendered the old handle:

| | Renders as |
|---|---|
| before rename | `<a class="team-mention" …>@petry-projects/probe</a>` |
| after rename | `<p>@petry-projects/probe please review</p>` |

The old handle becomes **plain text**. So it isn't a silently-broken mention that *looks* live — the reader sees grey text and knows instantly it didn't resolve, and the fix is local: mention the new handle. Aliases would only route text GitHub itself no longer treats as a mention.

## Rule 4 becomes a theorem; rule 5 becomes a Renames section

**Rule 4** — *"Handles and aliases MUST be unique across all personas"* → **"Handles are unique BY CONSTRUCTION"**: the pattern pins the org, `slug == id`, `id ==` the persona directory name, and directory names are unique. Two personas cannot claim the same handle. #1289 removed the corresponding `check_handles_unique` for the same reason — it could never fire.

**Rule 5** — *"a rename keeps the old handle as an alias"* → a **§4.1 Renames** section documenting exactly what to change on a rename, and stating plainly that old mentions stop resolving **visibly**, which is the correct signal rather than a regression.

## Verification

- `persona.schema.json` is a valid Draft 2020-12 schema; **diff is +2/-10**
- Edited as **text**, not re-serialized — a JSON round-trip reformats every inline array and rewrote 264 untouched lines (the same trap as `canary-rings.json`)
- `qa-lead`'s post-#1289 shape (handle only) **PASSES**; a manifest carrying `aliases` **FAILS**
- `TEMPLATE/persona.yml` validates against the updated schema
- `markdownlint-cli2` clean
- Zero `aliases` references remain outside the deliberate explanatory notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified persona handle renaming and routing conventions.
  * Documented that renamed personas do not retain legacy handles as aliases.
  * Added guidance for updating persona metadata and corresponding team slugs.

* **Standards**
  * Removed support for alternate persona handles.
  * Updated the persona template and validation rules to require only a primary handle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->