### PR TITLE
feat: implement issue #852 — [#850 B] Auto-merge standards-sync PRs through branch protection (resolve the reviewer deadlock — no --admin)

### DIFF
--- a/.github/workflows/automerge-standards-sync-tests.yml
+++ b/.github/workflows/automerge-standards-sync-tests.yml
@@ -1,0 +1,48 @@
+# Tests for scripts/automerge-standards-sync.sh — the merge-side primitive that
+# clears the pr-quality reviewer deadlock on standards-sync PRs by approving from
+# a distinct code-owner identity and enabling native auto-merge (issue #852).
+# Gates: shellcheck (the script) + bats (eligibility gating, distinct-reviewer
+# resolution, deadlock detection, and the "never --admin" invariant).
+name: Automerge Standards-Sync Tests
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/automerge-standards-sync.sh'
+      - 'test/scripts/automerge-standards-sync/**'
+      - '.github/workflows/automerge-standards-sync-tests.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/automerge-standards-sync.sh'
+      - 'test/scripts/automerge-standards-sync/**'
+      - '.github/workflows/automerge-standards-sync-tests.yml'
+
+permissions: {}
+
+concurrency:
+  group: automerge-standards-sync-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Lint and bats
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install bats, shellcheck, jq
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends bats shellcheck jq
+
+      - name: shellcheck
+        run: shellcheck --severity=warning -x scripts/automerge-standards-sync.sh
+
+      - name: bats
+        run: bats --print-output-on-failure test/scripts/automerge-standards-sync/

