### PR TITLE
Router sends the comment's API url, not html_url

### DIFF
--- a/.github/workflows/persona-mention-reusable.yml
+++ b/.github/workflows/persona-mention-reusable.yml
@@ -126,7 +126,12 @@ jobs:
           COMMENT_BODY: ${{ github.event.comment.body }}
           COMMENT_USER: ${{ github.event.comment.user.login }}
           COMMENT_ASSOC: ${{ github.event.comment.author_association }}
-          COMMENT_URL: ${{ github.event.comment.html_url }}
+          # The comment's API url (.url), not .html_url: the dispatch target (the
+          # persona runner) fetches the comment body with `gh api "$COMMENT_URL"`
+          # to learn what the persona was asked, and gh api cannot fetch a
+          # github.com browser url. The API response still carries .html_url if a
+          # human-facing link is ever needed.
+          COMMENT_URL: ${{ github.event.comment.url }}
           EVENT_NAME: ${{ github.event_name }}
           ITEM_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number || github.event.discussion.number }}
           SOURCE_REPO: ${{ github.repository }}


### PR DESCRIPTION
Companion to `petry-projects/.github-private#1293` (the persona runtime).

The runner fetches the summoning comment's body with `gh api "$COMMENT_URL"` to learn what the persona was asked. `gh api` cannot fetch a `github.com` browser url, so the router must pass the comment's **`.url`** (API), not `.html_url`. The API response still carries `.html_url` if a human-facing link is ever needed.

**No ordering dependency** with #1293: the runner's prompt degrades gracefully when the body fetch fails ("proceed from the item's title/body/diff"), so the soak works either way — this just makes the body-read actually succeed.

Single-field change; the value flows unchanged through the existing `client_payload[comment_url]` dispatch. actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)