### PR TITLE
feat: implement issue #928 — auto-rebase: verify DIRTY PRs now reach the conflict-sentinel path; retire the redundant stuck-comment escalation

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pr-893",
+  "name": "pr-932",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pr-893",
+  "name": "pr-932",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/test/workflows/auto-rebase/conflict-sentinel.bats
+++ b/test/workflows/auto-rebase/conflict-sentinel.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# Confirms AC4 of issue #926 (tracked by #928): a DIRTY (merge-conflict),
+# non-draft PR is now actually ATTEMPTED by update-branch — it is no longer
+# skipped for lacking an approval — and therefore reaches the existing
+# <!-- auto-rebase-conflict: --> sentinel → dev-lead agentic-rebase path.
+#
+# Since #927 the eligibility default is `all` and the approval / review-ready
+# plumbing is gone (see eligibility.bats). These grep-based regression guards
+# pin the reusable workflow so the DIRTY → conflict-sentinel path cannot
+# silently regress by reintroducing an approval precondition before
+# update-branch. They mirror the file-scanning style of merge-method.bats.
+
+load 'helpers/setup'
+
+REUSABLE="${TT_REPO_ROOT}/.github/workflows/auto-rebase-reusable.yml"
+
+@test "conflict-sentinel: reusable workflow file exists" {
+  [ -f "$REUSABLE" ]
+}
+
+@test "conflict-sentinel: every eligible behind PR is attempted via update-branch" {
+  # The DIRTY PR must actually be attempted — the update-branch call is present.
+  run grep -F 'pulls/$PR_NUMBER/update-branch' "$REUSABLE"
+  [ "$status" -eq 0 ]
+}
+
+@test "conflict-sentinel: update-branch is not gated on an approval / review decision" {
+  # A DIRTY PR must not be skipped for lacking an approval (#927 removed this).
+  # Guard against reintroducing any review-decision precondition in the reusable.
+  run grep -Ei 'reviewDecision|has_current_approval|has_ready_label|/reviews' "$REUSABLE"
+  [ "$status" -eq 1 ]
+}
+
+@test "conflict-sentinel: a merge-conflict update failure branches to the conflict path" {
+  run grep -i 'merge conflict' "$REUSABLE"
+  [ "$status" -eq 0 ]
+}
+
+@test "conflict-sentinel: the merge-conflict path posts the <!-- auto-rebase-conflict: --> dev-lead sentinel" {
+  run grep -F '<!-- auto-rebase-conflict:' "$REUSABLE"
+  [ "$status" -eq 0 ]
+}
+
+@test "conflict-sentinel: the weaker one-time <!-- auto-rebase-stuck --> escalation is absent (retired)" {
+  # AC4 retires the redundant stuck-comment escalation as dead code. The primary
+  # retirement lives in petry-projects/.github-private#711; this guard ensures the
+  # weaker sentinel is never (re)introduced into this repo's auto-rebase reusable.
+  run grep -F 'auto-rebase-stuck' "$REUSABLE"
+  [ "$status" -eq 1 ]
+}

--- a/test/workflows/auto-rebase/conflict-sentinel.bats
+++ b/test/workflows/auto-rebase/conflict-sentinel.bats
@@ -27,7 +27,10 @@ REUSABLE="${TT_REPO_ROOT}/.github/workflows/auto-rebase-reusable.yml"
 @test "conflict-sentinel: update-branch is not gated on an approval / review decision" {
   # A DIRTY PR must not be skipped for lacking an approval (#927 removed this).
   # Guard against reintroducing any review-decision precondition in the reusable.
-  run grep -Ei 'reviewDecision|has_current_approval|has_ready_label|/reviews' "$REUSABLE"
+  # Patterns are scoped to the specific identifiers removed in #927 — broad tokens
+  # like /reviews are omitted because they can appear in unrelated comments or API
+  # calls and would cause false positives on legitimate refactors.
+  run grep -Ei 'reviewDecision|has_current_approval|has_ready_label' "$REUSABLE"
   [ "$status" -eq 1 ]
 }
 

--- a/test/workflows/auto-rebase/conflict-sentinel.bats
+++ b/test/workflows/auto-rebase/conflict-sentinel.bats
@@ -20,7 +20,7 @@ REUSABLE="${TT_REPO_ROOT}/.github/workflows/auto-rebase-reusable.yml"
 
 @test "conflict-sentinel: every eligible behind PR is attempted via update-branch" {
   # The DIRTY PR must actually be attempted — the update-branch call is present.
-  run grep -F 'pulls/$PR_NUMBER/update-branch' "$REUSABLE"
+  run grep -E 'pulls/\$\{?PR_NUMBER\}?/update-branch' "$REUSABLE"
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
## **User description**
Closes #928

Implemented by dev-lead agent. Please review.


___

## **CodeAnt-AI Description**
Add regression coverage for dirty pull requests reaching the conflict-rebase path

### What Changed
- Verifies eligible dirty, non-draft pull requests are attempted even without an approval
- Verifies merge-conflict failures post the conflict sentinel used for rebase handling
- Verifies the retired one-time stuck escalation is not reintroduced

### Impact
`✅ Dirty PRs reach conflict handling`
`✅ Conflict rebase notifications remain reliable`
`✅ Prevents obsolete stuck escalations`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
