### PR TITLE
feat: implement issue #793 — Adopt sonarcloud stub's JDK-21 step + checkout v6.0.3 into standards (clears remaining template-drift; no downgrades)

### DIFF
--- a/standards/workflows/sonarcloud.yml
+++ b/standards/workflows/sonarcloud.yml
@@ -38,9 +38,15 @@ jobs:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+      - name: Set up JDK 21
+        id: setup_java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
       - name: SonarCloud Scan
         id: sonar
         if: env.SONAR_TOKEN != ''


### PR DESCRIPTION
Closes #793

Implemented by dev-lead agent. Please review.