### PR TITLE
feat: implement issue #875 — [#850] templates drop the S7635 NOSONAR marker on secrets: inherit (dev-lead/add-to-project/auto-rebase/dependabot-automerge) — restore + guard

### DIFF
--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -732,12 +732,18 @@ first time it is **added** to a SonarCloud-gated repo. (The legacy per-file
 also works and is accepted during transition, but the inline marker is canonical.)
 
 Caller-stub templates that use `secrets: inherit` and therefore carry the S7635
-marker: `initiative-planner.yml`, `idea-triage.yml`, `idea-enhancer.yml`.
-**Pending:** `dev-lead.yml`, `auto-rebase.yml`, `dependabot-automerge.yml`, and
-`pr-review-mention.yml` also use `secrets: inherit` but do not yet carry the
-marker; because they are already deployed fleet-wide (so re-syncing them fans out
-broadly) the marker is being added to them under a separate rollout — until then a
-**new** adoption of one of those four needs the legacy per-file S7635 exemption.
+marker: `initiative-planner.yml`, `idea-triage.yml`, `idea-enhancer.yml`,
+`persona-mention.yml`, `dev-lead.yml`, `auto-rebase.yml`,
+`dependabot-automerge.yml`. Every template with a `secrets: inherit` line now
+carries the marker; the
+[`s7635-secrets-inherit.bats`](https://github.com/petry-projects/.github/blob/main/test/scripts/standards-templates/s7635-secrets-inherit.bats)
+template guard fails CI if any such line drops it (mirrors the S7637 v-form pin
+guard).
+
+Stubs that pass secrets **explicitly** (least privilege — no `secrets: inherit`
+line, e.g. `add-to-project.yml`, `pr-review-mention.yml`) never trip S7635 and
+carry **no** marker. Do not add one: the marker suppresses S7635 on a
+`secrets: inherit` line, and there is none to suppress.
 
 ### 4. Secret Scanning (`ci.yml` — gitleaks job)
 

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -742,8 +742,7 @@ guard).
 
 Stubs that pass secrets **explicitly** (least privilege — no `secrets: inherit`
 line, e.g. `add-to-project.yml`, `pr-review-mention.yml`) never trip S7635 and
-carry **no** marker. Do not add one: the marker suppresses S7635 on a
-`secrets: inherit` line, and there is none to suppress.
+carry **no** marker. Do not add one, as the marker is only necessary for `secrets: inherit` lines, which these stubs lack.
 
 ### 4. Secret Scanning (`ci.yml` — gitleaks job)
 

--- a/standards/workflows/auto-rebase.yml
+++ b/standards/workflows/auto-rebase.yml
@@ -51,4 +51,4 @@ jobs:
       contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write # post comments on PRs
     uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@auto-rebase/v2-stable  # NOSONAR(githubactions:S7637) first-party channel ref
-    secrets: inherit
+    secrets: inherit  # NOSONAR(githubactions:S7635) first-party trusted reusable

--- a/standards/workflows/dependabot-automerge.yml
+++ b/standards/workflows/dependabot-automerge.yml
@@ -36,4 +36,4 @@ jobs:
       contents: read
       pull-requests: read
     uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@dependabot-automerge/v2-stable  # NOSONAR(githubactions:S7637) first-party channel ref
-    secrets: inherit
+    secrets: inherit  # NOSONAR(githubactions:S7635) first-party trusted reusable

--- a/standards/workflows/dev-lead.yml
+++ b/standards/workflows/dev-lead.yml
@@ -64,7 +64,7 @@ jobs:
     uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/v1-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
       agent_ref: dev-lead/v1-stable
-    secrets: inherit
+    secrets: inherit  # NOSONAR(githubactions:S7635) first-party trusted reusable
     permissions:
       contents: write
       pull-requests: write