--- a/scripts/automerge-standards-sync.sh
+++ b/scripts/automerge-standards-sync.sh
@@ -92,7 +92,7 @@ fi
 
 # in_list <needle> <comma-separated-haystack>
 in_list() {
-  local needle="$1" hay="$2" item
+  local needle="$1" hay="$2" item _items
   IFS=',' read -ra _items <<< "$hay"
   for item in "${_items[@]}"; do
     item="${item#"${item%%[![:space:]]*}"}"; item="${item%"${item##*[![:space:]]}"}"
@@ -104,7 +104,7 @@ in_list() {
 # resolve_approver <author> <last_pusher> — echo the code-owner that is neither
 # the author nor the last pusher, or empty when none exists (the deadlock).
 resolve_approver() {
-  local author="$1" last="$2" item
+  local author="$1" last="$2" item _members
   IFS=',' read -ra _members <<< "$ORG_LEADS_MEMBERS"
   for item in "${_members[@]}"; do
     item="${item#"${item%%[![:space:]]*}"}"; item="${item%"${item##*[![:space:]]}"}"
@@ -175,6 +175,21 @@ process_pr() {
     echo "  [dry-run] ${url} — would approve as '${approver}' (distinct code-owner) and enable native auto-merge (squash); admin=none"
     echo "AUDIT pr=${url} approver=${approver} merge=native-auto-merge admin=none dry_run=true"
     return 0
+  fi
+
+  # Verify APPROVER_TOKEN actually authenticates as the resolved approver, so the
+  # audit line and the review body attribute the approval to the real identity
+  # (a token/login mismatch from misconfiguration or rotation must not silently
+  # post a misattributed code-owner approval).
+  local token_login
+  token_login=$(GH_TOKEN="$APPROVER_TOKEN" gh api user --jq '.login' 2>/dev/null || true)
+  if [ -z "$token_login" ]; then
+    echo "::error::${url} — APPROVER_TOKEN did not authenticate (gh api user failed); refusing to post an unattributable approval" >&2
+    return 1
+  fi
+  if [ "$token_login" != "$approver" ]; then
+    echo "::error::${url} — APPROVER_TOKEN authenticates as '${token_login}', not the resolved approver '${approver}'; refusing to post a misattributed approval" >&2
+    return 1
   fi
 
   echo "  [approve] ${url} — approving as '${approver}' (distinct code-owner: neither author nor last pusher)"

--- a/scripts/automerge-standards-sync.sh
+++ b/scripts/automerge-standards-sync.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# automerge-standards-sync.sh — merge `standards-sync` PRs THROUGH branch
+# protection, with no `--admin` bypass and no human click (issue #852, Epic #850).
+#
+# The problem
+# -----------
+# The `pr-quality` ruleset (standards/rulesets/pr-quality.json) requires a
+# code-owner approval, `require_last_push_approval`, and — implicitly — that the
+# approval is not the PR author's own. CODEOWNERS is `* @petry-projects/org-leads`
+# = {don-petry, donpetry-bot}. On a standards-sync PR author=don-petry (cannot
+# self-approve) and last-pusher=donpetry-bot (last-push-approval disqualifies its
+# own approval), so BOTH code-owners are disqualified and the only historical way
+# to merge was an org-admin `--admin` bypass — automation could not merge its own
+# remediation.
+#
+# The fix (issue Options 1 + 2, "through protection, not around it")
+# ------------------------------------------------------------------
+#  1. Distinct review identity — approve as the org-leads code-owner that is
+#     NEITHER the author NOR the last pusher. That single approval legitimately
+#     satisfies require_code_owner_review + require_last_push_approval + not-own-PR.
+#  2. Native auto-merge — `gh pr merge --auto --squash`, so GitHub merges the PR
+#     itself once the required status checks are green. The merge goes THROUGH the
+#     ruleset (all required checks + the now-satisfied approval), never around it.
+#
+# This script NEVER passes `--admin` and never mutates the ruleset; the required
+# status-check gates are untouched. Every action is logged for audit.
+#
+# Usage:
+#   automerge-standards-sync.sh --repo <owner/repo> --pr <number> [--dry-run]
+#   automerge-standards-sync.sh --repo <owner/repo> [--dry-run]   # sweep open PRs
+#
+# Options:
+#   --repo <owner/repo>   Target repository (required). Works for the SKIP_REPOS
+#                         meta-repos too (e.g. petry-projects/.github-private).
+#   --pr <number>         Operate on a single PR. Omit to sweep every open PR that
+#                         carries the standards-sync label.
+#   --dry-run             Print intended actions; make no mutating gh calls.
+#   --approver-login <u>  Pin the approving code-owner instead of auto-resolving.
+#
+# Environment:
+#   GH_TOKEN         Token for read/list/merge calls (repo scope).
+#   APPROVER_TOKEN   Token for the DISTINCT approver identity used to post the
+#                    approval review. Required unless --dry-run. In production the
+#                    approver's own PAT is supplied here so the approval is
+#                    attributable to that identity (audit trail).
+#   SYNC_LABEL           Merge-eligibility label (default: standards-sync).
+#   SYNC_BRANCH_PREFIX   Required head-branch prefix (default: standards-sync).
+#   ORG_LEADS_MEMBERS    Comma-separated code-owner set that satisfies CODEOWNERS
+#                        (default: don-petry,donpetry-bot).
+#   TRUSTED_AUTHORS      Comma-separated allowlist of PR authors whose standards-sync
+#                        PRs are eligible (default: value of ORG_LEADS_MEMBERS).
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Dependencies
+# ---------------------------------------------------------------------------
+for _cmd in gh jq; do
+  command -v "$_cmd" >/dev/null 2>&1 || { echo "::error::${_cmd} is required but not installed." >&2; exit 1; }
+done
+unset _cmd
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+SYNC_LABEL="${SYNC_LABEL:-standards-sync}"
+SYNC_BRANCH_PREFIX="${SYNC_BRANCH_PREFIX:-standards-sync}"
+ORG_LEADS_MEMBERS="${ORG_LEADS_MEMBERS:-don-petry,donpetry-bot}"
+TRUSTED_AUTHORS="${TRUSTED_AUTHORS:-$ORG_LEADS_MEMBERS}"
+
+REPO=""
+PR_NUMBER=""
+DRY_RUN=false
+APPROVER_LOGIN=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo)           REPO="${2:?--repo needs a value}"; shift 2 ;;
+    --pr)             PR_NUMBER="${2:?--pr needs a value}"; shift 2 ;;
+    --approver-login) APPROVER_LOGIN="${2:?--approver-login needs a value}"; shift 2 ;;
+    --dry-run)        DRY_RUN=true; shift ;;
+    -h|--help)        sed -n '1,52p' "$0"; exit 0 ;;
+    *) echo "::error::unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$REPO" ] || { echo "::error::--repo <owner/repo> is required" >&2; exit 2; }
+if [ "$DRY_RUN" != "true" ] && [ -z "${APPROVER_TOKEN:-}" ]; then
+  echo "::error::APPROVER_TOKEN is required for a live run (the distinct approver's token). Use --dry-run to preview." >&2
+  exit 2
+fi
+
+# in_list <needle> <comma-separated-haystack>
+in_list() {
+  local needle="$1" hay="$2" item
+  IFS=',' read -ra _items <<< "$hay"
+  for item in "${_items[@]}"; do
+    item="${item#"${item%%[![:space:]]*}"}"; item="${item%"${item##*[![:space:]]}"}"
+    [ "$item" = "$needle" ] && return 0
+  done
+  return 1
+}
+
+# resolve_approver <author> <last_pusher> — echo the code-owner that is neither
+# the author nor the last pusher, or empty when none exists (the deadlock).
+resolve_approver() {
+  local author="$1" last="$2" item
+  IFS=',' read -ra _members <<< "$ORG_LEADS_MEMBERS"
+  for item in "${_members[@]}"; do
+    item="${item#"${item%%[![:space:]]*}"}"; item="${item%"${item##*[![:space:]]}"}"
+    [ -z "$item" ] && continue
+    if [ "$item" != "$author" ] && [ "$item" != "$last" ]; then
+      printf '%s' "$item"
+      return 0
+    fi
+  done
+  return 0
+}
+
+# process_pr <pr-number> — returns 0 on success/skip, 1 on an unresolved deadlock.
+process_pr() {
+  local pr="$1"
+  local pr_json author head last url labels
+
+  pr_json=$(gh pr view "$pr" --repo "$REPO" \
+    --json number,url,author,headRefName,labels,commits 2>/dev/null) || {
+    echo "  [warn] ${REPO}#${pr} — could not read PR" >&2
+    return 0
+  }
+
+  author=$(jq -r '.author.login // empty' <<< "$pr_json")
+  head=$(jq -r '.headRefName // empty' <<< "$pr_json")
+  url=$(jq -r '.url // empty' <<< "$pr_json")
+  last=$(jq -r '.commits[-1].authors[0].login // empty' <<< "$pr_json")
+  labels=$(jq -r '.labels[].name' <<< "$pr_json" 2>/dev/null || true)
+  [ -n "$url" ] || url="${REPO}#${pr}"
+
+  # --- Eligibility gates (auditable trusted source) ---
+  if ! grep -qxF "$SYNC_LABEL" <<< "$labels"; then
+    echo "  [skip] ${url} — missing '${SYNC_LABEL}' label"
+    return 0
+  fi
+  if [[ "$head" != "${SYNC_BRANCH_PREFIX}/"* ]]; then
+    echo "  [skip] ${url} — head branch '${head}' is not a '${SYNC_BRANCH_PREFIX}/' branch"
+    return 0
+  fi
+  if ! in_list "$author" "$TRUSTED_AUTHORS"; then
+    echo "  [skip] ${url} — author '${author}' is not in the trusted allowlist"
+    return 0
+  fi
+
+  # --- Resolve the distinct review identity (Option 1) ---
+  local approver
+  if [ -n "$APPROVER_LOGIN" ]; then
+    if ! in_list "$APPROVER_LOGIN" "$ORG_LEADS_MEMBERS"; then
+      echo "::error::approver '${APPROVER_LOGIN}' is not an org-leads code-owner (${ORG_LEADS_MEMBERS})" >&2
+      return 1
+    fi
+    if [ "$APPROVER_LOGIN" = "$author" ] || [ "$APPROVER_LOGIN" = "$last" ]; then
+      echo "::error::${url} — pinned approver '${APPROVER_LOGIN}' is the author or last pusher; cannot satisfy require_last_push_approval / not-own-PR" >&2
+      return 1
+    fi
+    approver="$APPROVER_LOGIN"
+  else
+    approver=$(resolve_approver "$author" "$last")
+  fi
+
+  if [ -z "$approver" ]; then
+    echo "::error::${url} — reviewer DEADLOCK: author='${author}' and last-pusher='${last}' consume every code-owner {${ORG_LEADS_MEMBERS}}, so no distinct code-owner can approve. Resolve by giving the PR a single push identity (author == last pusher) or by adding a distinct org-leads code-owner. NOT merging via --admin." >&2
+    return 1
+  fi
+
+  # --- Approve as the distinct identity + enable native auto-merge (Option 2) ---
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "  [dry-run] ${url} — would approve as '${approver}' (distinct code-owner) and enable native auto-merge (squash); admin=none"
+    echo "AUDIT pr=${url} approver=${approver} merge=native-auto-merge admin=none dry_run=true"
+    return 0
+  fi
+
+  echo "  [approve] ${url} — approving as '${approver}' (distinct code-owner: neither author nor last pusher)"
+  if ! GH_TOKEN="$APPROVER_TOKEN" gh pr review "$pr" --repo "$REPO" --approve \
+      --body "Code-owner approval by @${approver} to clear the pr-quality reviewer deadlock on this standards-sync PR (issue #852). Merges via native auto-merge on required-checks-green — through branch protection, no admin bypass."; then
+    echo "::error::${url} — failed to post approval review as '${approver}'" >&2
+    return 1
+  fi
+
+  echo "  [automerge] ${url} — enabling native auto-merge (squash); merges on required-checks-green through branch protection"
+  if ! gh pr merge "$pr" --repo "$REPO" --auto --squash; then
+    echo "::error::${url} — failed to enable native auto-merge" >&2
+    return 1
+  fi
+
+  echo "AUDIT pr=${url} approver=${approver} merge=native-auto-merge admin=none"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+echo "=== Standards-sync auto-merge ==="
+echo "  Repo:            ${REPO}"
+echo "  Label:           ${SYNC_LABEL}"
+echo "  Code-owners:     ${ORG_LEADS_MEMBERS}"
+echo "  Dry run:         ${DRY_RUN}"
+echo ""
+
+rc=0
+if [ -n "$PR_NUMBER" ]; then
+  process_pr "$PR_NUMBER" || rc=1
+else
+  numbers=$(gh pr list --repo "$REPO" --state open --label "$SYNC_LABEL" \
+    --json number --jq '.[].number' 2>/dev/null || true)
+  if [ -z "$numbers" ]; then
+    echo "  No open '${SYNC_LABEL}' PRs in ${REPO}."
+  else
+    while IFS= read -r n; do
+      [ -z "$n" ] && continue
+      process_pr "$n" || rc=1
+    done <<< "$numbers"
+  fi
+fi
+
+echo ""
+if [ "$rc" -eq 0 ]; then
+  echo "=== Done — no --admin bypass used ==="
+else
+  echo "=== Completed with unresolved deadlock(s); see errors above (no --admin used) ===" >&2
+fi
+exit "$rc"

--- a/standards/github-settings.md
+++ b/standards/github-settings.md
@@ -260,6 +260,20 @@ the merge occurs — the automation only handles the final merge step after huma
 See [GitHub's auto-merge documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request)
 for more details.
 
+##### `standards-sync` PRs — clearing the reviewer deadlock without `--admin`
+
+`standards-sync` / dev-lead remediation PRs cannot satisfy `pr-quality`
+unaided: with CODEOWNERS = `* @petry-projects/org-leads` = `{don-petry,
+donpetry-bot}`, an author=one-lead / last-pusher=other-lead PR disqualifies
+**both** code-owners (author can't self-approve; the last pusher's approval is
+voided by `require_last_push_approval`), so historically only an `--admin` bypass
+merged them. [`scripts/automerge-standards-sync.sh`](../scripts/automerge-standards-sync.sh)
+resolves this **through** the ruleset: it approves as the code-owner that is
+neither the author nor the last pusher (a legitimate code-owner + last-push +
+not-own-PR approval), then enables **native auto-merge** so GitHub merges on
+required-checks-green — no `--admin`, no human click, required-check gates
+unchanged. See the [Ruleset Remediation Runbook §6](ruleset-remediation-runbook.md#6-merging-standards-sync-prs-through-protection-no---admin).
+
 #### Bypass Actors
 
 See [Bypass Actors — Required on Every Ruleset Targeting `main`](#bypass-actors--required-on-every-ruleset-targeting-main) above.

--- a/standards/ruleset-remediation-runbook.md
+++ b/standards/ruleset-remediation-runbook.md
@@ -131,6 +131,62 @@ jq '{name,target,enforcement,conditions,rules,bypass_actors}' "$SNAP/<repo>__<id
 
 ---
 
+## 6. Merging `standards-sync` PRs through protection (no `--admin`)
+
+Standards-sync / dev-lead remediation PRs hit a **structural reviewer deadlock**
+under `pr-quality` — the ruleset requires a code-owner approval **plus**
+`require_last_push_approval` **plus** not-own-PR, but CODEOWNERS is
+`* @petry-projects/org-leads` = `{don-petry, donpetry-bot}`. On these PRs the
+author is one org-lead (cannot self-approve) and the last pusher is the other
+(its own approval is disqualified by last-push-approval), so **both** code-owners
+are disqualified and the only historical path was an org-admin `--admin` bypass.
+That is why the automation could not merge its own remediation across the
+2026-07-21 rollout.
+
+**Resolution — approve as the distinct code-owner, then native auto-merge.**
+[`scripts/automerge-standards-sync.sh`](../scripts/automerge-standards-sync.sh)
+resolves the deadlock **through** branch protection, never around it:
+
+1. **Distinct review identity.** It approves as the org-leads code-owner that is
+   **neither the author nor the last pusher**. That single approval legitimately
+   satisfies `require_code_owner_review` + `require_last_push_approval` +
+   not-own-PR. The approval is posted with `APPROVER_TOKEN` (the approver's own
+   PAT) so the review is attributable to that identity — auditable.
+2. **Native auto-merge.** It then runs `gh pr merge --auto --squash`, so **GitHub**
+   merges the PR once the **required status checks are green**. The merge passes
+   the full ruleset (all required checks + the now-satisfied approval); the
+   required-status-check gates are never weakened and `--admin` is never used.
+
+```bash
+# One PR (approver's token supplies the distinct identity):
+GH_TOKEN=<repo-scope> APPROVER_TOKEN=<approver-pat> \
+  bash scripts/automerge-standards-sync.sh --repo petry-projects/<repo> --pr <n>
+
+# Sweep every open standards-sync PR in a repo (incl. the SKIP_REPOS meta-repos):
+GH_TOKEN=<repo-scope> APPROVER_TOKEN=<approver-pat> \
+  bash scripts/automerge-standards-sync.sh --repo petry-projects/.github-private
+
+# Preview only — no approval, no auto-merge, no mutation:
+bash scripts/automerge-standards-sync.sh --repo petry-projects/<repo> --pr <n> --dry-run
+```
+
+Eligibility is gated to a **trusted source**: the PR must carry the
+`standards-sync` label, its head branch must be a `standards-sync/` branch, and
+its author must be in `TRUSTED_AUTHORS` (default = `ORG_LEADS_MEMBERS`). Anything
+else is skipped untouched. Every run emits an `AUDIT pr=… approver=…
+merge=native-auto-merge admin=none` line.
+
+> **Genuine deadlock (author + last-pusher consume every code-owner).** With only
+> `{don-petry, donpetry-bot}` as code-owners, a PR whose author is one and whose
+> last pusher is the other leaves **no** distinct approver. The script refuses to
+> proceed (non-zero, no `--admin`) and prints the remediation: give the PR a
+> **single push identity** (author == last pusher, freeing the other owner) or add
+> a **distinct org-leads code-owner** (a third machine user in the team — see the
+> [CODEOWNERS Standard](codeowners-standard.md#required-setup-for-new-bots)) and
+> pass it via `--approver-login`.
+
+---
+
 ## Reference: 2026-06-10 fleet remediation
 
 First full application of this runbook. Re-audit afterward reported **zero

--- a/test/scripts/automerge-standards-sync/automerge.bats
+++ b/test/scripts/automerge-standards-sync/automerge.bats
@@ -1,0 +1,167 @@
+#!/usr/bin/env bats
+# Tests for scripts/automerge-standards-sync.sh — the merge-side primitive that
+# clears the pr-quality reviewer deadlock on `standards-sync` PRs by approving
+# from a DISTINCT code-owner identity and enabling GitHub NATIVE auto-merge, so
+# the PR merges on required-checks-green THROUGH branch protection (never
+# `--admin`).
+#
+# A fake `gh` returns a single `pr view --json …` blob per PR (env
+# GH_PR_VIEW_JSON) and logs every invocation to GH_CALLS so the assertions can
+# prove exactly which mutating calls were (not) made — and that no call ever
+# carries `--admin`.
+
+setup() {
+  TT_TMP="$(mktemp -d)"
+  REPO_ROOT="$(cd -- "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  SCRIPT="${REPO_ROOT}/scripts/automerge-standards-sync.sh"
+  GH_CALLS="${TT_TMP}/gh-calls.log"; export GH_CALLS
+  : > "$GH_CALLS"
+  install_gh_stub
+}
+
+teardown() { rm -rf "$TT_TMP"; }
+
+install_gh_stub() {
+  local bin="${TT_TMP}/bin"
+  mkdir -p "$bin"
+  cat > "$bin/gh" <<'STUB'
+#!/usr/bin/env bash
+{ printf 'gh'; for a in "$@"; do printf ' %s' "$a"; done; printf '\n'; } >> "$GH_CALLS"
+case "$1 ${2:-}" in
+  "pr view")  printf '%s' "${GH_PR_VIEW_JSON:-null}" ; exit 0 ;;
+  "pr list")  printf '%s' "${GH_PR_LIST_JSON:-[]}" ; exit 0 ;;
+  "pr review") exit 0 ;;
+  "pr merge")  exit 0 ;;
+  "auth status") exit 0 ;;
+esac
+exit 0
+STUB
+  chmod +x "$bin/gh"
+  PATH="${bin}:${PATH}"; export PATH
+}
+
+# Build a pr view JSON blob: $1 author, $2 headRefName, $3 last-commit author,
+# $4 comma-separated label list.
+pr_json() {
+  local author="$1" head="$2" last="$3" labels="$4"
+  local labels_json="[]"
+  if [ -n "$labels" ]; then
+    labels_json="$(printf '%s\n' "$labels" | tr ',' '\n' \
+      | jq -R '{name: .}' | jq -sc '.')"
+  fi
+  jq -nc \
+    --arg author "$author" --arg head "$head" --arg last "$last" \
+    --argjson labels "$labels_json" '
+    { number: 42,
+      url: "https://github.com/petry-projects/acme/pull/42",
+      author: {login: $author},
+      headRefName: $head,
+      labels: $labels,
+      commits: [ {authors: [ {login: $last} ]} ] }'
+}
+
+run_single() {  # extra args passed through
+  run env GH_TOKEN=x APPROVER_TOKEN=faketoken bash "$SCRIPT" \
+    --repo petry-projects/acme --pr 42 "$@"
+}
+
+# ── Eligibility gating ────────────────────────────────────────────────────────
+
+@test "skips a PR that is missing the standards-sync label" {
+  GH_PR_VIEW_JSON="$(pr_json don-petry standards-sync/2026-07-21 don-petry "dependencies")"
+  export GH_PR_VIEW_JSON
+  run_single
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qi 'skip'
+  echo "$output" | grep -qi 'standards-sync'
+  ! grep -q 'pr review' "$GH_CALLS"
+  ! grep -q 'pr merge' "$GH_CALLS"
+}
+
+@test "skips a PR whose author is not trusted" {
+  GH_PR_VIEW_JSON="$(pr_json mallory standards-sync/2026-07-21 don-petry "standards-sync")"
+  export GH_PR_VIEW_JSON
+  run_single
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qi 'skip'
+  ! grep -q 'pr review' "$GH_CALLS"
+  ! grep -q 'pr merge' "$GH_CALLS"
+}
+
+@test "skips a PR whose head branch is not a standards-sync branch" {
+  GH_PR_VIEW_JSON="$(pr_json don-petry feature/x don-petry "standards-sync")"
+  export GH_PR_VIEW_JSON
+  run_single
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qi 'skip'
+  ! grep -q 'pr review' "$GH_CALLS"
+  ! grep -q 'pr merge' "$GH_CALLS"
+}
+
+# ── Happy path: distinct reviewer resolves the deadlock ───────────────────────
+
+@test "approves as the distinct code-owner and enables native auto-merge" {
+  # author==last-pusher==don-petry frees donpetry-bot as the distinct reviewer.
+  GH_PR_VIEW_JSON="$(pr_json don-petry standards-sync/2026-07-21 don-petry "standards-sync")"
+  export GH_PR_VIEW_JSON
+  run_single
+  [ "$status" -eq 0 ]
+  # A real approval review was posted…
+  grep -q 'pr review 42 --repo petry-projects/acme --approve' "$GH_CALLS"
+  # …and native auto-merge (squash) was enabled — merge fires on green THROUGH protection.
+  grep -qE 'pr merge 42 --repo petry-projects/acme .*--auto' "$GH_CALLS"
+  grep -q -- '--squash' "$GH_CALLS"
+  # The chosen approver is the code-owner that is neither author nor last-pusher.
+  echo "$output" | grep -q 'donpetry-bot'
+  # NEVER an admin bypass — anywhere.
+  ! grep -q -- '--admin' "$GH_CALLS"
+  echo "$output" | grep -q 'admin=none'
+}
+
+@test "never emits an --admin bypass on the happy path" {
+  GH_PR_VIEW_JSON="$(pr_json donpetry-bot standards-sync/2026-07-21 donpetry-bot "standards-sync")"
+  export GH_PR_VIEW_JSON
+  run_single
+  [ "$status" -eq 0 ]
+  ! grep -q -- '--admin' "$GH_CALLS"
+  # here don-petry is the free code-owner
+  echo "$output" | grep -q 'don-petry'
+}
+
+# ── Deadlock: author + last-pusher consume every code-owner ───────────────────
+
+@test "reports the deadlock (no distinct owner) and never uses --admin" {
+  GH_PR_VIEW_JSON="$(pr_json don-petry standards-sync/2026-07-21 donpetry-bot "standards-sync")"
+  export GH_PR_VIEW_JSON
+  run_single
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -qi 'deadlock'
+  ! grep -q 'pr review' "$GH_CALLS"
+  ! grep -q 'pr merge' "$GH_CALLS"
+  ! grep -q -- '--admin' "$GH_CALLS"
+}
+
+# ── Dry-run mutates nothing ───────────────────────────────────────────────────
+
+@test "dry-run posts no approval and enables no auto-merge" {
+  GH_PR_VIEW_JSON="$(pr_json don-petry standards-sync/2026-07-21 don-petry "standards-sync")"
+  export GH_PR_VIEW_JSON
+  run_single --dry-run
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qi 'dry'
+  ! grep -q 'pr review' "$GH_CALLS"
+  ! grep -q 'pr merge' "$GH_CALLS"
+}
+
+# ── Meta-repo (.github-private / SKIP_REPOS) is handled the same way ───────────
+
+@test "processes a .github-private meta-repo PR the same way" {
+  GH_PR_VIEW_JSON="$(pr_json don-petry standards-sync/2026-07-21 don-petry "standards-sync")"
+  export GH_PR_VIEW_JSON
+  run env GH_TOKEN=x APPROVER_TOKEN=faketoken bash "$SCRIPT" \
+    --repo petry-projects/.github-private --pr 42
+  [ "$status" -eq 0 ]
+  grep -q 'pr review 42 --repo petry-projects/.github-private --approve' "$GH_CALLS"
+  grep -qE 'pr merge 42 --repo petry-projects/.github-private .*--auto' "$GH_CALLS"
+  ! grep -q -- '--admin' "$GH_CALLS"
+}

--- a/test/scripts/automerge-standards-sync/automerge.bats
+++ b/test/scripts/automerge-standards-sync/automerge.bats
@@ -32,6 +32,7 @@ case "$1 ${2:-}" in
   "pr list")  printf '%s' "${GH_PR_LIST_JSON:-[]}" ; exit 0 ;;
   "pr review") exit 0 ;;
   "pr merge")  exit 0 ;;
