### PR TITLE
feat: implement issue #860 — [#850 Phase 1a] Re-pin 13 caller-stub templates to validated major-scoped v<M>-stable channels

### DIFF
--- a/.github/workflows/standards-templates-tests.yml
+++ b/.github/workflows/standards-templates-tests.yml
@@ -1,0 +1,51 @@
+# Quality gate for the caller-stub templates under standards/workflows/.
+#
+# Triggered on any PR that touches:
+#   - standards/workflows/**            (a template pin changed)
+#   - test/scripts/standards-templates/** (the guard itself changed)
+#
+# Gate: bats — every deployable template pins its major-scoped
+#       `<agent>/v<M>-stable` channel and never the bare `<agent>/stable` form.
+
+name: Standards Templates Tests
+
+on:
+  pull_request:
+    paths:
+      - 'standards/workflows/**'
+      - 'test/scripts/standards-templates/**'
+      - '.github/workflows/standards-templates-tests.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'standards/workflows/**'
+      - 'test/scripts/standards-templates/**'
+      - '.github/workflows/standards-templates-tests.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: standards-templates-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: bats
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: Install bats
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends bats
+
+      - name: Run bats suite
+        run: bats --print-output-on-failure test/scripts/standards-templates/

--- a/standards/workflows/add-to-project.yml
+++ b/standards/workflows/add-to-project.yml
@@ -7,7 +7,7 @@
 #   • This file is a THIN CALLER STUB. All noise-gate / reconcile logic lives
 #     in the reusable workflow above.
 #   • You MAY change: nothing in normal use. The `uses:` ref and `agent_ref`
-#     are pinned to the `add-to-project/stable` channel and move with it — do
+#     are pinned to the `add-to-project/v1-stable` channel and move with it — do
 #     not change them to `@main` or a SHA (see ci-standards.md → Reusable
 #     workflow versioning).
 #   • You MUST NOT change: trigger events, the concurrency group, or the

--- a/standards/workflows/add-to-project.yml
+++ b/standards/workflows/add-to-project.yml
@@ -47,11 +47,11 @@ jobs:
   add-to-project:
     permissions:
       contents: read
-    uses: petry-projects/.github/.github/workflows/add-to-project-reusable.yml@add-to-project/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/add-to-project-reusable.yml@add-to-project/v1-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
       project_id: PVT_kwDOD2inqs4BZq3-
       project_url: https://github.com/orgs/petry-projects/projects/1
-      agent_ref: add-to-project/stable
+      agent_ref: add-to-project/v1-stable
     # Pass only the secrets the reusable declares (least privilege; avoids
     # `secrets: inherit` handing the reusable every org secret).
     secrets:

--- a/standards/workflows/agent-shield.yml
+++ b/standards/workflows/agent-shield.yml
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   agent-shield:
-    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@agent-shield/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@agent-shield/v2-stable  # NOSONAR(githubactions:S7637) first-party channel ref

--- a/standards/workflows/auto-rebase.yml
+++ b/standards/workflows/auto-rebase.yml
@@ -50,5 +50,5 @@ jobs:
     permissions:
       contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write # post comments on PRs
-    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@auto-rebase/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@auto-rebase/v2-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets: inherit

--- a/standards/workflows/auto-rebase.yml
+++ b/standards/workflows/auto-rebase.yml
@@ -7,7 +7,7 @@
 #   • This file is a THIN CALLER STUB. All branch-update logic lives in the
 #     reusable workflow above.
 #   • You MUST NOT change: the `uses:` ref — it is pinned to the
-#     `auto-rebase/stable` channel, a moving tag advanced centrally. Never
+#     `auto-rebase/v2-stable` channel, a moving tag advanced centrally. Never
 #     repoint it to `@main`, a SHA, or a frozen `@vX` (see ci-standards.md →
 #     Reusable workflow versioning). Also do not change the trigger event,
 #     the concurrency group name,

--- a/standards/workflows/dependabot-automerge.yml
+++ b/standards/workflows/dependabot-automerge.yml
@@ -35,5 +35,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@dependabot-automerge/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@dependabot-automerge/v2-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets: inherit

--- a/standards/workflows/dependabot-rebase.yml
+++ b/standards/workflows/dependabot-rebase.yml
@@ -50,7 +50,7 @@ jobs:
     permissions:
       contents: write   # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write  # re-approve PRs after branch update
-    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@dependabot-rebase/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@dependabot-rebase/v2-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/standards/workflows/dependabot-rebase.yml
+++ b/standards/workflows/dependabot-rebase.yml
@@ -7,7 +7,7 @@
 #   • This file is a THIN CALLER STUB. All rebase/merge serialization logic
 #     lives in the reusable workflow above.
 #   • You MUST NOT change: the `uses:` ref — it is pinned to the
-#     `dependabot-rebase/stable` channel, a moving tag advanced centrally.
+#     `dependabot-rebase/v2-stable` channel, a moving tag advanced centrally.
 #     Never repoint it to `@main`, a SHA, or a frozen `@vX` (see
 #     ci-standards.md → Reusable workflow versioning). Also do not change the
 #     concurrency group name, the explicit secrets

--- a/standards/workflows/dependency-audit.yml
+++ b/standards/workflows/dependency-audit.yml
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   dependency-audit:
-    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@dependency-audit/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@dependency-audit/v2-stable  # NOSONAR(githubactions:S7637) first-party channel ref

--- a/standards/workflows/dev-lead.yml
+++ b/standards/workflows/dev-lead.yml
@@ -61,9 +61,9 @@ jobs:
     # dependency). Promotion is done by moving the dev-lead/stable tag centrally; this
     # caller is never edited on release. agent_ref threads the same channel into
     # dev-lead's own scripts/prompts checkout. See https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#dev-lead-agent.
-    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/v1-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
-      agent_ref: dev-lead/stable
+      agent_ref: dev-lead/v1-stable
     secrets: inherit
     permissions:
       contents: write

--- a/standards/workflows/dev-lead.yml
+++ b/standards/workflows/dev-lead.yml
@@ -56,9 +56,9 @@ permissions: {}
 
 jobs:
   dev-lead:
-    # Pinned to the moving dev-lead/stable channel tag, not @main, so a broken
+    # Pinned to the moving dev-lead/v1-stable channel tag, not @main, so a broken
     # change to dev-lead can no longer gate its own fix (the self-host circular
-    # dependency). Promotion is done by moving the dev-lead/stable tag centrally; this
+    # dependency). Promotion is done by moving the dev-lead/v1-stable tag centrally; this
     # caller is never edited on release. agent_ref threads the same channel into
     # dev-lead's own scripts/prompts checkout. See https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#dev-lead-agent.
     uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/v1-stable  # NOSONAR(githubactions:S7637) first-party channel ref

--- a/standards/workflows/feature-ideation.yml
+++ b/standards/workflows/feature-ideation.yml
@@ -182,7 +182,7 @@ jobs:
       discussions: write
       id-token: write
       actions: read
-    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@feature-ideation/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@feature-ideation/v1-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
       # All values below come from `needs.prep.outputs.*` (resolved in the `prep`
       # job) — NOT the `inputs` context — so this reusable `with:` compiles on the

--- a/standards/workflows/idea-enhancer.yml
+++ b/standards/workflows/idea-enhancer.yml
@@ -45,5 +45,5 @@ permissions: {}
 
 jobs:
   idea-enhancer:
-    uses: petry-projects/.github/.github/workflows/idea-enhancer-reusable.yml@idea-enhancer/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/idea-enhancer-reusable.yml@idea-enhancer/v1-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets: inherit  # NOSONAR(githubactions:S7635) first-party trusted reusable

--- a/standards/workflows/idea-enhancer.yml
+++ b/standards/workflows/idea-enhancer.yml
@@ -7,7 +7,7 @@
 #   • This file is a THIN CALLER STUB. All enhancement-dispatch logic (including
 #     the Ideas-category / non-bot guard) lives in the reusable above.
 #   • You MUST NOT change: the `uses:` ref — it is pinned to the
-#     `idea-enhancer/stable` channel, a moving tag advanced centrally. Never
+#     `idea-enhancer/v1-stable` channel, a moving tag advanced centrally. Never
 #     repoint it to `@main`, a SHA, or a frozen `@vX`. Do not change the trigger
 #     events or the `secrets:` block.
 #   • You MAY change: the cron schedule if the weekly cadence doesn't suit.

--- a/standards/workflows/idea-triage.yml
+++ b/standards/workflows/idea-triage.yml
@@ -42,5 +42,5 @@ permissions: {}
 
 jobs:
   idea-triage:
-    uses: petry-projects/.github/.github/workflows/idea-triage-reusable.yml@idea-triage/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/idea-triage-reusable.yml@idea-triage/v1-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets: inherit  # NOSONAR(githubactions:S7635) first-party trusted reusable

--- a/standards/workflows/idea-triage.yml
+++ b/standards/workflows/idea-triage.yml
@@ -7,7 +7,7 @@
 #   • This file is a THIN CALLER STUB. All triage-dispatch logic lives in the
 #     reusable above.
 #   • You MUST NOT change: the `uses:` ref — it is pinned to the
-#     `idea-triage/stable` channel, a moving tag advanced centrally. Never
+#     `idea-triage/v1-stable` channel, a moving tag advanced centrally. Never
 #     repoint it to `@main`, a SHA, or a frozen `@vX`. Do not change the
 #     `secrets:` block.
 #   • You MAY change: the cron schedule if the weekly cadence doesn't suit.

--- a/standards/workflows/initiative-planner.yml
+++ b/standards/workflows/initiative-planner.yml
@@ -8,7 +8,7 @@
 #     `idea:approved` gate, the trusted-actor check, and the cross-repo dispatch
 #     to the central BMAD Scrum Master planner) lives in the reusable above.
 #   • You MUST NOT change: the `uses:` ref — it is pinned to the
-#     `initiative-planner/stable` channel, a moving tag advanced centrally.
+#     `initiative-planner/v1-stable` channel, a moving tag advanced centrally.
 #     Never repoint it to `@main`, a SHA, or a frozen `@vX` (see
 #     ci-standards.md → Reusable workflow versioning). Also do not change the
 #     trigger events or the `secrets:` block.

--- a/standards/workflows/initiative-planner.yml
+++ b/standards/workflows/initiative-planner.yml
@@ -44,5 +44,5 @@ permissions: {}
 
 jobs:
   initiative-planner:
-    uses: petry-projects/.github/.github/workflows/initiative-planner-reusable.yml@initiative-planner/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/initiative-planner-reusable.yml@initiative-planner/v1-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets: inherit  # NOSONAR(githubactions:S7635) first-party trusted reusable

--- a/standards/workflows/pr-auto-review.yml
+++ b/standards/workflows/pr-auto-review.yml
@@ -50,7 +50,7 @@ jobs:
       pull-requests: read
       checks: read
       actions: read
-    uses: petry-projects/.github/.github/workflows/pr-auto-review-reusable.yml@pr-auto-review/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/pr-auto-review-reusable.yml@pr-auto-review/v1-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets:
       # Canonical-first fallback (.github-private#1326). The reusable resolves this
       # secret BY NAME, so only the VALUE changes — the passed key stays named

--- a/standards/workflows/pr-auto-review.yml
+++ b/standards/workflows/pr-auto-review.yml
@@ -8,7 +8,7 @@
 #     reusable workflow above.
 #   • You MAY change: the workflow name(s) in `workflow_run.workflows` to match
 #     your repository's CI workflow name(s).
-#   • You MUST NOT change: the `@pr-auto-review/stable` channel in the `uses:`
+#   • You MUST NOT change: the `@pr-auto-review/v1-stable` channel in the `uses:`
 #     line — this reusable is on the org-wide moving-channel model (rollout and
 #     rollback are a single central tag move; a frozen `@vN`/`@<sha>` pin is
 #     rejected by the compliance audit). Nor the trigger event types or the

--- a/standards/workflows/pr-review-mention.yml
+++ b/standards/workflows/pr-review-mention.yml
@@ -7,7 +7,7 @@
 #   • This file is a THIN CALLER STUB. All review-dispatch logic lives in the
 #     reusable workflow above.
 #   • You MUST NOT change: the `uses:` ref — it is pinned to the
-#     `pr-review-mention/stable` channel, a moving tag advanced centrally.
+#     `pr-review-mention/v2-stable` channel, a moving tag advanced centrally.
 #     Never repoint it to `@main`, a SHA, or a frozen `@vX` (see
 #     ci-standards.md → Reusable workflow versioning). Also do not change the
 #     trigger events or the job-level `permissions:` block — reusable workflows

--- a/standards/workflows/pr-review-mention.yml
+++ b/standards/workflows/pr-review-mention.yml
@@ -41,7 +41,7 @@ jobs:
   pr-review-mention:
     permissions:
       pull-requests: write
-    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@pr-review-mention/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@pr-review-mention/v2-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets:
       GH_PAT_WORKFLOWS: ${{ secrets.GH_PAT_DON_PETRY || secrets.GH_PAT_WORKFLOWS }}
       DON_PETRY_BOT_GH_PAT: ${{ secrets.DON_PETRY_BOT_GH_PAT }}

--- a/test/scripts/standards-templates/vform-pins.bats
+++ b/test/scripts/standards-templates/vform-pins.bats
@@ -70,3 +70,20 @@ ref_of() {
     [ -z "$lines" ] || { echo "${name} unexpectedly has a channel-ref line"; return 1; }
   done
 }
+
+@test "every non-verbatim template HAS a marker-tagged channel-ref line" {
+  # Guards against a deployable template silently losing its channel pin (or the
+  # NOSONAR marker): without this, the first test's `[ -n "$lines" ] || continue`
+  # would skip an unmarked file and pass. Any non-verbatim template must carry a
+  # first-party channel-ref line so it stays under the v-form pin check.
+  local f name missing=()
+  for f in "${WF_DIR}"/*.yml; do
+    name="$(basename "$f")"
+    case " $VERBATIM " in *" $name "*) continue ;; esac
+    [ -n "$(channel_ref_lines "$f")" ] || missing+=("$name")
+  done
+  if [ "${#missing[@]}" -ne 0 ]; then
+    printf 'non-verbatim template missing a first-party channel-ref line -> %s\n' "${missing[@]}"
+    return 1
+  fi
+}

--- a/test/scripts/standards-templates/vform-pins.bats
+++ b/test/scripts/standards-templates/vform-pins.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+# Template-guard for the caller-stub templates under standards/workflows/ (#860).
+#
+# A "deployable" template is one that pins a first-party reusable through a
+# channel ref — the `uses:` line carrying the inline
+#   # NOSONAR(githubactions:S7637) first-party channel ref
+# marker. Every such pin must use the major-scoped `<agent>/v<M>-stable` channel
+# and never the bare `<agent>/stable` form (a bare pin cannot be migrated by the
+# major-scope tooling and silently rides whatever the tip of the channel is).
+#
+# The 4 verbatim templates (ci, copilot-setup-steps, initiative-driver,
+# sonarcloud) have no first-party reusable `uses:` line and are exempt.
+
+REPO_ROOT="$(cd -- "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+WF_DIR="${REPO_ROOT}/standards/workflows"
+
+# The templates that carry no first-party channel-ref `uses:` line.
+VERBATIM="ci.yml copilot-setup-steps.yml initiative-driver.yml sonarcloud.yml"
+
+# Emit each first-party channel-ref line in a file (marker-tagged uses lines).
+channel_ref_lines() {
+  grep -nE 'S7637\) first-party channel ref' "$1" || true
+}
+
+# Extract the `@<ref>` channel from a `uses: …-reusable.yml@<ref>  # …` line.
+ref_of() {
+  sed -E 's/.*-reusable\.yml@([^[:space:]]+).*/\1/' <<<"$1"
+}
+
+@test "every deployable template pins <agent>/v<M>-stable, never bare <agent>/stable" {
+  local violations=()
+  local f name lines line ref
+  for f in "${WF_DIR}"/*.yml; do
+    name="$(basename "$f")"
+    lines="$(channel_ref_lines "$f")"
+    [ -n "$lines" ] || continue
+    while IFS= read -r line; do
+      ref="$(ref_of "$line")"
+      # Must be the major-scoped v-form: <agent>/v<M>-stable.
+      if [[ ! "$ref" =~ ^[a-z0-9-]+/v[0-9]+-stable$ ]]; then
+        violations+=("${name}: '${ref}' is not <agent>/v<M>-stable")
+      fi
+    done <<<"$lines"
+  done
+  if [ "${#violations[@]}" -ne 0 ]; then
+    printf 'bad pin -> %s\n' "${violations[@]}"
+    return 1
+  fi
+}
+
+@test "agent_ref is byte-equal to the uses: channel where present" {
+  local f name uses_ref agent_ref
+  for f in "${WF_DIR}"/*.yml; do
+    name="$(basename "$f")"
+    grep -qE '^[[:space:]]*agent_ref:' "$f" || continue
+    uses_ref="$(ref_of "$(channel_ref_lines "$f")")"
+    agent_ref="$(grep -oE 'agent_ref:[[:space:]]*[^[:space:]]+' "$f" | sed -E 's/agent_ref:[[:space:]]*//')"
+    [ "$agent_ref" = "$uses_ref" ] || {
+      echo "${name}: agent_ref='${agent_ref}' != uses channel='${uses_ref}'"
+      return 1
+    }
+  done
+}
+
+@test "the 4 verbatim templates carry no first-party channel-ref line" {
+  local name lines
+  for name in $VERBATIM; do
+    [ -f "${WF_DIR}/${name}" ] || { echo "missing ${name}"; return 1; }
+    lines="$(channel_ref_lines "${WF_DIR}/${name}")"
+    [ -z "$lines" ] || { echo "${name} unexpectedly has a channel-ref line"; return 1; }
+  done
+}