--- a/test/scripts/standards-templates/s7635-secrets-inherit.bats
+++ b/test/scripts/standards-templates/s7635-secrets-inherit.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+# Template-guard for the S7635 NOSONAR marker on caller-stub templates under
+# standards/workflows/ (#875, mirrors the #860 v-form/S7637 pin guard).
+#
+# A caller stub that hands the reusable every org secret via `secrets: inherit`
+# trips SonarCloud rule `githubactions:S7635` ("only pass required secrets").
+# The reusable is first-party and fully trusted, so the stub carries an inline
+#   secrets: inherit  # NOSONAR(githubactions:S7635) <prose>
+# marker that suppresses S7635 on exactly that line and travels with the stub to
+# every consumer repo. Dropping the marker regresses any consumer that copied
+# the stub (re-triggers S7635 in their SonarCloud run). This guard fails in CI
+# the moment a template with `secrets: inherit` loses the marker.
+#
+# Stubs that pass secrets EXPLICITLY (least privilege, no `secrets: inherit`
+# line — e.g. add-to-project.yml, pr-review-mention.yml) do not trip S7635 and
+# are correctly ignored: the guard only inspects real `secrets: inherit` lines.
+
+REPO_ROOT="$(cd -- "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+WF_DIR="${REPO_ROOT}/standards/workflows"
+
+# The exact NOSONAR token every marked line must carry (grep -F, literal).
+MARKER='NOSONAR(githubactions:S7635)'
+
+# Emit `secrets: inherit` lines that are REAL YAML (indented key), never a `#`
+# comment mention. Anchors `secrets:` to the start-of-line-after-indent so a
+# prose line like `# ... secrets: inherit ...` is not matched.
+secrets_inherit_lines() {
+  grep -nE '^[[:space:]]*secrets:[[:space:]]+inherit([[:space:]]|$)' "$1" || true
+}
+
+@test "every template with 'secrets: inherit' carries the S7635 marker" {
+  local violations=()
+  local f name lines line
+  for f in "${WF_DIR}"/*.yml; do
+    name="$(basename "$f")"
+    lines="$(secrets_inherit_lines "$f")"
+    [ -n "$lines" ] || continue
+    while IFS= read -r line; do
+      if ! grep -qF "$MARKER" <<<"$line"; then
+        violations+=("${name}: 'secrets: inherit' line lacks ${MARKER}")
+      fi
+    done <<<"$lines"
+  done
+  if [ "${#violations[@]}" -ne 0 ]; then
+    printf 'missing S7635 marker -> %s\n' "${violations[@]}"
+    return 1
+  fi
+}
+
+@test "every S7635 marker uses the canonical inline shape" {
+  # Two spaces before the '#', then the exact token. Trailing prose is free-form
+  # (e.g. 'first-party trusted reusable' vs 'org secrets are scoped ...'), but
+  # the marker itself must be byte-consistent so SonarCloud honours it.
+  local violations=()
+  local f name lines line
+  for f in "${WF_DIR}"/*.yml; do
+    name="$(basename "$f")"
+    lines="$(secrets_inherit_lines "$f")"
+    [ -n "$lines" ] || continue
+    while IFS= read -r line; do
+      grep -qF "$MARKER" <<<"$line" || continue
+      if ! grep -qE 'secrets: inherit  # NOSONAR\(githubactions:S7635\) ' <<<"$line"; then
+        violations+=("${name}: marker is not the canonical 'secrets: inherit  # NOSONAR(githubactions:S7635) <prose>' shape")
+      fi
+    done <<<"$lines"
+  done
+  if [ "${#violations[@]}" -ne 0 ]; then
+    printf 'bad marker shape -> %s\n' "${violations[@]}"
+    return 1
+  fi
+}
+
+@test "the guard actually inspects at least one 'secrets: inherit' stub" {
+  # Positive control: without this, a broken matcher that finds nothing would let
+  # the first test pass vacuously (its `[ -n "$lines" ] || continue` skips every
+  # file). At least one template uses `secrets: inherit` by design.
+  local f found=0
+  for f in "${WF_DIR}"/*.yml; do
+    [ -n "$(secrets_inherit_lines "$f")" ] && found=1 && break
+  done
+  [ "$found" -eq 1 ] || { echo "no template with a real 'secrets: inherit' line found"; return 1; }
+}

--- a/test/scripts/standards-templates/s7635-secrets-inherit.bats
+++ b/test/scripts/standards-templates/s7635-secrets-inherit.bats
@@ -30,14 +30,16 @@ secrets_inherit_lines() {
 
 @test "every template with 'secrets: inherit' carries the S7635 marker" {
   local violations=()
-  local f name lines line
+  local f name lines line lineno content
   for f in "${WF_DIR}"/*.yml; do
     name="$(basename "$f")"
     lines="$(secrets_inherit_lines "$f")"
     [ -n "$lines" ] || continue
     while IFS= read -r line; do
-      if ! grep -qF "$MARKER" <<<"$line"; then
-        violations+=("${name}: 'secrets: inherit' line lacks ${MARKER}")
+      lineno="${line%%:*}"
+      content="${line#*:}"
+      if ! grep -qF "$MARKER" <<<"$content"; then
+        violations+=("${name}:${lineno}: 'secrets: inherit' line lacks ${MARKER}")
       fi
     done <<<"$lines"
   done
@@ -52,15 +54,17 @@ secrets_inherit_lines() {
   # (e.g. 'first-party trusted reusable' vs 'org secrets are scoped ...'), but
   # the marker itself must be byte-consistent so SonarCloud honours it.
   local violations=()
-  local f name lines line
+  local f name lines line lineno content
   for f in "${WF_DIR}"/*.yml; do
     name="$(basename "$f")"
     lines="$(secrets_inherit_lines "$f")"
     [ -n "$lines" ] || continue
     while IFS= read -r line; do
-      grep -qF "$MARKER" <<<"$line" || continue
-      if ! grep -qE 'secrets: inherit  # NOSONAR\(githubactions:S7635\) ' <<<"$line"; then
-        violations+=("${name}: marker is not the canonical 'secrets: inherit  # NOSONAR(githubactions:S7635) <prose>' shape")
+      lineno="${line%%:*}"
+      content="${line#*:}"
+      grep -qF "$MARKER" <<<"$content" || continue
+      if ! grep -qE 'secrets: inherit  # NOSONAR\(githubactions:S7635\) ' <<<"$content"; then
+        violations+=("${name}:${lineno}: marker is not the canonical 'secrets: inherit  # NOSONAR(githubactions:S7635) <prose>' shape")
       fi
     done <<<"$lines"
   done


### PR DESCRIPTION
## **User description**
Closes #875

Implemented by dev-lead agent. Please review.


___

## **CodeAnt-AI Description**
**Keep SonarCloud from flagging trusted workflow stubs that inherit secrets**

### What Changed
- Added the missing S7635 marker to workflow templates that use `secrets: inherit`, so they no longer trigger SonarCloud warnings on the inherited-secrets line.
- Added a CI guard that fails if any template with `secrets: inherit` loses the required marker, preventing the issue from coming back.
- Updated the workflow standards guide to reflect which templates carry the marker and to clarify that templates passing secrets explicitly should not use one.

### Impact
`✅ Fewer false SonarCloud alerts on trusted workflows`
`✅ Earlier detection when a secrets-inheriting template drops its marker`
`✅ Clearer guidance for workflow template authors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified security-comment requirements for reusable workflow templates.
  * Documented which templates inherit secrets and which pass them explicitly.

* **Tests**
  * Added automated checks to ensure all `secrets: inherit` entries include the required inline security marker.
  * Added validation for the marker’s format and confirmed the checks cover applicable templates.

* **Chores**
  * Updated several workflow templates with the required inline security annotations without changing their behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->