### PR TITLE
feat: implement issue #864 — [#850] standards-deploy driver can't write to consumer repos — wrong token (ORG_SCORECARD_TOKEN) + opaque put-failed

### DIFF
--- a/.github/workflows/standards-deploy.yml
+++ b/.github/workflows/standards-deploy.yml
@@ -47,7 +47,19 @@ jobs:
     permissions:
       contents: read   # only to check out this repo; all cross-repo writes use the PAT below
     env:
-      GH_TOKEN: ${{ secrets.ORG_SCORECARD_TOKEN }}
+      # Cross-repo write identity for the sweep. NOT ORG_SCORECARD_TOKEN — that is
+      # the audit identity (a fine-grained PAT with Contents: Read-only), so it
+      # cannot PUT stub content into consumer repos and every deploy 422'd
+      # (petry-projects/.github#864). GH_PAT_DON_PETRY (falling back to the legacy
+      # GH_PAT_WORKFLOWS) is the SAME identity dev-lead.yml / pr-auto-review.yml /
+      # initiative-driver.yml already use to author cross-repo PRs. Its login is
+      # `don-petry` (or the GH_PAT_WORKFLOWS owner) — deliberately NOT donpetry-bot
+      # — so the standards-sync PRs it opens can be approved by donpetry-bot via the
+      # pr-review agent and land through native auto-merge with no `--admin`.
+      # Least-privilege: needs only contents:write + pull_requests:write on the
+      # target repos (a GitHub App with those two scopes, non-author-blocked and not
+      # donpetry-bot, is an acceptable substitute).
+      GH_TOKEN: ${{ secrets.GH_PAT_DON_PETRY || secrets.GH_PAT_WORKFLOWS }}
       TARGET_REPO: ${{ inputs.target_repo }}
       TARGET_WORKFLOW: ${{ inputs.target_workflow }}
       DRY_RUN: ${{ inputs.dry_run == true && 'true' || 'false' }}

--- a/scripts/lib/standards-deploy.sh
+++ b/scripts/lib/standards-deploy.sh
@@ -7,9 +7,10 @@
 # default branch directly and NEVER merges or uses --admin. Instead it:
 #
 #   1. checks for an already-open PR on the sync branch (idempotent skip),
-#   2. creates (or reuses) a sync branch off the repo's default branch,
-#   3. PUTs the verbatim file content onto that branch via the Contents API,
-#   4. opens a labeled pull request.
+#   2. preflights that the token can write the repo (clear finding on a scope gap),
+#   3. creates (or reuses) a sync branch off the repo's default branch,
+#   4. PUTs the verbatim file content onto that branch via the Contents API,
+#   5. opens a labeled pull request.
 #
 # Why a PR and not a direct push: a direct Contents-API push to the default
 # branch is rejected (HTTP 409) on repos whose ruleset enforces required status
