### PR TITLE
feat: implement issue #927 — auto-rebase: default eligibility to all; remove dead review-ready code; lock merge-method invariant

### DIFF
--- a/.github/scripts/auto-rebase/README.md
+++ b/.github/scripts/auto-rebase/README.md
@@ -13,28 +13,17 @@ workflow version. Set `tooling_ref` only to test a branch end-to-end.
 
 ## `lib/eligibility.sh`
 
-Pure, side-effect-free predicates. Source the file, then call:
+Pure, side-effect-free predicate. Source the file, then call:
 
 | Function | Input | Returns |
 |----------|-------|---------|
-| `auto_rebase_has_current_approval` | PR reviews JSON array on stdin (`GET /repos/{repo}/pulls/{n}/reviews`, oldest-first) | `0` if the PR has a current APPROVED review, else `1` |
-| `auto_rebase_has_ready_label LABEL` | PR labels JSON array on stdin | `0` if a label named `LABEL` is present, else `1` |
-| `auto_rebase_pr_eligible MODE IS_DRAFT IS_APPROVED HAS_LABEL` | mode + three `true`/`false` strings | `0` eligible, `1` not eligible, `2` unknown mode |
-
-### Approval semantics
-
-`auto_rebase_has_current_approval` inspects the **actual review states**, not
-`reviewDecision` (which is `null` on repos without required reviews). The most
-recent *decision* review per reviewer wins — a later `CHANGES_REQUESTED` or
-`DISMISSED` cancels an earlier `APPROVED`, while `COMMENTED`/`PENDING` reviews
-do not change a reviewer's stance.
+| `auto_rebase_pr_eligible MODE` | mode string | `0` eligible, `2` unknown mode |
 
 ### Eligibility modes (the tunable `eligibility` workflow input)
 
 | Mode | Meaning |
 |------|---------|
-| `review-ready` (default) | non-draft **AND** (current approval **OR** carries the ready label) |
-| `all` | every behind PR, including drafts — restores the original unrestricted fan-out |
+| `all` (default) | every behind PR, including drafts |
 
 New modes (e.g. a future "front-of-queue N") can be added here and selected by
 callers via the `eligibility` input with no change to the workflow file.

--- a/.github/scripts/auto-rebase/lib/eligibility.sh
+++ b/.github/scripts/auto-rebase/lib/eligibility.sh
@@ -23,6 +23,12 @@ auto_rebase_pr_eligible() {
     all)
       return 0
       ;;
+    review-ready)
+      # Deprecated alias: review-ready was removed in issue #927; treat as `all`
+      # so existing callers continue to work without breaking.
+      echo "auto_rebase_pr_eligible: 'review-ready' is deprecated and will be removed; use 'all' instead" >&2
+      return 0
+      ;;
     *)
       echo "auto_rebase_pr_eligible: unknown eligibility mode '$mode'" >&2
       return 2

--- a/.github/scripts/auto-rebase/lib/eligibility.sh
+++ b/.github/scripts/auto-rebase/lib/eligibility.sh
@@ -1,63 +1,27 @@
 #!/usr/bin/env bash
-# Eligibility predicates for the auto-rebase reusable workflow.
+# Eligibility predicate for the auto-rebase reusable workflow.
 #
-# These are pure, side-effect-free functions so they can be unit-tested with
-# bats (see test/workflows/auto-rebase/eligibility.bats). The reusable
-# workflow sources this file and uses the predicate to decide which behind
-# PRs to update-branch, instead of fanning out to every behind PR.
+# Pure and side-effect-free so it can be unit-tested with bats (see
+# test/workflows/auto-rebase/eligibility.bats). The reusable workflow sources
+# this file and uses the predicate to decide which behind PRs to update-branch.
 #
 # Contract: see .github/scripts/auto-rebase/README.md
 
