### PR TITLE
feat: implement issue #884 — [#850] Finish #857 tail: 6 convergence PRs blocked on CI-infra noise (cancelled dev-lead checks + repo-specific fails)

### DIFF
--- a/test/workflows/pr-auto-review/ready.bats
+++ b/test/workflows/pr-auto-review/ready.bats
@@ -116,6 +116,7 @@ REQUIRED='["Lint"]'
   [ "$output" = "dispatched" ]
 }
 
+# REQ: required-only gate ignores cancelled dev-lead orchestration checks and non-required failing checks, dispatching when all REQUIRED contexts are green
 # #884 fleet-convergence repro (the exact "main blocker" fact pattern): a
 # standards-sync PR whose REQUIRED contexts are all green, carrying BOTH
 # concurrency-churn cancelled dev-lead orchestration checks

--- a/test/workflows/pr-auto-review/ready.bats
+++ b/test/workflows/pr-auto-review/ready.bats
@@ -116,6 +116,22 @@ REQUIRED='["Lint"]'
   [ "$output" = "dispatched" ]
 }
 
+# #884 fleet-convergence repro (the exact "main blocker" fact pattern): a
+# standards-sync PR whose REQUIRED contexts are all green, carrying BOTH
+# concurrency-churn cancelled dev-lead orchestration checks
+# (`dev-lead / dispatch` + `dev-lead / ci-relay`) AND a non-required failing
+# advisory (mirroring ContentTwin `Test` / google-app-scripts `autofix`). The
+# required-only gate must ignore all three non-required contexts and dispatch —
+# so the pr-auto-review path never reads CANCELLED (or a non-required FAILURE) as
+# a merge-readiness blocker.
+@test "ready: #884 convergence — required green + cancelled dev-lead pair + non-required failure → dispatched" {
+  run pr_auto_review_ready "OPEN" "false" \
+    '[{"name":"CI / Lint","bucket":"pass"},{"name":"dev-lead / dispatch","bucket":"cancel"},{"name":"dev-lead / ci-relay","bucket":"cancel"},{"name":"Test","bucket":"fail"}]' \
+    "$REQUIRED" "" "" "0"
+  [ "$status" -eq 0 ]
+  [ "$output" = "dispatched" ]
+}
+
 # ── criterion #3: review decision ────────────────────────────────────────────
 
 @test "not ready: CHANGES_REQUESTED → skip-changes-requested" {


### PR DESCRIPTION
## **User description**
Closes #884

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for pull request readiness when all required checks pass, even if orchestration checks are cancelled.
  * Verifies readiness is dispatched when a non-required advisory check fails.
  * Confirms correct behavior for fleet-convergence scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Verify green required checks are not blocked by unrelated cancelled or failing checks

### What Changed
- Added regression coverage showing PR review dispatch proceeds when all required checks pass, even when both dev-lead orchestration checks are cancelled
- Confirms a failing non-required advisory check does not block dispatch

### Impact
`✅ Fewer false review blocks`
`✅ Reliable dispatch for PRs with green required checks`
`✅ Coverage for cancelled orchestration checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