+  "api user") printf '%s' "${GH_API_USER_LOGIN:-donpetry-bot}" ; exit 0 ;;
   "auth status") exit 0 ;;
 esac
 exit 0
@@ -121,6 +122,8 @@ run_single() {  # extra args passed through
 @test "never emits an --admin bypass on the happy path" {
   GH_PR_VIEW_JSON="$(pr_json donpetry-bot standards-sync/2026-07-21 donpetry-bot "standards-sync")"
   export GH_PR_VIEW_JSON
+  # here don-petry is the free code-owner, so the approver token authenticates as don-petry
+  GH_API_USER_LOGIN=don-petry; export GH_API_USER_LOGIN
   run_single
   [ "$status" -eq 0 ]
   ! grep -q -- '--admin' "$GH_CALLS"
@@ -136,6 +139,22 @@ run_single() {  # extra args passed through
   run_single
   [ "$status" -ne 0 ]
   echo "$output" | grep -qi 'deadlock'
+  ! grep -q 'pr review' "$GH_CALLS"
+  ! grep -q 'pr merge' "$GH_CALLS"
+  ! grep -q -- '--admin' "$GH_CALLS"
+}
+
+# ── Approver-token identity is verified before any approval is posted ─────────
+
+@test "refuses to approve when APPROVER_TOKEN authenticates as a different login" {
+  # Resolved approver is donpetry-bot, but the token authenticates as someone else
+  # (misconfiguration / rotation) → refuse rather than post a misattributed approval.
+  GH_PR_VIEW_JSON="$(pr_json don-petry standards-sync/2026-07-21 don-petry "standards-sync")"
+  export GH_PR_VIEW_JSON
+  GH_API_USER_LOGIN=someone-else; export GH_API_USER_LOGIN
+  run_single
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -qi 'misattributed'
   ! grep -q 'pr review' "$GH_CALLS"
   ! grep -q 'pr merge' "$GH_CALLS"
   ! grep -q -- '--admin' "$GH_CALLS"


### PR DESCRIPTION
## **User description**
Closes #852

Implemented by dev-lead agent. Please review.


___

## **CodeAnt-AI Description**
**Auto-merge standards-sync PRs through branch protection without admin bypass**

### What Changed
- Standards-sync PRs can now be approved by a distinct org-leads code owner and set to auto-merge once checks pass, instead of requiring a manual `--admin` merge.
- The script skips PRs that do not meet the expected label, branch, and trusted-author rules, and it refuses to continue when no distinct approver exists or when the approver token belongs to a different account.
- New tests cover the skip rules, successful approval and auto-merge flow, deadlock handling, dry-run mode, and meta-repo support.
- The runbook and GitHub settings docs now explain the deadlock and how the new flow resolves it.

### Impact
`✅ Fewer manual merges for standards-sync PRs`
`✅ Clearer approval audit trail`
`✅ Fewer accidental admin bypasses`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