-# auto_rebase_has_current_approval
-#   Reads a GitHub pull-request reviews JSON array on stdin (the response of
-#   `GET /repos/{repo}/pulls/{n}/reviews`, oldest-first) and returns 0 if the
-#   PR currently has at least one APPROVED review, else 1.
-#
-#   "Current" means the reviewer's most recent decision review wins: a later
-#   CHANGES_REQUESTED or DISMISSED cancels an earlier APPROVED, while
-#   COMMENTED/PENDING reviews do not change a reviewer's stance. We check the
-#   real review states here rather than reviewDecision, which is null on repos
-#   without required reviews (issue #465 implementer note).
-auto_rebase_has_current_approval() {
-  local result
-  result=$(jq -r '
-    reduce (.[] | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")) as $r ({}; .[$r.user.login] = $r.state)
-    | any(. == "APPROVED")
-  ')
-  [[ "$result" == "true" ]]
-}
-
-# auto_rebase_has_ready_label LABEL
-#   Reads a PR labels JSON array on stdin (objects with a .name field) and
-#   returns 0 if a label named LABEL is present, else 1.
-auto_rebase_has_ready_label() {
-  local label="$1" present
-  present=$(jq -r --arg L "$label" 'any(.[]; .name == $L)')
-  [[ "$present" == "true" ]]
-}
-
-# auto_rebase_pr_eligible MODE IS_DRAFT IS_APPROVED HAS_LABEL
-#   Decides whether a behind PR should be updated, given its draft/approval/
-#   label state. IS_DRAFT, IS_APPROVED and HAS_LABEL are the strings "true"
-#   or "false". Returns 0 (eligible), 1 (not eligible), or 2 (unknown mode).
+# auto_rebase_pr_eligible MODE
+#   Decides whether a behind PR should be updated. Returns 0 (eligible) or
+#   2 (unknown mode).
 #
 #   Modes (the tunable `eligibility` workflow input):
-#     review-ready  non-draft AND (approved OR carries the ready label).
-#                   The default — restricts fan-out to review-ready PRs.
-#     all           every behind PR, including drafts. Escape hatch that
-#                   restores the original unrestricted fan-out behavior.
+#     all   every behind PR, including drafts.
+#
+#   Kept as a mode dispatch so future modes (e.g. a "front-of-queue N") can be
+#   added here and selected via the `eligibility` input without changing the
+#   workflow file.
 auto_rebase_pr_eligible() {
-  local mode="$1" is_draft="$2" is_approved="$3" has_label="$4"
+  local mode="$1"
   case "$mode" in
     all)
       return 0
-      ;;
-    review-ready)
-      [[ "$is_draft" == "true" ]] && return 1
-      if [[ "$is_approved" == "true" || "$has_label" == "true" ]]; then
-        return 0
-      fi
-      return 1
       ;;
     *)
       echo "auto_rebase_pr_eligible: unknown eligibility mode '$mode'" >&2

--- a/.github/workflows/auto-rebase-reusable.yml
+++ b/.github/workflows/auto-rebase-reusable.yml
@@ -52,6 +52,15 @@ on:
         required: false
         default: 'all'
         type: string
+      ready_label:
+        description: |
+          Deprecated — this input is accepted but silently ignored so callers
+          that were passing it (when eligibility: review-ready was supported)
+          continue to dispatch without a GitHub Actions validation error.
+          Remove it from your caller when convenient.
+        required: false
+        default: ''
+        type: string
       tooling_ref:
         description: |
           Ref of petry-projects/.github to source the auto-rebase scripts from.

--- a/.github/workflows/auto-rebase-reusable.yml
+++ b/.github/workflows/auto-rebase-reusable.yml
@@ -11,15 +11,13 @@
 # Solution: after every push to main (typically a merged PR), this workflow:
 #   1. Finds all open non-Dependabot PRs from the same repo (no fork PRs)
 #   2. Keeps only the PRs eligible under the `eligibility` input (default
-#      `review-ready`: non-draft AND (current APPROVED review OR a ready label))
+#      `all`: every behind PR, including drafts)
 #   3. Updates the remaining behind PRs using the merge method (not rebase)
 #
-# Why the eligibility gate (issue #465): updating *every* behind PR fans out
-# 170-220 redundant branch-update CI runs/day, most re-staled before review.
-# Restricting to review-ready PRs cuts that waste for free. The predicate lives
-# in .github/scripts/auto-rebase/lib/eligibility.sh (unit-tested via bats) and
-# is selectable via the `eligibility` input so a future "front-of-queue N"
-# variant needs no change to this file.
+# The eligibility predicate lives in
+# .github/scripts/auto-rebase/lib/eligibility.sh (unit-tested via bats) and is
+# selectable via the `eligibility` input so a future "front-of-queue N" variant
+# needs no change to this file.
 #
 # Skips Dependabot PRs — those are handled by dependabot-rebase-reusable.yml.
 # Skips fork PRs — update-branch requires push access to the head branch.
