### PR TITLE
feat(personas): declarative runtime.identity for the persona standard

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pr-720",
+  "name": "pr-782",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pr-720",
+  "name": "pr-782",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/standards/persona-standards.md
+++ b/standards/persona-standards.md
@@ -310,6 +310,39 @@ meaningful answer: "not a persona". That is also how a real, non-persona team
 - **AgentShield** — every definition layer is subject to the AgentShield scan;
   a persona that fails the scan cannot be onboarded.
 
+### 5.1 Runtime identity — the account a persona acts as
+
+A persona's **identity** is the GitHub account it authenticates as at runtime —
+the login it commits, pushes, reviews, or comments as, plus the Actions secret
+holding that account's PAT. Declare it in `runtime.identity`:
+
+```yaml
+runtime:
+  identity:
+    account: don-petry        # the login this persona ACTS AS
+    credential: GH_PAT_DON_PETRY   # the Actions secret holding its PAT
+```
+
+**Identity is not the address handle.** `address.handle` (§4.1) is the org *team*
+a human `@`-mentions to *route* work; `runtime.identity.account` is the *account*
+that *does* the work. They are orthogonal: a persona addressed as
+`@petry-projects/dev-lead` may act as `don-petry`.
+
+**Why it is declarative and per-persona.** Before this field, every write persona
+derived its account from one shared `vars.BOT_USER` variable. Two personas that
+must act as *different* accounts (dev-lead as `don-petry`, pr-review as the
+review-only machine user `donpetry-bot`) shared that one variable, so setting it
+for one silently changed the other — a real regression where dev-lead began
+committing as the review bot. A per-persona `identity` makes collisions
+impossible: the runtime resolves `BOT_USER` from `identity.account`, and CI
+asserts the workflow's credential reference matches `identity.credential`.
+
+**Credential naming.** Secrets follow `GH_PAT_<ACCOUNT>[_<QUALIFIER>]`, where
+`<ACCOUNT>` is the login upper-snake-cased (`don-petry` → `GH_PAT_DON_PETRY`);
+`<QUALIFIER>` distinguishes multiple PATs for one account (e.g.
+`GH_PAT_DON_PETRY_COPILOT`). Pre-existing account-named secrets such as
+`DON_PETRY_BOT_GH_PAT` are grandfathered.
+
 ---
 
 ## 6. Canary onboarding (the last step)
@@ -369,6 +402,10 @@ A persona is "done" (ready for `stable`) when all of the following are true:
 - [ ] If it ships a reusable: caller stub grants a **superset** of
       `runtime.permissions`, carries the `SOURCE OF TRUTH` header, and pins a
       channel tag.
+- [ ] `runtime.identity` declares the `account` the persona acts as and the
+      `credential` secret holding its PAT; the credential follows
+      `GH_PAT_<ACCOUNT>[_<QUALIFIER>]` (or is a grandfathered account-named
+      secret), and the runtime workflow resolves `BOT_USER` from it (§5.1).
 - [ ] AgentShield passes on all layers; no immutable file is touched.
 - [ ] `evals/<id>/` holds `dev/` + `holdout/` splits with ≥ `evals.min_cases`
       held-out cases; `validate-cases.py` passes and the eval gate is green.

--- a/standards/persona-standards.md
+++ b/standards/persona-standards.md
@@ -402,10 +402,11 @@ A persona is "done" (ready for `stable`) when all of the following are true:
 - [ ] If it ships a reusable: caller stub grants a **superset** of
       `runtime.permissions`, carries the `SOURCE OF TRUTH` header, and pins a
       channel tag.
-- [ ] `runtime.identity` declares the `account` the persona acts as and the
-      `credential` secret holding its PAT; the credential follows
-      `GH_PAT_<ACCOUNT>[_<QUALIFIER>]` (or is a grandfathered account-named
-      secret), and the runtime workflow resolves `BOT_USER` from it (§5.1).
+- [ ] If it ships a reusable: `runtime.identity` declares the `account` the
+      persona acts as and the `credential` secret holding its PAT; the credential
+      follows `GH_PAT_<ACCOUNT>[_<QUALIFIER>]` (or is a grandfathered
+      account-named secret), and the runtime workflow resolves `BOT_USER` from
+      the account (§5.1).
 - [ ] AgentShield passes on all layers; no immutable file is touched.
 - [ ] `evals/<id>/` holds `dev/` + `holdout/` splits with ≥ `evals.min_cases`
       held-out cases; `validate-cases.py` passes and the eval gate is green.