@@ -81,7 +82,19 @@ sd_deploy_files_via_pr() {
     return 0
   fi
 
-  # 2. Resolve the default branch and its tip SHA (branch point).
+  # 2. Preflight write check. The driver must run under a contents/PR-write
+  #    identity; an audit/read-only token silently produces per-file 422s deep in
+  #    step 4 (petry-projects/.github#864). Probe the repo permission set once, up
+  #    front, so a token-scope gap surfaces as one clear finding, not opaque
+  #    per-file put-failures.
+  local can_push
+  can_push=$(gh api "repos/${repo}" --jq '.permissions.push // false' 2>/dev/null || echo "false")
+  if [ "$can_push" != "true" ]; then
+    echo "FAILED no-write-access"
+    return 1
+  fi
+
+  # 3. Resolve the default branch and its tip SHA (branch point).
   local default_branch base_sha
   default_branch=$(gh api "repos/${repo}" --jq '.default_branch' 2>/dev/null || echo "main")
   base_sha=$(gh api "repos/${repo}/git/ref/heads/${default_branch}" \
@@ -91,7 +104,7 @@ sd_deploy_files_via_pr() {
     return 1
   fi
 
-  # 3. Create the sync branch; reuse it if a prior run already created it.
+  # 4. Create the sync branch; reuse it if a prior run already created it.
   if ! gh api "repos/${repo}/git/refs" --method POST \
         --raw-field "ref=refs/heads/${branch}" \
         --raw-field "sha=${base_sha}" --silent 2>/dev/null; then
@@ -101,14 +114,39 @@ sd_deploy_files_via_pr() {
     fi
   fi
 
-  # 4. PUT each file verbatim onto the branch. The blob SHA is looked up per file
+  # 5. PUT each file verbatim onto the branch. The blob SHA is looked up per file
   #    on the branch so both create (absent → empty SHA) and update (drifted stub)
-  #    work, whether the branch is fresh or reused.
-  local path local_file branch_sha encoded j
+  #    work, whether the branch is fresh or reused. Errors are NOT swallowed: a
+  #    read failure that yields an empty SHA would make the subsequent PUT omit
+  #    `sha` and 422 against an existing file — the exact opaque failure in #864.
+  local path local_file branch_sha encoded j err_file get_rc get_msg put_msg
   for (( i = 1; i < $#; i += 2 )); do
     j=$(( i + 1 )); path="${!i}"; local_file="${!j}"
+
+    # Resolve the file's blob SHA on the branch, capturing stderr and exit code.
+    err_file=$(mktemp)
     branch_sha=$(gh api "repos/${repo}/contents/${path}?ref=${branch}" \
-      --jq '.sha // ""' 2>/dev/null || true)
+      --jq '.sha // ""' 2>"$err_file") && get_rc=0 || get_rc=$?
+    if [ "$get_rc" -eq 0 ]; then
+      # GET succeeded → the file EXISTS on the branch, so its SHA must resolve.
+      # A blank SHA here means we cannot update it safely; a sha-less PUT would
+      # 422. Fail loudly rather than mask it.
+      if [ -z "$branch_sha" ]; then
+        rm -f "$err_file"
+        echo "FAILED sha-unresolved:${path}"
+        return 1
+      fi
+    else
+      get_msg=$(tr '\n' ' ' < "$err_file"); rm -f "$err_file"
+      if printf '%s' "$get_msg" | grep -q 'HTTP 404'; then
+        branch_sha=""   # file absent on the branch → create path, no SHA
+      else
+        echo "FAILED contents-get-failed:${get_msg}"
+        return 1
+      fi
+    fi
+    rm -f "$err_file"
+
     encoded=$(base64 -w 0 "$local_file" 2>/dev/null || base64 -b 0 "$local_file")
 
     local put_args=(--method PUT
@@ -117,13 +155,16 @@ sd_deploy_files_via_pr() {
       --raw-field "branch=${branch}")
     [ -n "$branch_sha" ] && put_args+=(--raw-field "sha=${branch_sha}")
 
-    if ! gh api "repos/${repo}/contents/${path}" "${put_args[@]}" --silent 2>/dev/null; then
-      echo "FAILED put-failed"
+    err_file=$(mktemp)
+    if ! gh api "repos/${repo}/contents/${path}" "${put_args[@]}" --silent 2>"$err_file"; then
+      put_msg=$(tr '\n' ' ' < "$err_file"); rm -f "$err_file"
+      echo "FAILED put-failed:${put_msg}"
       return 1
     fi
+    rm -f "$err_file"
   done
 
-  # 5. Ensure the label exists, then open the PR. `gh pr create --label` fails
+  # 6. Ensure the label exists, then open the PR. `gh pr create --label` fails
   #    outright if the label is absent, and consumer repos do not carry the
   #    standards-sync label by default. Create-if-missing (no --force, so an
   #    existing curated label is never clobbered); ignore the "already exists"

--- a/scripts/lib/standards-deploy.sh
+++ b/scripts/lib/standards-deploy.sh
@@ -84,11 +84,20 @@ sd_deploy_files_via_pr() {
 
   # 2. Preflight write check. The driver must run under a contents/PR-write
   #    identity; an audit/read-only token silently produces per-file 422s deep in
-  #    step 4 (petry-projects/.github#864). Probe the repo permission set once, up
+  #    step 5 (petry-projects/.github#864). Probe the repo permission set once, up
   #    front, so a token-scope gap surfaces as one clear finding, not opaque
-  #    per-file put-failures.
-  local can_push
-  can_push=$(gh api "repos/${repo}" --jq '.permissions.push // false' 2>/dev/null || echo "false")
+  #    per-file put-failures. The probe's OWN errors (a transient/auth/404) are
+  #    surfaced distinctly — they must NOT be misreported as "no write access".
+  #    Repo-level push permission implies PR-create for a collaborator identity.
+  local can_push perm_err perm_rc
+  perm_err=$(mktemp)
+  can_push=$(gh api "repos/${repo}" --jq '.permissions.push // false' 2>"$perm_err") && perm_rc=0 || perm_rc=$?
+  if [ "$perm_rc" -ne 0 ]; then
+    local perm_msg; perm_msg=$(tr '\n' ' ' < "$perm_err"); rm -f "$perm_err"
+    echo "FAILED perm-probe-failed:${perm_msg}"
+    return 1
+  fi
+  rm -f "$perm_err"
   if [ "$can_push" != "true" ]; then
     echo "FAILED no-write-access"
     return 1

--- a/scripts/standards-deploy-driver.sh
+++ b/scripts/standards-deploy-driver.sh
@@ -22,7 +22,10 @@
 # Overridable for tests:
 #   DEPLOY_SCRIPT    Path to the deploy script (default: sibling in this dir).
 #
-# Requires GH_TOKEN with repo scope for cross-repo branch + PR creation.
+# Requires GH_TOKEN to be a cross-repo WRITE identity — contents:write +
+# pull_requests:write on the target repos (e.g. GH_PAT_DON_PETRY / the legacy
+# GH_PAT_WORKFLOWS). The audit token (ORG_SCORECARD_TOKEN) is read-only for
+# Contents and cannot deploy stubs — see petry-projects/.github#864.
 
 set -euo pipefail
 

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -357,6 +357,28 @@ open for that workflow. Deployment never edits a caller's `uses:`/`agent_ref`
 pins by hand — a release is rolled out by moving the channel tag (see
 [Reusable workflow versioning](#reusable-workflow-versioning--the-stable-channel)).
 
+**Deploy identity (least-privilege).** The scheduled driver
+([`standards-deploy.yml`](workflows/standards-deploy.yml)) writes stub content and
+opens PRs **across the fleet**, so it must run under a cross-repo write identity —
+`contents:write` + `pull_requests:write` on the target repos, and nothing more. It
+uses `GH_PAT_DON_PETRY` (falling back to the legacy `GH_PAT_WORKFLOWS`), the same
+identity `dev-lead.yml` / `pr-auto-review.yml` / `initiative-driver.yml` already
+author cross-repo PRs with. It **must not** use `ORG_SCORECARD_TOKEN`: that is the
+**audit** identity (a fine-grained PAT with **Contents: Read-only**), so its
+content PUTs 422 and every deploy fails with an opaque `put-failed`
+([#864](https://github.com/petry-projects/.github/issues/864)). The deploy identity
+is also deliberately **not `donpetry-bot`** (it acts as `don-petry`): the PRs it
+opens are authored by a distinct code-owner, so `donpetry-bot` can approve them via
+the pr-review agent and they land through native auto-merge with **no `--admin`**. A
+GitHub App carrying only those two scopes — non-author-blocked and not
+`donpetry-bot` — is an acceptable substitute.
+
+The deploy primitive also **preflights write access per repo** before touching any
+branch and **never issues a sha-less content PUT against an existing file**: a
+token-scope gap surfaces as a single `no-write-access` finding, and a genuine HTTP
+error is reported with its status (e.g. `put-failed:… (HTTP 422)`) instead of being
+swallowed.
+
 #### Self-managing meta-repos: `SKIP_REPOS` + `SKIP_OVERRIDES`
 
 `deploy-standard-workflows.sh` exempts a small set of **self-managing meta-repos**

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -358,7 +358,7 @@ pins by hand — a release is rolled out by moving the channel tag (see
 [Reusable workflow versioning](#reusable-workflow-versioning--the-stable-channel)).
 
 **Deploy identity (least-privilege).** The scheduled driver
-([`standards-deploy.yml`](workflows/standards-deploy.yml)) writes stub content and
+([`standards-deploy.yml`](../.github/workflows/standards-deploy.yml)) writes stub content and
 opens PRs **across the fleet**, so it must run under a cross-repo write identity —
 `contents:write` + `pull_requests:write` on the target repos, and nothing more. It
 uses `GH_PAT_DON_PETRY` (falling back to the legacy `GH_PAT_WORKFLOWS`), the same

--- a/test/scripts/lib/standards-deploy.bats
+++ b/test/scripts/lib/standards-deploy.bats
@@ -39,9 +39,36 @@ case "$sub" in
         else
           exit "${GH_REF_EXISTS_RC:-0}"
         fi ;;
-      *contents*"?"ref=*)  printf '%s' "${GH_FILE_SHA:-}" ;;
-      *contents*)          exit "${GH_PUT_RC:-0}" ;;
-      repos/*)             printf '%s' "${GH_DEFAULT_BRANCH:-main}" ;;
+      *contents*"?"ref=*)
+        # contents GET used to resolve a file's blob sha on the branch.
+        #   GH_GET_RC!=0            -> the GET errors (prints GH_GET_ERR to stderr)
+        #   GH_FILE_SHA unset       -> file absent on the branch (404 create path)
+        #   GH_FILE_SHA set (maybe
+        #     empty)                -> file present; echo the (maybe empty) sha
+        if [ "${GH_GET_RC:-0}" -ne 0 ]; then
+          printf '%s\n' "${GH_GET_ERR:-gh: Something went wrong (HTTP 500)}" >&2
+          exit "${GH_GET_RC}"
+        fi
+        if [ -z "${GH_FILE_SHA+x}" ]; then
+          printf '%s\n' 'gh: Not Found (HTTP 404)' >&2
+          exit 1
+        fi
+        printf '%s' "${GH_FILE_SHA}" ;;
+      *contents*)
+        # contents PUT. On failure surface an HTTP-status-bearing stderr message.
+        if [ "${GH_PUT_RC:-0}" -ne 0 ]; then
+          printf '%s\n' "${GH_PUT_ERR:-gh: sha was not supplied (HTTP 422)}" >&2
+          exit "${GH_PUT_RC}"
+        fi
+        exit 0 ;;
+      repos/*)
+        # repos/<repo>: the default-branch lookup AND the preflight write probe
+        # (--jq .permissions.push) both land here — differentiate on the jq arg.
+        if printf '%s' "$args" | grep -q 'permissions.push'; then
+          printf '%s' "${GH_CAN_PUSH:-true}"
+        else
+          printf '%s' "${GH_DEFAULT_BRANCH:-main}"
+        fi ;;
     esac
     ;;
 esac
@@ -190,11 +217,13 @@ deploy() {
   [ "$output" = "FAILED no-branch" ]
 }
 
-@test "fails when the PUT is rejected" {
+@test "fails when the PUT is rejected and surfaces the real HTTP status" {
   GH_PUT_RC="1"; export GH_PUT_RC
+  GH_PUT_ERR='gh: "sha" wasn'\''t supplied. (HTTP 422)'; export GH_PUT_ERR
   run deploy
   [ "$status" -ne 0 ]
-  [ "$output" = "FAILED put-failed" ]
+  [[ "$output" == FAILED\ put-failed:* ]]
+  [[ "$output" == *"HTTP 422"* ]]
 }
 
 @test "fails when the PR cannot be created" {
@@ -209,4 +238,57 @@ deploy() {
     "${TT_TMP}/does-not-exist.yml" "standards-sync/x" "standards-sync" "t" "b"
   [ "$status" -ne 0 ]
   [ "$output" = "FAILED missing-local-file" ]
+}
+
+# ---------------------------------------------------------------------------
+# Fix 2 (petry-projects/.github#864): preflight write check + real error
+# surfacing + never a sha-less PUT on an existing file.
+# ---------------------------------------------------------------------------
+
+# Preflight: a token without contents/PR write is reported as a clear finding,
+# not an opaque per-file put-failed. No branch or PUT is attempted.
+@test "fails loudly when the token lacks write access (preflight probe)" {
+  GH_CAN_PUSH="false"; export GH_CAN_PUSH
+  run deploy
+  [ "$status" -ne 0 ]
+  [ "$output" = "FAILED no-write-access" ]
+  ! grep -q 'git/refs --method POST' "$GH_CALLS"
+  ! grep -q 'contents/.* --method PUT' "$GH_CALLS"
+}
+
+# Regression guard for the reported bug: when the stub file already exists on the
+# branch, the update PUT must ALWAYS carry its blob sha — a sha-less PUT against
+# an existing file is a guaranteed 422.
+@test "existing-file update always supplies a sha in the PUT" {
+  GH_FILE_SHA="deadbeefsha"; export GH_FILE_SHA
+  run deploy
+  [ "$status" -eq 0 ]
+  local put_lines
+  put_lines=$(grep 'contents/.* --method PUT' "$GH_CALLS")
+  [ -n "$put_lines" ]
+  while IFS= read -r line; do
+    printf '%s' "$line" | grep -q -- '--raw-field sha=deadbeefsha'
+  done <<< "$put_lines"
+}
+
+# The contents GET must not swallow errors: a non-404 failure (e.g. a token-scope
+# 403) is surfaced with its HTTP status, and no PUT is attempted.
+@test "fails loudly when the contents GET errors with a non-404 status" {
+  GH_GET_RC="1"; export GH_GET_RC
+  GH_GET_ERR='gh: Resource not accessible by integration (HTTP 403)'; export GH_GET_ERR
+  run deploy
+  [ "$status" -ne 0 ]
+  [[ "$output" == FAILED\ contents-get-failed:* ]]
+  [[ "$output" == *"HTTP 403"* ]]
+  ! grep -q 'contents/.* --method PUT' "$GH_CALLS"
+}
+
+# The file exists on the branch (GET 200) but its sha cannot be resolved: fail
+# loudly rather than issue a sha-less PUT that is guaranteed to 422.
+@test "fails loudly when an existing file's sha cannot be resolved" {
+  GH_FILE_SHA=""; export GH_FILE_SHA   # present (GET 200) but empty sha
+  run deploy
+  [ "$status" -ne 0 ]
+  [[ "$output" == FAILED\ sha-unresolved:* ]]
+  ! grep -q 'contents/.* --method PUT' "$GH_CALLS"
 }

--- a/test/scripts/lib/standards-deploy.bats
+++ b/test/scripts/lib/standards-deploy.bats
@@ -65,6 +65,10 @@ case "$sub" in
         # repos/<repo>: the default-branch lookup AND the preflight write probe
         # (--jq .permissions.push) both land here — differentiate on the jq arg.
         if printf '%s' "$args" | grep -q 'permissions.push'; then
+          if [ -n "${GH_PERM_RC:-}" ] && [ "${GH_PERM_RC}" != "0" ]; then
+            printf '%s\n' "${GH_PERM_ERR:-gh: Not Found (HTTP 404)}" >&2
+            exit "${GH_PERM_RC}"
+          fi
           printf '%s' "${GH_CAN_PUSH:-true}"
         else
           printf '%s' "${GH_DEFAULT_BRANCH:-main}"
@@ -256,6 +260,21 @@ deploy() {
   ! grep -q 'contents/.* --method PUT' "$GH_CALLS"
 }
 
+# Preflight: an ERROR on the probe itself (transient / auth / 404) is surfaced
+# distinctly with its HTTP status — NOT misreported as "no-write-access". No
+# branch or PUT is attempted.
+@test "preflight probe error is surfaced distinctly, not as no-write-access" {
+  GH_PERM_RC="1"; export GH_PERM_RC
+  GH_PERM_ERR='gh: Resource not accessible by integration (HTTP 403)'; export GH_PERM_ERR
+  run deploy
+  [ "$status" -ne 0 ]
+  [[ "$output" == FAILED\ perm-probe-failed:* ]]
+  [[ "$output" == *"HTTP 403"* ]]
+  [[ "$output" != *"no-write-access"* ]]
+  ! grep -q 'git/refs --method POST' "$GH_CALLS"
+  ! grep -q 'contents/.* --method PUT' "$GH_CALLS"
+}
+
 # Regression guard for the reported bug: when the stub file already exists on the
 # branch, the update PUT must ALWAYS carry its blob sha — a sha-less PUT against
 # an existing file is a guaranteed 422.
@@ -267,7 +286,8 @@ deploy() {
   put_lines=$(grep 'contents/.* --method PUT' "$GH_CALLS")
   [ -n "$put_lines" ]
   while IFS= read -r line; do
-    printf '%s' "$line" | grep -q -- '--raw-field sha=deadbeefsha'
+    printf '%s' "$line" | grep -q -- '--raw-field sha=deadbeefsha' \
+      || { echo "PUT without sha: $line"; return 1; }
   done <<< "$put_lines"
 }
 


### PR DESCRIPTION
## **User description**
Closes #864

Implemented by dev-lead agent. Please review.


___

## **CodeAnt-AI Description**
**Use a cross-repo write token for standards deploys and show clear errors when writes fail**

### What Changed
- The scheduled standards sweep now uses a token that can write to consumer repos and open pull requests, instead of the read-only audit token that caused every deploy to fail.
- The deploy flow now checks write access before starting, so repos with the wrong token fail immediately with a clear `no-write-access` result.
- When updating an existing file, the deploy flow now keeps the file’s current revision and reports the real HTTP error if a read or write fails, instead of hiding it behind a generic `put-failed`.
- The workflow and docs now point to the correct deploy identity and explain that the audit token cannot be used for fleet deploys.

### Impact
`✅ Fewer failed standards-sync deploys`
`✅ Clearer token-scope errors`
`✅ Fewer opaque 422 write failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