@@ -48,19 +46,11 @@ on:
       eligibility:
         description: |
           Which behind PRs to update:
-            review-ready (default) — non-draft AND (current APPROVED review OR
-              the `ready_label`). Restricts fan-out to review-ready PRs.
-            all — every behind PR, including drafts. Escape hatch that restores
-              the original unrestricted fan-out.
+            all (default) — every behind PR, including drafts.
           New modes can be added to lib/eligibility.sh and selected here without
           changing this workflow.
         required: false
-        default: 'review-ready'
-        type: string
-      ready_label:
-        description: 'Label that opts a non-draft PR into auto-rebase even without an approval.'
-        required: false
-        default: 'auto-rebase:ready'
+        default: 'all'
         type: string
       tooling_ref:
         description: |
@@ -111,7 +101,6 @@ jobs:
           HAS_PAT: ${{ (secrets.GH_PAT_DON_PETRY || secrets.GH_PAT_WORKFLOWS) != '' }}
           REPO: ${{ github.repository }}
           ELIGIBILITY: ${{ inputs.eligibility }}
-          READY_LABEL: ${{ inputs.ready_label }}
         run: |
           # shellcheck source=/dev/null
           . .auto-rebase-tooling/.github/scripts/auto-rebase/lib/eligibility.sh
@@ -128,63 +117,18 @@ jobs:
           fi
 
           while IFS=' ' read -r PR_NUMBER HEAD_REF; do
-            # Fetch PR metadata once: base branch, draft state, labels.
-            PR_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER")
-            BASE_BRANCH=$(jq -r '.base.ref' <<< "$PR_JSON")
-            IS_DRAFT=$(jq -r '.draft' <<< "$PR_JSON")
+            BASE_BRANCH=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.base.ref')
 
-            # Eligibility gate (issue #465): only update review-ready PRs.
-            # Approval is read from the actual review states, not reviewDecision
-            # (which is null on repos without required reviews).
-            if auto_rebase_has_ready_label "$READY_LABEL" <<< "$(jq -c '.labels' <<< "$PR_JSON")"; then
-              HAS_LABEL=true
-            else
-              HAS_LABEL=false
-            fi
-            if gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/reviews" | jq -s 'add | .' | auto_rebase_has_current_approval; then
-              IS_APPROVED=true
-            else
-              IS_APPROVED=false
-            fi
-
+            # Eligibility gate: which behind PRs to update, selectable via the
+            # `eligibility` input (default `all` — every behind PR).
             ELIG=0
-            auto_rebase_pr_eligible "$ELIGIBILITY" "$IS_DRAFT" "$IS_APPROVED" "$HAS_LABEL" || ELIG=$?
+            auto_rebase_pr_eligible "$ELIGIBILITY" || ELIG=$?
             if [[ "$ELIG" -eq 2 ]]; then
               echo "::error::Unknown eligibility mode '$ELIGIBILITY'"
               exit 1
             fi
             if [[ "$ELIG" -ne 0 ]]; then
