### PR TITLE
fix: restore S7635 NOSONAR markers on secrets: inherit stubs

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -41,4 +41,4 @@ jobs:
       contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write # post comments on PRs
     uses: ./.github/workflows/auto-rebase-reusable.yml  # local ref — always current
-    secrets: inherit
+    secrets: inherit  # NOSONAR(githubactions:S7635) first-party trusted reusable

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -36,4 +36,4 @@ jobs:
       contents: read
       pull-requests: read
     uses: ./.github/workflows/dependabot-automerge-reusable.yml  # local ref — always current (ring0 dogfood, #541)
-    secrets: inherit
+    secrets: inherit  # NOSONAR(githubactions:S7635) first-party trusted reusable


### PR DESCRIPTION
## **User description**
Meta-repo quality fix (#879). Adds the inline `# NOSONAR(githubactions:S7635)` marker to the `secrets: inherit` line of auto-rebase dependabot-automerge — these had correct pins/self-host refs but were missing the marker (regressed during #857), so SonarCloud S7635 would re-flag them. Pins unchanged.


___

## **CodeAnt-AI Description**
**Restore Sonar ignore markers on trusted workflow secret inheritance**

### What Changed
- Added the missing Sonar ignore note back to the `secrets: inherit` lines in the auto-rebase and dependabot-automerge workflows
- Prevents these trusted workflow calls from being flagged again by code quality checks
- No change to workflow behavior or secret usage

### Impact
`✅ Fewer false Sonar warnings`
`✅ Cleaner workflow quality checks`
`✅ No change to automerge or rebase behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
