### PR TITLE
Mention stub template must grant contents:read

### DIFF
--- a/standards/workflows/persona-mention.yml
+++ b/standards/workflows/persona-mention.yml
@@ -57,6 +57,9 @@ permissions: {}
 jobs:
   persona-mention:
     permissions:
+      contents: read        # the reusable checks out its tooling repo — required,
+                            # or the call fails at startup (a reusable is granted
+                            # no more than the caller; persona-standards.md §5)
       issues: read
       pull-requests: read
     uses: petry-projects/.github/.github/workflows/persona-mention-reusable.yml@persona-mention/v1-stable  # NOSONAR(githubactions:S7637) first-party channel ref


### PR DESCRIPTION
The router reusable's job needs `contents: read` (to check out its tooling); the stub template granted only `issues`+`pull-requests` read, so every adopting repo would hit `startup_failure` — a reusable is granted no more than the caller (`persona-standards` §5, which this template violated).

Caught by the `next`-ring soak (petry-projects/.github-private#1300/#1301). Companion to the `.github-private` adopted-stub fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)