-              echo "PR #$PR_NUMBER ($HEAD_REF) not eligible under '$ELIGIBILITY' (draft=$IS_DRAFT approved=$IS_APPROVED label=$HAS_LABEL) — skipping"
-
-              # Escalate silently-rotting PRs (issue #711): a skipped PR that is
-              # already CONFLICTING will never be updated by auto-rebase and cannot
-              # be approved while red (pr-review skips red PRs) — a deadlock that
-              # rots the PR for weeks with no signal. Surface it exactly once so a
-              # human can act. mergeable_state comes free from PR_JSON (no extra
-              # API call); it may be "unknown" until GitHub computes it, in which
-              # case a later run catches it. Idempotent via the stuck sentinel.
-              MERGE_STATE=$(jq -r '.mergeable_state // "unknown"' <<< "$PR_JSON")
-              if [[ "$MERGE_STATE" == "dirty" ]]; then
-                STUCK_SENTINEL="<!-- auto-rebase-stuck -->"
-                STUCK_POSTED=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
-                  --json comments --jq "[.comments[] | select(.body | contains(\"$STUCK_SENTINEL\"))] | length" 2>/dev/null || echo "-1")
-                if [[ "$STUCK_POSTED" -eq 0 ]]; then
-                  echo "  Conflicting + not review-ready — posting one-time manual-attention notice"
-                  STUCK_BODY="$STUCK_SENTINEL"
-                  STUCK_BODY+=$'\n'"**Auto-rebase is skipping this PR.** It has merge conflicts with \`$BASE_BRANCH\`"
-                  STUCK_BODY+=" but is not review-ready (draft=$IS_DRAFT, approved=$IS_APPROVED,"
-                  STUCK_BODY+=" \`$READY_LABEL\`=$HAS_LABEL), so auto-rebase will not update it — and it cannot be"
-                  STUCK_BODY+=" approved while red. Left alone it will not progress."
-                  STUCK_BODY+=$'\n\n'"To unblock, do one of:"
-                  STUCK_BODY+=$'\n'"- add the \`$READY_LABEL\` label (opts it into auto-rebase without an approval), or"
-                  STUCK_BODY+=$'\n'"- get it approved, or"
-                  STUCK_BODY+=$'\n'"- resolve manually:"
-                  STUCK_BODY+=$'\n'"\`\`\`"$'\n'"git fetch origin"$'\n'"git merge origin/$BASE_BRANCH"$'\n'"# resolve conflicts, then:"$'\n'"git add . && git commit && git push"$'\n'"\`\`\`"
-                  # Best-effort: a comment-side failure (e.g. the 2500-comment cap)
-                  # must not abort the step or starve other PRs — logged and swallowed.
-                  auto_rebase_post_comment_best_effort "$PR_NUMBER" "$REPO" "$STUCK_BODY"
-                fi
-              fi
+              echo "PR #$PR_NUMBER ($HEAD_REF) not eligible under '$ELIGIBILITY' — skipping"
               continue
             fi
 

--- a/docs/initiatives/pull-request-limits-adr.md
+++ b/docs/initiatives/pull-request-limits-adr.md
@@ -83,7 +83,7 @@ on GitHub's side. Stories 2 and 3 must be planned on that basis.
 | **dev-lead** | Yes | `dev-lead/*` branches | Largest single source in the baseline (§5). One PR per assigned issue. |
 | **Claude / agentic PRs** | Yes | `claude/*` branches | Code-agent PRs; a distinct source the planner did not separately name but the baseline surfaced. |
 | **initiative-driver / initiative-planner** | Yes (intermittent) | initiative branches | None open at measurement time, but a known burst source when an epic is fanned out. |
-| **auto-rebase fan-out** | **No** | n/a | Important correction: [auto-rebase-reusable.yml](../../.github/workflows/auto-rebase-reusable.yml) **updates the branches of existing PRs** — it does not open new ones. It is a **CI-load amplifier**, not a PR source. A count limit on open PRs will not throttle it directly; the relevant lever for it is its `eligibility` input (already `review-ready`). |
+| **auto-rebase fan-out** | **No** | n/a | Important correction: [auto-rebase-reusable.yml](../../.github/workflows/auto-rebase-reusable.yml) **updates the branches of existing PRs** — it does not open new ones. It is a **CI-load amplifier**, not a PR source. A count limit on open PRs will not throttle it directly; the relevant lever for it is its `eligibility` input (default: `all` — every behind PR). |
 
 ---
 

--- a/standards/ci-standards.md
+++ b/standards/ci-standards.md
@@ -1032,21 +1032,17 @@ On each run the workflow:
    job in `claude-code-reusable.yml` to automatically resolve the conflict.
    If Claude cannot resolve it, it posts a clear failure comment with manual instructions.
 
-**Eligibility (fan-out restriction):** Updating *every* behind PR generates a large
-volume of redundant branch-update CI runs, most re-staled before review. The reusable
-therefore gates updates on a tunable `eligibility` input:
+**Eligibility:** Which behind PRs to update is selectable via a tunable
+`eligibility` input:
 
 | `eligibility` | Updates a behind PR when… |
 |---------------|---------------------------|
-| `review-ready` (default) | the PR is **non-draft** AND (it has a **current `APPROVED` review** OR carries the `ready_label`, default `auto-rebase:ready`) |
-| `all` | always — restores the original unrestricted fan-out |
+| `all` (default) | always — every behind PR, including drafts |
 
