### PR TITLE
fix(canary): request permission-workflows:write for tag-move token (unblocks .github promotions)

### DIFF
--- a/.github/workflows/canary-rollout.yml
+++ b/.github/workflows/canary-rollout.yml
@@ -150,6 +150,13 @@ jobs:
             .github
             .github-private
           permission-contents: write
+          # workflows:write is REQUIRED to move a channel tag on a repo whose HEAD touches
+          # .github/workflows/** — GitHub refuses an App without it ("Resource not accessible
+          # by integration", surfacing the "create/update workflow without workflows permission"
+          # block via the git-refs API). The `.github` repo is all reusable workflows, so every
+          # promotion there tripped it. `create-github-app-token` restricts the token to the
+          # permissions requested here, so this MUST be listed even though the App now grants it.
+          permission-workflows: write
 
       - name: Checkout (with tags)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0


### PR DESCRIPTION
**Validated live** before merge: dispatched canary-rollout from this branch → `promoted agent-shield/v2-ring0` (was 403 'Resource not accessible by integration' on every .github move since ~2026-07-13).

Root cause: the repo-scoped write token was minted `permission-contents: write` only, so create-github-app-token restricted it to contents — even after the release-manager App was granted `workflows: write`. Moving a channel tag on the `.github` repo (whose HEAD touches `.github/workflows/**`) requires the workflows permission or GitHub returns 403 via the git-refs API (the 'create/update workflow without workflows permission' block). Fix = request `permission-workflows: write` so the minted token carries it.

Refs prior investigation #743/#744/#745/#749; community discussions #26164, #109715.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved canary rollout reliability by ensuring the required permissions are available when updating channel tags in repositories with workflow-related changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->