--- a/standards/personas/TEMPLATE/persona.yml
+++ b/standards/personas/TEMPLATE/persona.yml
@@ -145,6 +145,9 @@ trust:
 #   caller_stub: .github/workflows/CHANGE-ME.yml
 #   run_workflow: CHANGE-ME                 # MUST match canary-rings.json run_workflow
 #   permissions: [contents:read, pull-requests:write]   # caller stub grants a superset
+#   identity:                               # the account this persona ACTS AS (§5.1)
+#     account: CHANGE-ME                    # GitHub login (user/machine user), NOT the address team
+#     credential: GH_PAT_CHANGE_ME          # Actions secret with that account's PAT (GH_PAT_<ACCOUNT>[_<QUALIFIER>])
 
 # --- Held-out eval gate ----------------------------------------------------
 evals:

--- a/standards/personas/persona.schema.json
+++ b/standards/personas/persona.schema.json
@@ -35,7 +35,7 @@
     "schema_version": {
       "type": "integer",
       "const": 1,
-      "description": "Manifest schema version. Bump only when the schema shape changes."
+      "description": "Manifest schema version. Bump only when the schema shape changes in a backwards-incompatible way; additive optional fields stay at v1."
     },
     "id": {
       "type": "string",
@@ -235,6 +235,7 @@
     "runtime": {
       "type": "object",
       "additionalProperties": false,
+      "required": ["identity"],
       "description": "How the persona is wired into CI. Optional for advisory-only personas that run entirely inside an existing workflow.",
       "properties": {
         "host": {"type": "string", "description": "Repo that owns the reusable (matches canary-rings.json host)."},
@@ -249,18 +250,19 @@
         "identity": {
           "type": "object",
           "additionalProperties": false,
-          "description": "The GitHub account this persona ACTS AS at runtime — the login it commits/pushes/reviews/comments as, and the Actions secret holding that account's PAT. This is deliberately distinct from `address.handle` (the org TEAM humans @-mention): the handle routes a mention, the identity authenticates the work. Making it declarative here is what stops two personas from silently sharing one machine user via a single `vars.BOT_USER` variable (the dev-lead→donpetry-bot regression). The runtime resolves `BOT_USER` from `identity.account`; CI asserts the workflow's credential reference matches `identity.credential`.",
+          "description": "The GitHub account this persona ACTS AS at runtime — the login it commits/pushes/reviews/comments as, and the Actions secret holding that account's PAT. This is deliberately distinct from `address.handle` (the org TEAM humans @-mention): the handle routes a mention, the identity authenticates the work. Making it declarative here is what stops two personas from silently sharing one machine user via a single `vars.BOT_USER` variable (the dev-lead→donpetry-bot regression). The runtime resolves `BOT_USER` from `identity.account`; CI asserts the workflow's credential reference matches `identity.credential`. The companion validator (`validate-personas.py`) further enforces that `credential` follows the `GH_PAT_<ACCOUNT>[_<QUALIFIER>]` naming convention (where `<ACCOUNT>` is the login upper-snake-cased), while accepting grandfathered account-named secrets such as `DON_PETRY_BOT_GH_PAT`.",
           "required": ["account", "credential"],
           "properties": {
             "account": {
               "type": "string",
+              "maxLength": 39,
               "pattern": "^[A-Za-z0-9](-?[A-Za-z0-9]){0,38}$",
               "description": "GitHub login this persona acts as (commits/pushes/reviews/comments). A user or machine-user account, NOT a team. e.g. 'don-petry' (dev-lead) or 'donpetry-bot' (pr-review)."
             },
             "credential": {
               "type": "string",
-              "pattern": "^[A-Z][A-Z0-9_]*$",
-              "description": "Name of the GitHub Actions secret holding `account`'s PAT. Convention: GH_PAT_<ACCOUNT>[_<QUALIFIER>] with <ACCOUNT> the login upper-snake-cased (e.g. GH_PAT_DON_PETRY). Pre-existing account-named secrets (e.g. DON_PETRY_BOT_GH_PAT) are grandfathered."
+              "pattern": "^(?!GITHUB_)[A-Z][A-Z0-9_]*$",
+              "description": "Name of the GitHub Actions secret holding `account`'s PAT. Convention: GH_PAT_<ACCOUNT>[_<QUALIFIER>] with <ACCOUNT> the login upper-snake-cased (e.g. GH_PAT_DON_PETRY). Pre-existing account-named secrets (e.g. DON_PETRY_BOT_GH_PAT) are grandfathered. Must not start with `GITHUB_` (GitHub blocks creation of secrets with that prefix)."
             }
           }
         }

--- a/standards/personas/persona.schema.json
+++ b/standards/personas/persona.schema.json
@@ -245,6 +245,24 @@
           "type": "array",
           "items": {"type": "string"},
           "description": "The full permission set the reusable requests. The caller stub MUST grant a superset of this or the fleet gets startup_failure."
+        },
+        "identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "The GitHub account this persona ACTS AS at runtime — the login it commits/pushes/reviews/comments as, and the Actions secret holding that account's PAT. This is deliberately distinct from `address.handle` (the org TEAM humans @-mention): the handle routes a mention, the identity authenticates the work. Making it declarative here is what stops two personas from silently sharing one machine user via a single `vars.BOT_USER` variable (the dev-lead→donpetry-bot regression). The runtime resolves `BOT_USER` from `identity.account`; CI asserts the workflow's credential reference matches `identity.credential`.",
+          "required": ["account", "credential"],
+          "properties": {
+            "account": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9](-?[A-Za-z0-9]){0,38}$",
+              "description": "GitHub login this persona acts as (commits/pushes/reviews/comments). A user or machine-user account, NOT a team. e.g. 'don-petry' (dev-lead) or 'donpetry-bot' (pr-review)."
+            },
+            "credential": {
+              "type": "string",
+              "pattern": "^[A-Z][A-Z0-9_]*$",
+              "description": "Name of the GitHub Actions secret holding `account`'s PAT. Convention: GH_PAT_<ACCOUNT>[_<QUALIFIER>] with <ACCOUNT> the login upper-snake-cased (e.g. GH_PAT_DON_PETRY). Pre-existing account-named secrets (e.g. DON_PETRY_BOT_GH_PAT) are grandfathered."
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
## Why

Personas derive their acting GitHub account from a single shared `vars.BOT_USER` variable. Two personas that must act as **different** accounts — dev-lead as `don-petry`, pr-review as the review-only machine user `donpetry-bot` — shared that one variable, so setting it for one silently changed the other. That is the root cause of the dev-lead → donpetry-bot regression (petry-projects/.github-private#1316).

## What

Adds a `runtime.identity` block to the persona schema so each persona **declares the account it acts as** and the secret holding its PAT, orthogonal to `address.handle` (the mention team):

```yaml
runtime:
  identity:
    account: don-petry
    credential: GH_PAT_DON_PETRY
```

- `standards/personas/persona.schema.json` — new `runtime.identity` (account + credential, both required within the block).
- `standards/persona-standards.md` — new §5.1 (identity vs handle; the `GH_PAT_<ACCOUNT>[_<QUALIFIER>]` credential-naming schema) + a Definition-of-Done checklist item.
- `standards/personas/TEMPLATE/persona.yml` — shows the field.

## Companion

Consumer PR (manifests + runtime wiring + validator enforcement): **petry-projects/.github-private** branch `feat/persona-identity-1316`. Merge this schema PR first — the consumer's `validate-personas` job resolves the schema from the same-named branch, falling back to `main`.

Closes part of petry-projects/.github-private#1316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added runtime identity guidance for personas, including the acting GitHub account and associated credential naming.
  - Updated onboarding requirements to ensure runtime identity is declared and consistently resolved.
  - Added template guidance and validation for required identity account and credential fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->