-Approval is determined from the **actual review states** (latest decision review per
-reviewer wins; a later `CHANGES_REQUESTED`/`DISMISSED` cancels an earlier `APPROVED`),
-**not** `reviewDecision`, which is `null` on repos without required reviews. The
-predicate lives in `.github/scripts/auto-rebase/lib/eligibility.sh` and is unit-tested
-via bats; new modes (e.g. a future "front-of-queue N") can be added there and selected
-through the `eligibility` input with no change to the workflow file.
+The predicate lives in `.github/scripts/auto-rebase/lib/eligibility.sh` and is
+unit-tested via bats; new modes (e.g. a future "front-of-queue N") can be added
+there and selected through the `eligibility` input with no change to the
+workflow file.
 
 **Secrets:** `GH_PAT_WORKFLOWS` is optional but **required for `claude-rebase` to be triggered** —
 comments posted with `GITHUB_TOKEN` do not fire `issue_comment` workflow runs (GitHub limitation).

--- a/standards/workflows/auto-rebase.yml
+++ b/standards/workflows/auto-rebase.yml
@@ -22,14 +22,12 @@
 # To adopt: copy this file to .github/workflows/auto-rebase.yml in your repo.
 # No secrets required — uses GITHUB_TOKEN only.
 #
-# By default the reusable only updates *review-ready* PRs: non-draft AND
-# (carrying a current APPROVED review OR the `auto-rebase:ready` label). This
-# keeps the workflow from fanning out branch-update CI runs to every behind PR.
-# To tune it, pass inputs to the reusable, e.g.:
+# By default the reusable updates *every* behind PR (`eligibility: all`). The
+# `eligibility` input is a tunable extension point for future modes; to select
+# one, pass it to the reusable, e.g.:
 #
 #   with:
-#     eligibility: review-ready      # default; or `all` to update every behind PR
-#     ready_label: auto-rebase:ready # label that opts a non-draft PR in
+#     eligibility: all  # default — update every behind PR
 #
 name: Auto-rebase non-Dependabot PRs
 

--- a/test/workflows/auto-rebase/eligibility.bats
+++ b/test/workflows/auto-rebase/eligibility.bats
@@ -29,9 +29,9 @@ setup() {
   [ "$status" -eq 2 ]
 }
 