--- a/test/workflows/pr-auto-review/stub-secrets.bats
+++ b/test/workflows/pr-auto-review/stub-secrets.bats
@@ -25,8 +25,8 @@ CHAIN='${{ secrets.GH_PAT_DON_PETRY || secrets.GH_PAT_WORKFLOWS }}'
   [ "$output" = 'GH_PAT_WORKFLOWS' ]
 }
 
-@test "stub: keeps the @pr-auto-review/stable channel pin in the uses: line" {
+@test "stub: keeps the @pr-auto-review/v1-stable channel pin in the uses: line" {
   run yq -r '.jobs.pr-auto-review.uses' "$STUB"
   [ "$status" -eq 0 ]
-  [[ "$output" == *'@pr-auto-review/stable'* ]]
+  [[ "$output" == *'@pr-auto-review/v1-stable'* ]]
 }


### PR DESCRIPTION
## **User description**
Closes #860

Implemented by dev-lead agent. Please review.


___

## **CodeAnt-AI Description**
**Re-pin workflow templates to major-scoped stable channels and add a guard against bare stable pins**

### What Changed
- Updated caller-stub workflows to use `v<M>-stable` channels instead of bare `stable`, including the main automation templates and `dev-lead`
- Kept matching `agent_ref` values aligned with the pinned channel where they are passed through
- Added a test suite that blocks deployable templates from using bare `stable` pins and checks the exempt verbatim templates stay unchanged
- Added workflow coverage so these template checks run on pull requests and pushes
- Updated the auto-review stub test to expect the new `v1-stable` pin

### Impact
`✅ Safer workflow updates`
`✅ Fewer broken template releases`
`✅ Consistent agent pins across automation` 
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks to validate standards workflow templates and reusable workflow version pins.

* **Improvements**
  * Updated workflow integrations to use major-version stable channels for improved consistency and control.
  * Updated related validation tests to reflect the new channel versions.

* **Tests**
  * Added coverage ensuring templates use approved versioned channels and matching configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->