-@test "pr_eligible: the removed review-ready mode is rejected as unknown (exit 2)" {
+@test "pr_eligible: the deprecated review-ready mode is treated as 'all' (exit 0)" {
   run auto_rebase_pr_eligible review-ready
-  [ "$status" -eq 2 ]
+  [ "$status" -eq 0 ]
 }
 
 # ── dead review-ready/approval plumbing is gone ──────────────────────────────

--- a/test/workflows/auto-rebase/eligibility.bats
+++ b/test/workflows/auto-rebase/eligibility.bats
@@ -1,9 +1,9 @@
 #!/usr/bin/env bats
 # Tests for .github/scripts/auto-rebase/lib/eligibility.sh
 #
-# Pins issue #465: auto-rebase must update a behind PR only when it is
-# non-draft AND (has a current APPROVED review OR carries the ready label),
-# with the predicate selectable via a tunable mode.
+# auto-rebase updates every behind PR (the `all` mode). The predicate is kept
+# selectable via a tunable mode so future modes (e.g. a "front-of-queue N")
+# can be added without touching the workflow file.
 
 load 'helpers/setup'
 
@@ -12,135 +12,36 @@ setup() {
   . "${TT_SCRIPTS_DIR}/lib/eligibility.sh"
 }
 
-# ── auto_rebase_has_current_approval ─────────────────────────────────────────
-
-@test "has_current_approval: single APPROVED review counts as approved" {
-  run auto_rebase_has_current_approval <<'JSON'
-[{"user":{"login":"alice"},"state":"APPROVED","submitted_at":"2026-06-01T00:00:00Z"}]
-JSON
-  [ "$status" -eq 0 ]
-}
-
-@test "has_current_approval: no reviews is not approved" {
-  run auto_rebase_has_current_approval <<'JSON'
-[]
-JSON
-  [ "$status" -ne 0 ]
-}
-
-@test "has_current_approval: only COMMENTED reviews are not approved" {
-  run auto_rebase_has_current_approval <<'JSON'
-[{"user":{"login":"alice"},"state":"COMMENTED","submitted_at":"2026-06-01T00:00:00Z"}]
-JSON
-  [ "$status" -ne 0 ]
-}
-
-@test "has_current_approval: reviewer who approved then requested changes is not approved" {
-  run auto_rebase_has_current_approval <<'JSON'
-[
-  {"user":{"login":"alice"},"state":"APPROVED","submitted_at":"2026-06-01T00:00:00Z"},
-  {"user":{"login":"alice"},"state":"CHANGES_REQUESTED","submitted_at":"2026-06-02T00:00:00Z"}
-]
-JSON
-  [ "$status" -ne 0 ]
-}
-
-@test "has_current_approval: reviewer who requested changes then approved is approved" {
-  run auto_rebase_has_current_approval <<'JSON'
-[
-  {"user":{"login":"alice"},"state":"CHANGES_REQUESTED","submitted_at":"2026-06-01T00:00:00Z"},
-  {"user":{"login":"alice"},"state":"APPROVED","submitted_at":"2026-06-02T00:00:00Z"}
-]
-JSON
-  [ "$status" -eq 0 ]
-}
-
-@test "has_current_approval: a later COMMENTED review does not cancel an approval" {
-  run auto_rebase_has_current_approval <<'JSON'
-[
-  {"user":{"login":"alice"},"state":"APPROVED","submitted_at":"2026-06-01T00:00:00Z"},
-  {"user":{"login":"alice"},"state":"COMMENTED","submitted_at":"2026-06-03T00:00:00Z"}
-]
-JSON
-  [ "$status" -eq 0 ]
-}
-
-@test "has_current_approval: a dismissed approval is not approved" {
-  run auto_rebase_has_current_approval <<'JSON'
-[
-  {"user":{"login":"alice"},"state":"APPROVED","submitted_at":"2026-06-01T00:00:00Z"},
-  {"user":{"login":"alice"},"state":"DISMISSED","submitted_at":"2026-06-02T00:00:00Z"}
-]
-JSON
-  [ "$status" -ne 0 ]
-}
-
-@test "has_current_approval: one approver among several reviewers counts" {
-  run auto_rebase_has_current_approval <<'JSON'
-[
-  {"user":{"login":"alice"},"state":"CHANGES_REQUESTED","submitted_at":"2026-06-01T00:00:00Z"},
-  {"user":{"login":"bob"},"state":"APPROVED","submitted_at":"2026-06-02T00:00:00Z"}
-]
-JSON
-  [ "$status" -eq 0 ]
-}
-
-# ── auto_rebase_has_ready_label ──────────────────────────────────────────────
-
-@test "has_ready_label: label present" {
-  run auto_rebase_has_ready_label "auto-rebase:ready" <<'JSON'
-[{"name":"enhancement"},{"name":"auto-rebase:ready"}]
-JSON
-  [ "$status" -eq 0 ]
-}
-
-@test "has_ready_label: label absent" {
-  run auto_rebase_has_ready_label "auto-rebase:ready" <<'JSON'
-[{"name":"enhancement"}]
-JSON
-  [ "$status" -ne 0 ]
-}
-
-@test "has_ready_label: empty labels array" {
-  run auto_rebase_has_ready_label "auto-rebase:ready" <<'JSON'
-[]
-JSON
-  [ "$status" -ne 0 ]
-}
-
 # ── auto_rebase_pr_eligible ──────────────────────────────────────────────────
 
-@test "pr_eligible review-ready: non-draft + approved is eligible" {
-  run auto_rebase_pr_eligible review-ready false true false
-  [ "$status" -eq 0 ]
-}
-
-@test "pr_eligible review-ready: non-draft + ready label is eligible" {
-  run auto_rebase_pr_eligible review-ready false false true
-  [ "$status" -eq 0 ]
-}
-
-@test "pr_eligible review-ready: non-draft but neither approved nor labelled is ineligible" {
-  run auto_rebase_pr_eligible review-ready false false false
-  [ "$status" -eq 1 ]
-}
-
-@test "pr_eligible review-ready: draft is ineligible even when approved" {
-  run auto_rebase_pr_eligible review-ready true true true
-  [ "$status" -eq 1 ]
-}
-
-@test "pr_eligible all: always eligible (legacy fan-out escape hatch)" {
-  run auto_rebase_pr_eligible all false false false
-  [ "$status" -eq 0 ]
-}
-
-@test "pr_eligible all: eligible even for drafts (preserves prior behavior)" {
-  run auto_rebase_pr_eligible all true false false
+@test "pr_eligible all: every behind PR is eligible" {
+  run auto_rebase_pr_eligible all
   [ "$status" -eq 0 ]
 }
 
 @test "pr_eligible: unknown mode errors out (exit 2)" {
-  run auto_rebase_pr_eligible bogus-mode false true false
+  run auto_rebase_pr_eligible bogus-mode
   [ "$status" -eq 2 ]
+}
+
+@test "pr_eligible: empty mode errors out (exit 2)" {
+  run auto_rebase_pr_eligible ""
+  [ "$status" -eq 2 ]
+}
+
+@test "pr_eligible: the removed review-ready mode is rejected as unknown (exit 2)" {
+  run auto_rebase_pr_eligible review-ready
+  [ "$status" -eq 2 ]
+}
+
+# ── dead review-ready/approval plumbing is gone ──────────────────────────────
+
+@test "auto_rebase_has_current_approval is no longer defined" {
+  run type -t auto_rebase_has_current_approval
+  [ "$status" -ne 0 ]
+}
+
+@test "auto_rebase_has_ready_label is no longer defined" {
+  run type -t auto_rebase_has_ready_label
+  [ "$status" -ne 0 ]
 }

--- a/test/workflows/auto-rebase/merge-method.bats
+++ b/test/workflows/auto-rebase/merge-method.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+# Regression guard: the auto-rebase reusable must ALWAYS update behind branches
+# with update_method=merge, never rebase.
+#
+# The API update-branch endpoint with the rebase method rewrites SHAs, which
+# confuses CI and invalidates existing approvals; the merge method preserves the
+# original commits. This invariant must not regress.
+
+load 'helpers/setup'
+
+REUSABLE="${TT_REPO_ROOT}/.github/workflows/auto-rebase-reusable.yml"
+
+@test "merge-method: reusable workflow file exists" {
+  [ -f "$REUSABLE" ]
+}
+
+@test "merge-method: update-branch is called with update_method=merge" {
+  run grep -F 'update_method=merge' "$REUSABLE"
+  [ "$status" -eq 0 ]
+}
+
+@test "merge-method: update-branch is never called with the rebase method" {
+  run grep -E 'update_method[=:][[:space:]]*rebase' "$REUSABLE"
+  [ "$status" -ne 0 ]
+}

--- a/test/workflows/auto-rebase/merge-method.bats
+++ b/test/workflows/auto-rebase/merge-method.bats
@@ -21,5 +21,5 @@ REUSABLE="${TT_REPO_ROOT}/.github/workflows/auto-rebase-reusable.yml"
 
 @test "merge-method: update-branch is never called with the rebase method" {
   run grep -E 'update_method[=:][[:space:]]*rebase' "$REUSABLE"
-  [ "$status" -ne 0 ]
+  [ "$status" -eq 1 ]
 }


### PR DESCRIPTION
## **User description**
Closes #927

Implemented by dev-lead agent. Please review.


___

## **CodeAnt-AI Description**
Auto-update every behind pull request while preserving commits and approvals

### What Changed
- Auto-rebase now updates every behind same-repository pull request by default, including drafts, instead of requiring an approval or ready label.
- Removed the review and label checks, along with the related ready-label configuration and stuck-conflict notices.
- Branch updates always use merge mode, avoiding rewritten commits and invalidated approvals.
- Invalid eligibility modes, including the removed `review-ready` mode, now fail clearly.

### Impact
`✅ Fewer pull requests left behind after merges`
`✅ Preserved commit history and approvals during branch updates`
`✅ Clearer configuration errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-rebase now updates all behind pull requests by default, including drafts.
  * Added support for the simplified `all` eligibility mode.

* **Bug Fixes**
  * Unknown or unsupported eligibility modes now fail clearly instead of being processed.

* **Tests**
  * Added coverage confirming merge-based branch updates and the updated eligibility behavior.

* **Documentation**
  * Updated auto-rebase guidance to reflect the new default and simplified configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->